### PR TITLE
Add AGENTS.md, track skills in git, full image names in README

### DIFF
--- a/.claude/skills/add-compatibility-tests.md
+++ b/.claude/skills/add-compatibility-tests.md
@@ -1,0 +1,53 @@
+# Skill: Add Compatibility Tests for an AWS Service
+
+Use this skill when writing tests that verify robotocore matches LocalStack behavior for a specific AWS service.
+
+## Process
+
+1. **Identify the full API surface:**
+   ```python
+   import botocore.session
+   s = botocore.session.get_session()
+   m = s.get_service_model('SERVICE_NAME')
+   for op in sorted(m.operation_names):
+       print(op)
+   ```
+
+2. **Check what LocalStack community supports:**
+   - Read `vendor/localstack/localstack-core/localstack/services/{service}/provider.py`
+   - Methods that raise `NotImplementedError` or are missing are not supported
+   - Methods decorated with `@handler` are implemented
+
+3. **Create the test file:**
+   - File: `tests/compatibility/test_{service}_compat.py`
+   - Use `ENDPOINT_URL` env var so tests run against both robotocore and LocalStack
+   - Use boto3 clients, not raw HTTP — we care about SDK-level compatibility
+
+4. **Test structure:**
+   - One test class per logical group of operations
+   - Each test should be independent (create its own resources, clean up after)
+   - Use fixtures for shared setup (client creation, resource creation)
+   - Test both success and error paths
+
+5. **Priority order for test coverage:**
+   - CRUD operations (Create, Describe/Get, Update, Delete)
+   - List operations with pagination
+   - Error cases (resource not found, invalid input, duplicate creation)
+   - Tagging operations
+   - Cross-service integration (if applicable in LocalStack community)
+
+6. **Run against both targets:**
+   ```bash
+   # Against robotocore
+   uv run pytest tests/compatibility/test_{service}_compat.py -v
+
+   # Against LocalStack
+   ENDPOINT_URL=http://localhost:4567 uv run pytest tests/compatibility/test_{service}_compat.py -v
+   ```
+
+7. **Mark tests by implementation status:**
+   ```python
+   @pytest.mark.skip(reason="Not yet implemented in robotocore")
+   def test_advanced_feature(self):
+       pass
+   ```

--- a/.claude/skills/compare-localstack.md
+++ b/.claude/skills/compare-localstack.md
@@ -1,0 +1,64 @@
+# Skill: Compare robotocore Behavior with LocalStack
+
+Use this skill when verifying that robotocore produces identical responses to LocalStack for a given AWS API operation.
+
+## Process
+
+1. **Start both services:**
+   ```bash
+   # Terminal 1: robotocore
+   uv run python -m robotocore.main  # port 4566
+
+   # Terminal 2: localstack (on different port)
+   docker run --rm -p 4567:4566 localstack/localstack
+   ```
+
+2. **Capture responses from both:**
+   ```python
+   import boto3
+   import json
+
+   def make_client(service, port):
+       return boto3.client(
+           service,
+           endpoint_url=f"http://localhost:{port}",
+           region_name="us-east-1",
+           aws_access_key_id="testing",
+           aws_secret_access_key="testing",
+       )
+
+   roboto = make_client("SERVICE", 4566)
+   localstack = make_client("SERVICE", 4567)
+
+   # Make identical calls and compare
+   r1 = roboto.OPERATION(...)
+   r2 = localstack.OPERATION(...)
+
+   # Remove metadata for comparison
+   del r1["ResponseMetadata"]
+   del r2["ResponseMetadata"]
+
+   print(json.dumps(r1, indent=2, default=str))
+   print(json.dumps(r2, indent=2, default=str))
+   ```
+
+3. **Key things to compare:**
+   - Response body structure (field names, nesting)
+   - Data types (strings vs numbers, date formats)
+   - Error responses (error codes, messages, HTTP status)
+   - HTTP headers (especially Content-Type, x-amzn-RequestId)
+   - Pagination behavior (NextToken, MaxResults)
+   - Default values for optional fields
+
+4. **Check the vendor source for differences:**
+   - Read `vendor/localstack/localstack-core/localstack/services/{service}/` for LocalStack's provider
+   - Read `vendor/moto/moto/{service}/` for Moto's implementation
+   - Look for places where LocalStack wraps or overrides Moto behavior
+
+5. **Write compatibility tests for any differences found:**
+   - Add tests to `tests/compatibility/test_{service}_compat.py`
+   - Tests should capture the exact expected behavior
+   - Use `pytest.mark.parametrize` for testing multiple cases
+
+6. **Document significant behavioral differences:**
+   - If Moto and LocalStack genuinely differ, document which behavior robotocore follows and why

--- a/.claude/skills/debug-aws-request.md
+++ b/.claude/skills/debug-aws-request.md
@@ -1,0 +1,56 @@
+# Skill: Debug an AWS API Request
+
+Use this skill when a request to robotocore is failing, returning wrong responses, or not routing correctly.
+
+## Process
+
+1. **Reproduce the issue with verbose logging:**
+   ```bash
+   # Enable debug logging
+   ROBOTOCORE_DEBUG=1 uv run python -m robotocore.main
+   ```
+   ```bash
+   # In another terminal, make the failing request with boto3 debug:
+   import boto3
+   import logging
+   logging.basicConfig(level=logging.DEBUG)
+   boto3.set_stream_logger('')
+   # ... make the call
+   ```
+
+2. **Check routing first:**
+   - Is the request reaching the gateway? Check uvicorn logs.
+   - Is `route_to_service()` returning the correct service name?
+   - Look at the Authorization header, X-Amz-Target, and URL path
+   - Add temporary debug logging to `src/robotocore/gateway/router.py` if needed
+
+3. **Check the Moto bridge:**
+   - Is `forward_to_moto()` finding the right backend?
+   - Is the region/account extraction correct?
+   - Add logging to `src/robotocore/providers/moto_bridge.py`
+
+4. **Compare with LocalStack:**
+   - Run the same request against LocalStack to see the expected response
+   - `docker run --rm -p 4567:4566 localstack/localstack`
+   - Diff the responses (headers, body, status code)
+
+5. **Compare with Moto standalone:**
+   - Run the same request against Moto's server mode
+   - `uv run moto_server -p 5555`
+   - This isolates whether the issue is in our gateway/routing or in Moto itself
+
+6. **Check botocore's service spec:**
+   - The protocol type matters (query, json, rest-json, rest-xml, ec2)
+   - Different protocols encode requests differently
+   ```python
+   import botocore.session
+   s = botocore.session.get_session()
+   m = s.get_service_model('SERVICE_NAME')
+   print(m.protocol)  # Shows the protocol type
+   ```
+
+7. **Fix and test:**
+   - Write a failing test first
+   - Fix the issue
+   - Verify the test passes
+   - Run the full test suite to check for regressions

--- a/.claude/skills/docker-build-test.md
+++ b/.claude/skills/docker-build-test.md
@@ -1,0 +1,44 @@
+# Skill: Build and Test Docker Container
+
+Use this skill when building the robotocore Docker image and running tests against it.
+
+## Build
+
+```bash
+docker build -t robotocore .
+# Image size target: < 600MB (currently ~559MB)
+docker image ls robotocore --format "{{.Size}}"
+```
+
+## Run
+
+```bash
+# Run the container on a test port
+docker rm -f robotocore-test 2>/dev/null
+docker run -d --name robotocore-test -p 14567:4566 robotocore
+sleep 5
+curl -s http://localhost:14567/_robotocore/health
+```
+
+## Test against the container
+
+```bash
+# Run all compatibility tests
+ENDPOINT_URL=http://localhost:14567 uv run pytest tests/compatibility/ -q
+
+# Generate parity report
+uv run python scripts/parity_report.py
+```
+
+## Clean up
+
+```bash
+docker rm -f robotocore-test
+```
+
+## Notes
+- Uses `python:3.12-slim` as base, supports ARM and x86
+- Port 4566 exposed (same as LocalStack)
+- `MOTO_ALLOW_NONEXISTENT_REGION=true` set in image
+- Health check at `/_robotocore/health`
+- Don't install dev dependencies in image (`--no-dev`)

--- a/.claude/skills/explore-vendor-code.md
+++ b/.claude/skills/explore-vendor-code.md
@@ -1,0 +1,57 @@
+# Skill: Explore Vendor Code (Moto / LocalStack)
+
+Use this skill when you need to understand how Moto or LocalStack implements a specific AWS service or feature.
+
+## Moto Code Navigation
+
+Moto's code is in `vendor/moto/moto/`. Each service follows a consistent pattern:
+
+- `moto/{service}/__init__.py` — Exports `mock_{service}` decorator
+- `moto/{service}/models.py` — **Start here.** Contains the backend class with all business logic
+- `moto/{service}/responses.py` — HTTP request parsing, dispatches to models, formats responses
+- `moto/{service}/urls.py` — URL patterns that route to this service
+- `moto/{service}/exceptions.py` — Service-specific error responses
+
+### Key Moto patterns:
+- Backend classes inherit from `BaseBackend`
+- `responses.py` classes inherit from `BaseResponse`
+- Request dispatch uses method names matching the AWS Action parameter
+- State is stored in Python dicts/lists on the backend instance
+
+### Finding how an operation works:
+```
+1. grep for the operation name in responses.py (e.g., "create_bucket")
+2. Follow the call into models.py
+3. Check what state is created/modified
+```
+
+## LocalStack Code Navigation
+
+LocalStack's code is in `vendor/localstack/localstack-core/localstack/`. Structure:
+
+- `localstack/services/{service}/provider.py` — **Start here.** The main service provider
+- `localstack/services/{service}/models.py` — Data models (if separate from provider)
+- `localstack/services/{service}/stores.py` — State stores (per-account, per-region)
+- `localstack/aws/api/{service}/` — Auto-generated API stubs from Smithy specs
+- `localstack/aws/protocol/` — Protocol parsers and serializers
+- `localstack/aws/handlers/` — Gateway handler chain
+
+### Key LocalStack patterns:
+- Providers inherit from the generated API class
+- Methods are decorated with `@handler("OperationName")`
+- `call_moto(context)` forwards to Moto's implementation
+- State is stored in `AccountRegionBundle` stores
+- Many providers mix native implementation with Moto fallbacks
+
+### Finding how an operation works:
+```
+1. Open provider.py, search for the operation name
+2. If it calls call_moto(), the logic is in Moto
+3. If it has custom logic, that's the LocalStack extension
+4. Check stores.py for state management
+```
+
+## Comparing implementations:
+When implementing a service in robotocore, always check BOTH:
+1. What does Moto do? (this is our foundation)
+2. What does LocalStack add on top? (this is what we need to match)

--- a/.claude/skills/implement-service.md
+++ b/.claude/skills/implement-service.md
@@ -1,0 +1,74 @@
+# Skill: Implement an AWS Service Provider
+
+Use this skill when implementing a new AWS service in robotocore or extending an existing one.
+
+## Process
+
+1. **Research the service in both vendor submodules:**
+   - Read `vendor/moto/moto/{service}/models.py` to understand Moto's implementation
+   - Read `vendor/moto/moto/{service}/responses.py` to understand request/response handling
+   - Read `vendor/moto/moto/{service}/urls.py` to understand URL routing
+   - Read `vendor/localstack/localstack-core/localstack/services/{service}/` to understand LocalStack's implementation
+   - Note any places where LocalStack extends beyond what Moto provides
+
+2. **Check botocore specs:**
+   - Look at the botocore service model for the full API surface
+   - Run: `python -c "import botocore.session; s=botocore.session.get_session(); m=s.get_service_model('{service}'); print(sorted(m.operation_names))"`
+
+3. **Update the gateway router if needed:**
+   - If the service uses a unique routing mechanism (special headers, path patterns), add it to `src/robotocore/gateway/router.py`
+   - Add tests for the new routing rules in `tests/unit/gateway/test_router.py`
+
+4. **Create a service extension if Moto is insufficient:**
+   - Only create `src/robotocore/services/{service}/` if Moto's implementation is missing behavior that LocalStack provides
+   - The moto_bridge should handle most services automatically
+   - Extensions should wrap Moto, not replace it
+   - Register native providers in `src/robotocore/gateway/app.py` NATIVE_PROVIDERS dict
+
+5. **Access Moto backends correctly:**
+   ```python
+   from moto.backends import get_backend
+   from moto.core import DEFAULT_ACCOUNT_ID
+   backend = get_backend("service_name")[DEFAULT_ACCOUNT_ID][region]
+   # For global services (IAM, S3):
+   backend = get_backend("service_name")[DEFAULT_ACCOUNT_ID]["global"]
+   ```
+   **NEVER** use `from moto.backends import moto_backends` — it's been removed.
+
+6. **Write compatibility tests:**
+   - Create `tests/compatibility/test_{service}_compat.py`
+   - Use the shared conftest: `from tests.compatibility.conftest import make_client`
+   - Use unique resource names with `uuid.uuid4().hex[:8]` to avoid conflicts
+   - Tests must be runnable against both robotocore AND LocalStack (use ENDPOINT_URL env var)
+
+7. **Update the service registry:**
+   - Add entry to `src/robotocore/services/registry.py`
+
+8. **Add CloudFormation resource type if applicable:**
+   - Add create/delete handlers in `src/robotocore/services/cloudformation/resources.py`
+   - Check Moto method signatures with `inspect.signature()` — they change between versions
+
+9. **Run the full test suite:**
+   - `uv run pytest tests/unit/` must pass
+   - `uv run pytest tests/compatibility/test_{service}_compat.py` must pass
+
+## Template for compatibility tests
+
+```python
+"""${SERVICE} compatibility tests."""
+import uuid
+import pytest
+from tests.compatibility.conftest import make_client
+
+@pytest.fixture
+def client():
+    return make_client("${service}")
+
+def _uid():
+    return uuid.uuid4().hex[:8]
+
+class Test${Service}Operations:
+    def test_basic_crud(self, client):
+        # Create, Read, Update, Delete
+        pass
+```

--- a/.claude/skills/use-in-tests.md
+++ b/.claude/skills/use-in-tests.md
@@ -1,0 +1,211 @@
+# Skill: Use robotocore in a Project's Test Suite
+
+Use this skill when adding robotocore to an existing project so tests can run against a local AWS digital twin instead of real AWS or mocks.
+
+## What you're setting up
+
+robotocore runs as a Docker container on port 4566 and responds to real AWS SDK calls. Tests use real boto3 clients pointed at `http://localhost:4566`. No mocking libraries needed.
+
+## Step 1 — Ensure robotocore is running
+
+### Option A: start it per-session (local dev)
+
+```bash
+docker run -d -p 4566:4566 --name robotocore jackdanger/robotocore:latest
+```
+
+### Option B: docker-compose (team standard)
+
+Add to `docker-compose.yml`:
+
+```yaml
+services:
+  aws:
+    image: jackdanger/robotocore:latest
+    ports:
+      - "4566:4566"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:4566/_localstack/health"]
+      interval: 5s
+      retries: 10
+```
+
+### Option C: GitHub Actions
+
+```yaml
+services:
+  robotocore:
+    image: jackdanger/robotocore:latest
+    ports:
+      - 4566:4566
+    options: >-
+      --health-cmd "curl -f http://localhost:4566/_localstack/health"
+      --health-interval 5s
+      --health-retries 10
+```
+
+## Step 2 — Add pytest fixtures
+
+Create `tests/conftest.py` (or add to an existing one):
+
+```python
+import uuid
+import boto3
+import pytest
+
+ENDPOINT = "http://localhost:4566"
+REGION   = "us-east-1"
+
+
+def _session(account_id: str = "123456789012") -> dict:
+    """Base kwargs for any boto3 client/resource."""
+    return dict(
+        endpoint_url=ENDPOINT,
+        aws_access_key_id=account_id,
+        aws_secret_access_key="test",
+        region_name=REGION,
+    )
+
+
+@pytest.fixture(scope="session")
+def aws():
+    """Shared boto3 session kwargs. Uses a fixed account ID for the test session."""
+    return _session()
+
+
+@pytest.fixture
+def isolated_aws():
+    """Per-test boto3 kwargs with a unique account ID.
+
+    Resources created with this fixture are invisible to other tests.
+    Use this when tests must not share state.
+    """
+    account_id = str(uuid.uuid4().int)[:12].zfill(12)
+    return _session(account_id)
+
+
+@pytest.fixture
+def s3(aws):
+    return boto3.client("s3", **aws)
+
+
+@pytest.fixture
+def sqs(aws):
+    return boto3.client("sqs", **aws)
+
+
+@pytest.fixture
+def sns(aws):
+    return boto3.client("sns", **aws)
+
+
+@pytest.fixture
+def dynamodb(aws):
+    return boto3.resource("dynamodb", **aws)
+
+
+@pytest.fixture
+def lambda_client(aws):
+    return boto3.client("lambda", **aws)
+
+
+@pytest.fixture
+def ssm(aws):
+    return boto3.client("ssm", **aws)
+
+
+@pytest.fixture
+def secrets(aws):
+    return boto3.client("secretsmanager", **aws)
+```
+
+## Step 3 — Write tests using the fixtures
+
+```python
+# tests/test_myfeature.py
+import uuid
+
+
+def test_uploads_report_to_s3(s3):
+    bucket = f"test-{uuid.uuid4().hex[:8]}"
+    s3.create_bucket(Bucket=bucket)
+
+    # call the code under test
+    from myapp.reports import generate_and_upload
+    generate_and_upload(bucket=bucket, s3_client=s3)
+
+    objects = s3.list_objects_v2(Bucket=bucket)["Contents"]
+    assert any(o["Key"].endswith(".csv") for o in objects)
+
+
+def test_sends_notification(sns, sqs):
+    queue = sqs.create_queue(QueueName=f"q-{uuid.uuid4().hex[:8]}")
+    url   = queue["QueueUrl"]
+    arn   = sqs.get_queue_attributes(
+        QueueUrl=url, AttributeNames=["QueueArn"]
+    )["Attributes"]["QueueArn"]
+
+    topic = sns.create_topic(Name=f"t-{uuid.uuid4().hex[:8]}")
+    sns.subscribe(TopicArn=topic["TopicArn"], Protocol="sqs", Endpoint=arn)
+
+    from myapp.notifications import send_alert
+    send_alert(topic_arn=topic["TopicArn"], sns_client=sns, message="test")
+
+    msgs = sqs.receive_message(QueueUrl=url)
+    assert len(msgs.get("Messages", [])) == 1
+```
+
+## Step 4 — Isolation strategies
+
+**Same account for all tests** (fast, may have resource name collisions):
+- Use unique resource names with `uuid.uuid4().hex[:8]` suffix
+- Clean up in teardown or accept the state is ephemeral per container restart
+
+**Per-test accounts** (fully isolated, slightly slower):
+- Use `isolated_aws` fixture instead of `aws`
+- Each test gets its own account ID, so bucket/queue names can be identical
+
+```python
+def test_isolated(isolated_aws):
+    s3 = boto3.client("s3", **isolated_aws)
+    s3.create_bucket(Bucket="assets")  # won't conflict with any other test
+```
+
+## Step 5 — Make the endpoint configurable
+
+Let tests run against real AWS too (for CI on the real cloud):
+
+```python
+# tests/conftest.py
+import os
+
+ENDPOINT = os.getenv("AWS_ENDPOINT_URL", "http://localhost:4566")
+```
+
+```bash
+# Against robotocore (default)
+pytest tests/
+
+# Against real AWS
+AWS_ENDPOINT_URL="" pytest tests/
+```
+
+## Adding robotocore as a dev dependency
+
+```toml
+# pyproject.toml — no Python package needed, just document the Docker image
+[tool.robotocore]
+image = "jackdanger/robotocore:latest"
+port  = 4566
+```
+
+Or just document it in `README.md` or `CONTRIBUTING.md`:
+
+```markdown
+## Running tests
+
+Start robotocore before running tests:
+
+    docker run -d -p 4566:4566 jackdanger/robotocore:latest
+    pytest tests/
+```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,288 @@
+# AGENTS.md — robotocore
+
+robotocore is a **digital twin of AWS** — a local server that responds faithfully to real AWS API calls. Run it in Docker, point any AWS SDK at `http://localhost:4566`, and it behaves like AWS. Free, MIT licensed, no registration, no telemetry.
+
+Named for [botocore](https://github.com/boto/botocore), the library underlying boto3.
+
+---
+
+## Start robotocore
+
+```bash
+docker run -d -p 4566:4566 --name robotocore jackdanger/robotocore:latest
+```
+
+Also available from GHCR:
+
+```bash
+docker run -d -p 4566:4566 --name robotocore ghcr.io/jackdanger/robotocore:latest
+```
+
+Verify it's running:
+
+```bash
+curl -s http://localhost:4566/_localstack/health | python3 -m json.tool
+```
+
+Expected output includes `"running": true` and a list of services.
+
+---
+
+## Endpoint & credentials
+
+| Setting | Value |
+|---------|-------|
+| Endpoint | `http://localhost:4566` |
+| Access key ID | any 12-digit number (becomes your account ID) |
+| Secret key | any non-empty string |
+| Session token | not required |
+| Region | any valid AWS region; default `us-east-1` |
+
+---
+
+## Minimal Python setup
+
+```python
+import boto3
+
+# Replace 123456789012 with any 12-digit number to choose your account ID
+SESSION = dict(
+    endpoint_url="http://localhost:4566",
+    aws_access_key_id="123456789012",
+    aws_secret_access_key="test",
+    region_name="us-east-1",
+)
+
+s3      = boto3.client("s3",              **SESSION)
+sqs     = boto3.client("sqs",             **SESSION)
+sns     = boto3.client("sns",             **SESSION)
+dynamo  = boto3.resource("dynamodb",      **SESSION)
+lam     = boto3.client("lambda",          **SESSION)
+iam     = boto3.client("iam",             **SESSION)
+cfn     = boto3.client("cloudformation", **SESSION)
+kms     = boto3.client("kms",             **SESSION)
+ssm     = boto3.client("ssm",             **SESSION)
+secrets = boto3.client("secretsmanager",  **SESSION)
+```
+
+---
+
+## Multi-account & multi-region
+
+The `aws_access_key_id` you provide (when it's a 12-digit number) is your account ID. Resources are stored separately per account and per region.
+
+```python
+# Two completely isolated AWS accounts in the same robotocore instance
+prod = boto3.client("s3", endpoint_url="http://localhost:4566",
+                    aws_access_key_id="111111111111", aws_secret_access_key="test",
+                    region_name="us-east-1")
+dev  = boto3.client("s3", endpoint_url="http://localhost:4566",
+                    aws_access_key_id="222222222222", aws_secret_access_key="test",
+                    region_name="us-east-1")
+
+prod.create_bucket(Bucket="assets")  # in account 111111111111
+dev.create_bucket(Bucket="assets")   # separate bucket in account 222222222222
+```
+
+Non-numeric access keys (e.g. `"test"`) route to the default account `123456789012`.
+
+---
+
+## Supported services (42)
+
+ACM, API Gateway v1, API Gateway v2, AppSync, Batch, CloudFormation, CloudWatch,
+CloudWatch Logs, Cognito, Config, DynamoDB, DynamoDB Streams, EC2, ECS,
+Elasticsearch, EventBridge, EventBridge Scheduler, Firehose, IAM, Kinesis, KMS,
+Lambda, OpenSearch, Redshift, Resource Groups, Resource Groups Tagging, Route 53,
+Route 53 Resolver, S3, S3 Control, Scheduler, Secrets Manager, SES, SES v2, SNS,
+SQS, SSM, Step Functions, STS, Support, SWF, Transcribe
+
+All standard SDK operations work. Services marked **Native** in the README have
+behavioral fidelity beyond Moto (real Lambda execution, real SQS visibility
+timeouts, full IAM policy evaluation, etc.).
+
+---
+
+## Common operation patterns
+
+### S3
+
+```python
+s3.create_bucket(Bucket="my-bucket")
+s3.put_object(Bucket="my-bucket", Key="file.txt", Body=b"hello")
+body = s3.get_object(Bucket="my-bucket", Key="file.txt")["Body"].read()
+s3.list_objects_v2(Bucket="my-bucket")
+```
+
+### SQS
+
+```python
+q = sqs.create_queue(QueueName="my-queue")
+url = q["QueueUrl"]
+sqs.send_message(QueueUrl=url, MessageBody="hello")
+msgs = sqs.receive_message(QueueUrl=url, MaxNumberOfMessages=10)
+for m in msgs.get("Messages", []):
+    sqs.delete_message(QueueUrl=url, ReceiptHandle=m["ReceiptHandle"])
+```
+
+### DynamoDB
+
+```python
+table = dynamo.create_table(
+    TableName="users",
+    KeySchema=[{"AttributeName": "id", "KeyType": "HASH"}],
+    AttributeDefinitions=[{"AttributeName": "id", "AttributeType": "S"}],
+    BillingMode="PAY_PER_REQUEST",
+)
+table.put_item(Item={"id": "u1", "name": "Alice"})
+item = table.get_item(Key={"id": "u1"})["Item"]
+```
+
+### SNS → SQS fanout
+
+```python
+queue = sqs.create_queue(QueueName="events")
+queue_arn = sqs.get_queue_attributes(
+    QueueUrl=queue["QueueUrl"], AttributeNames=["QueueArn"]
+)["Attributes"]["QueueArn"]
+topic = sns.create_topic(Name="alerts")
+sns.subscribe(TopicArn=topic["TopicArn"], Protocol="sqs", Endpoint=queue_arn)
+sns.publish(TopicArn=topic["TopicArn"], Message="something happened")
+```
+
+### Lambda
+
+```python
+import io, json, zipfile
+
+def make_zip(code: str) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as z:
+        z.writestr("index.py", code)
+    return buf.getvalue()
+
+lam.create_function(
+    FunctionName="hello",
+    Runtime="python3.12",
+    Role="arn:aws:iam::123456789012:role/lambda-role",
+    Handler="index.handler",
+    Code={"ZipFile": make_zip("def handler(e, c): return {'ok': True}")},
+)
+result = lam.invoke(FunctionName="hello", Payload=json.dumps({}))
+print(json.loads(result["Payload"].read()))  # {"ok": True}
+```
+
+### Secrets Manager
+
+```python
+secrets.create_secret(Name="db/password", SecretString="hunter2")
+val = secrets.get_secret_value(SecretId="db/password")["SecretString"]
+```
+
+### SSM Parameter Store
+
+```python
+ssm.put_parameter(Name="/app/env", Value="production", Type="String")
+val = ssm.get_parameter(Name="/app/env")["Parameter"]["Value"]
+```
+
+---
+
+## ARN format
+
+ARNs follow the real AWS format:
+
+```
+arn:aws:{service}:{region}:{account-id}:{resource}
+
+# Examples
+arn:aws:s3:::my-bucket
+arn:aws:sqs:us-east-1:123456789012:my-queue
+arn:aws:lambda:us-east-1:123456789012:function:hello
+arn:aws:iam::123456789012:role/my-role
+```
+
+---
+
+## Health & introspection endpoints
+
+```bash
+# Overall health + running services
+curl http://localhost:4566/_localstack/health
+
+# Version and build info
+curl http://localhost:4566/_localstack/info
+
+# Full service list
+curl http://localhost:4566/_localstack/health | python3 -c "
+import json,sys; h=json.load(sys.stdin)
+for svc,status in sorted(h.get('services',{}).items()):
+    print(f'{svc:40} {status}')
+"
+```
+
+---
+
+## State is in-memory
+
+All state lives in memory and is lost when the container stops. There is no
+persistence layer by default. This is intentional — robotocore is for development
+and testing, not production.
+
+To reset all state, restart the container:
+
+```bash
+docker restart robotocore
+```
+
+---
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|-------------|-----|
+| `ConnectionRefused` on 4566 | Container not running | `docker ps`, then `docker run ...` |
+| `NoCredentialsError` | boto3 has no credentials at all | Set `aws_access_key_id` and `aws_secret_access_key` |
+| Resources from different tests bleed together | Same account ID used across tests | Use a unique 12-digit account ID per test (see multi-account section) |
+| `InvalidClientTokenId` | Non-12-digit access key used as account | Use a 12-digit number like `"123456789012"` |
+| Operation returns `NotImplemented` | Moto doesn't implement it yet | Check [Moto coverage](https://github.com/getmoto/moto/blob/master/IMPLEMENTATION_COVERAGE.md) |
+
+---
+
+## Running in CI
+
+```yaml
+# GitHub Actions example
+services:
+  robotocore:
+    image: jackdanger/robotocore:latest
+    ports:
+      - 4566:4566
+    options: >-
+      --health-cmd "curl -f http://localhost:4566/_localstack/health"
+      --health-interval 5s
+      --health-timeout 3s
+      --health-retries 10
+```
+
+```yaml
+# docker-compose for local dev
+services:
+  aws:
+    image: jackdanger/robotocore:latest
+    ports:
+      - "4566:4566"
+    environment:
+      - AWS_DEFAULT_REGION=us-east-1
+```
+
+---
+
+## Source & contributing
+
+- **Repository**: https://github.com/jackdanger/robotocore
+- **Issues**: https://github.com/jackdanger/robotocore/issues
+- **Built on**: [Moto](https://github.com/getmoto/moto) (~195 AWS service implementations)
+- **Author**: Jack Danger, a Moto maintainer
+
+See [CLAUDE.md](CLAUDE.md) for contributor architecture notes.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@
   <a href="#for-ai-agents">For AI Agents</a> ·
   <a href="#supported-services">42 Services</a> ·
   <a href="#why-robotocore">Why robotocore</a> ·
-  <a href="#architecture">Architecture</a>
+  <a href="#architecture">Architecture</a> ·
+  <a href="AGENTS.md">AGENTS.md</a>
 </p>
 
 ---
@@ -35,10 +36,18 @@ Built by [Jack Danger](https://github.com/jackdanger), a maintainer of [Moto](ht
 ## Quick Start
 
 ```bash
-docker run -p 4566:4566 robotocore
+# Docker Hub
+docker run -d -p 4566:4566 jackdanger/robotocore:latest
+
+# GitHub Container Registry (alternative)
+docker run -d -p 4566:4566 ghcr.io/jackdanger/robotocore:latest
 ```
 
-That's it. Your local AWS digital twin is running.
+Verify it's running:
+
+```bash
+curl -s http://localhost:4566/_localstack/health | python3 -m json.tool
+```
 
 ### Python (boto3)
 
@@ -79,7 +88,7 @@ aws dynamodb list-tables
 ```yaml
 services:
   aws:
-    image: robotocore
+    image: jackdanger/robotocore:latest
     ports:
       - "4566:4566"
 
@@ -90,6 +99,31 @@ services:
       - AWS_ACCESS_KEY_ID=123456789012
       - AWS_SECRET_ACCESS_KEY=test
       - AWS_DEFAULT_REGION=us-east-1
+```
+
+### GitHub Actions
+
+```yaml
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    services:
+      robotocore:
+        image: jackdanger/robotocore:latest
+        ports:
+          - 4566:4566
+        options: >-
+          --health-cmd "curl -f http://localhost:4566/_localstack/health"
+          --health-interval 5s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@v4
+      - run: pytest tests/
+        env:
+          AWS_ENDPOINT_URL: http://localhost:4566
+          AWS_ACCESS_KEY_ID: "123456789012"
+          AWS_SECRET_ACCESS_KEY: test
+          AWS_DEFAULT_REGION: us-east-1
 ```
 
 ---
@@ -167,6 +201,8 @@ If you omit credentials or use a non-numeric access key (e.g. `"test"`), robotoc
 ---
 
 ## For AI Agents
+
+> **If you are an AI agent**, read [AGENTS.md](AGENTS.md) — it's a standalone reference with everything you need: Docker image, endpoint, credentials, multi-account setup, common patterns, health checks, and troubleshooting. No prior context required.
 
 If you are an AI agent or LLM being asked to work with AWS infrastructure locally, here is everything you need to know:
 


### PR DESCRIPTION
## Summary

- **AGENTS.md** — new standalone reference designed to be read by AI agents and LLMs with no prior context. Covers: full Docker image pull command, endpoint/credentials table, multi-account mechanics, all 42 services listed, common patterns for every major service, ARN format, health endpoints, CI examples, troubleshooting table.

- **README** — Quick Start now shows `jackdanger/robotocore:latest` and `ghcr.io/jackdanger/robotocore:latest` (previously just `robotocore` with no registry). Added health-check verify step, GitHub Actions CI example, and a direct callout linking to AGENTS.md at the top of the For AI Agents section.

- **Skills tracked in git** — `.claude/skills/` files were local-only before; now committed so contributors get them on clone. Added `use-in-tests.md` skill covering how to integrate robotocore into a project's pytest suite (fixtures, per-test account isolation, CI setup). Fixed "Robotocore" → "robotocore" capitalization in compare-localstack.md.

## Test plan

- [ ] `curl -s http://localhost:4566/_localstack/health` returns expected JSON after `docker run -d -p 4566:4566 jackdanger/robotocore:latest`
- [ ] AGENTS.md renders cleanly on GitHub
- [ ] README health-check example works verbatim
- [ ] Skills appear in `.claude/skills/` after fresh clone