### PR TITLE
Fix mediastore ListTagsForResource ARN lookup

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -746,7 +746,7 @@ wheels = [
 [[package]]
 name = "moto"
 version = "5.1.22.dev0"
-source = { git = "https://github.com/JackDanger/moto.git?branch=robotocore%2Fall-fixes#ff3f37d778586ac7da6da6dcdaa98865cbdddf26" }
+source = { git = "https://github.com/JackDanger/moto.git?branch=robotocore%2Fall-fixes#a189f28921c9d0fe43326e057d432a2ffbeba723" }
 dependencies = [
     { name = "boto3" },
     { name = "botocore" },


### PR DESCRIPTION
## Summary
- Moto's mediastore `list_tags_for_resource` looked up containers by name only, but the AWS `ListTagsForResource` API passes a Resource ARN
- Added `_resolve_resource` helper in Moto that checks both container name and ARN (JackDanger/moto@fix/mediastore-list-tags-for-resource)
- Updated `uv.lock` to pin the fixed Moto commit

## Test plan
- [x] `TestMediaStoreTagsForResource::test_list_tags_for_resource` — was failing, now passes
- [x] `TestMediaStoreTagsForResource::test_list_tags_for_resource_with_tags` — was failing, now passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)