### PR TITLE
Add e-commerce, content management, and multi-tenant SaaS app tests

### DIFF
--- a/tests/apps/test_content_mgmt_app.py
+++ b/tests/apps/test_content_mgmt_app.py
@@ -1,0 +1,781 @@
+"""
+Content Management System Application Tests
+
+Simulates a headless CMS where:
+- Media assets stored in S3 (with versioning for edit history)
+- Content metadata in DynamoDB (GSI by category, GSI by status)
+- Publish queue in SQS (content awaiting publication)
+- Webhook notifications via SNS when content is published
+- Content audit trail in CloudWatch Logs
+- Scheduled publishing via EventBridge rules
+"""
+
+import json
+import time
+import uuid
+
+import pytest
+
+
+@pytest.fixture
+def media_bucket(s3, unique_name):
+    bucket = f"cms-media-{unique_name}"
+    s3.create_bucket(Bucket=bucket)
+    s3.put_bucket_versioning(
+        Bucket=bucket,
+        VersioningConfiguration={"Status": "Enabled"},
+    )
+    yield bucket
+    # Cleanup: delete all versions + delete markers + bucket
+    try:
+        resp = s3.list_object_versions(Bucket=bucket)
+        for v in resp.get("Versions", []):
+            s3.delete_object(Bucket=bucket, Key=v["Key"], VersionId=v["VersionId"])
+        for dm in resp.get("DeleteMarkers", []):
+            s3.delete_object(Bucket=bucket, Key=dm["Key"], VersionId=dm["VersionId"])
+    except Exception:
+        pass
+    try:
+        objects = s3.list_objects_v2(Bucket=bucket).get("Contents", [])
+        for obj in objects:
+            s3.delete_object(Bucket=bucket, Key=obj["Key"])
+    except Exception:
+        pass
+    s3.delete_bucket(Bucket=bucket)
+
+
+@pytest.fixture
+def content_table(dynamodb, unique_name):
+    table_name = f"cms-content-{unique_name}"
+    dynamodb.create_table(
+        TableName=table_name,
+        KeySchema=[{"AttributeName": "content_id", "KeyType": "HASH"}],
+        AttributeDefinitions=[
+            {"AttributeName": "content_id", "AttributeType": "S"},
+            {"AttributeName": "category", "AttributeType": "S"},
+            {"AttributeName": "status", "AttributeType": "S"},
+            {"AttributeName": "updated_at", "AttributeType": "S"},
+        ],
+        GlobalSecondaryIndexes=[
+            {
+                "IndexName": "by-category",
+                "KeySchema": [
+                    {"AttributeName": "category", "KeyType": "HASH"},
+                    {"AttributeName": "updated_at", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+            {
+                "IndexName": "by-status",
+                "KeySchema": [
+                    {"AttributeName": "status", "KeyType": "HASH"},
+                    {"AttributeName": "updated_at", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+        ],
+        BillingMode="PAY_PER_REQUEST",
+    )
+    yield table_name
+    dynamodb.delete_table(TableName=table_name)
+
+
+@pytest.fixture
+def publish_queue(sqs, unique_name):
+    queue_name = f"cms-publish-{unique_name}"
+    resp = sqs.create_queue(QueueName=queue_name)
+    queue_url = resp["QueueUrl"]
+    yield queue_url
+    sqs.delete_queue(QueueUrl=queue_url)
+
+
+@pytest.fixture
+def webhook_topic(sns, unique_name):
+    topic_name = f"cms-webhook-{unique_name}"
+    resp = sns.create_topic(Name=topic_name)
+    topic_arn = resp["TopicArn"]
+    yield topic_arn
+    sns.delete_topic(TopicArn=topic_arn)
+
+
+@pytest.fixture
+def content_audit_log(logs, unique_name):
+    group_name = f"/cms/audit/{unique_name}"
+    stream_name = "content-changes"
+    logs.create_log_group(logGroupName=group_name)
+    logs.create_log_stream(logGroupName=group_name, logStreamName=stream_name)
+    yield group_name, stream_name
+    logs.delete_log_stream(logGroupName=group_name, logStreamName=stream_name)
+    logs.delete_log_group(logGroupName=group_name)
+
+
+@pytest.fixture
+def event_bus():
+    yield "default"
+
+
+class TestMediaManagement:
+    """S3 with versioning for media asset management."""
+
+    def test_upload_media_asset(self, s3, media_bucket):
+        """Upload a media asset and verify it can be retrieved."""
+        content_id = str(uuid.uuid4())
+        key = f"media/{content_id}/hero.jpg"
+        body = b"image-v1"
+
+        s3.put_object(Bucket=media_bucket, Key=key, Body=body)
+
+        resp = s3.get_object(Bucket=media_bucket, Key=key)
+        assert resp["Body"].read() == b"image-v1"
+
+    def test_media_versioning(self, s3, media_bucket):
+        """Upload same key 3 times, verify 3 versions exist and latest is correct."""
+        key = "media/article-001/banner.png"
+        contents = [b"banner-v1", b"banner-v2", b"banner-v3"]
+
+        for body in contents:
+            s3.put_object(Bucket=media_bucket, Key=key, Body=body)
+
+        resp = s3.list_object_versions(Bucket=media_bucket, Prefix=key)
+        versions = resp.get("Versions", [])
+        assert len(versions) == 3
+
+        latest = s3.get_object(Bucket=media_bucket, Key=key)
+        assert latest["Body"].read() == b"banner-v3"
+
+    def test_restore_previous_version(self, s3, media_bucket):
+        """Upload v1 then v2, retrieve v1 by VersionId."""
+        key = "media/article-002/photo.jpg"
+
+        resp_v1 = s3.put_object(Bucket=media_bucket, Key=key, Body=b"original-photo")
+        v1_version_id = resp_v1.get("VersionId")
+
+        s3.put_object(Bucket=media_bucket, Key=key, Body=b"edited-photo")
+
+        # If put_object didn't return VersionId, get it from list_object_versions
+        if not v1_version_id:
+            resp = s3.list_object_versions(Bucket=media_bucket, Prefix=key)
+            versions = sorted(
+                resp.get("Versions", []),
+                key=lambda v: v["LastModified"],
+            )
+            v1_version_id = versions[0]["VersionId"]
+
+        restored = s3.get_object(Bucket=media_bucket, Key=key, VersionId=v1_version_id)
+        assert restored["Body"].read() == b"original-photo"
+
+    def test_delete_and_recover_media(self, s3, media_bucket):
+        """Delete creates a marker; removing the marker restores the object."""
+        key = "media/article-003/thumbnail.png"
+        s3.put_object(Bucket=media_bucket, Key=key, Body=b"thumbnail-data")
+
+        # Delete object (creates delete marker)
+        s3.delete_object(Bucket=media_bucket, Key=key)
+
+        # Verify object is "gone" via normal get
+        with pytest.raises(Exception):
+            s3.get_object(Bucket=media_bucket, Key=key)
+
+        # Find the delete marker
+        resp = s3.list_object_versions(Bucket=media_bucket, Prefix=key)
+        delete_markers = resp.get("DeleteMarkers", [])
+        assert len(delete_markers) >= 1
+        dm_version_id = delete_markers[0]["VersionId"]
+
+        # Remove the delete marker
+        s3.delete_object(Bucket=media_bucket, Key=key, VersionId=dm_version_id)
+
+        # Object is restored
+        restored = s3.get_object(Bucket=media_bucket, Key=key)
+        assert restored["Body"].read() == b"thumbnail-data"
+
+
+class TestContentMetadata:
+    """DynamoDB for content metadata with GSIs."""
+
+    def test_create_content(self, dynamodb, content_table):
+        """Create a content item and verify all fields."""
+        content_id = f"article-{uuid.uuid4().hex[:8]}"
+        item = {
+            "content_id": {"S": content_id},
+            "title": {"S": "Introduction to AWS"},
+            "category": {"S": "tech"},
+            "status": {"S": "draft"},
+            "author": {"S": "jane-doe"},
+            "created_at": {"S": "2026-01-15T10:00:00Z"},
+            "updated_at": {"S": "2026-01-15T10:00:00Z"},
+            "body_s3_key": {"S": f"content/{content_id}/body.md"},
+        }
+        dynamodb.put_item(TableName=content_table, Item=item)
+
+        resp = dynamodb.get_item(
+            TableName=content_table,
+            Key={"content_id": {"S": content_id}},
+        )
+        result = resp["Item"]
+        assert result["title"]["S"] == "Introduction to AWS"
+        assert result["category"]["S"] == "tech"
+        assert result["status"]["S"] == "draft"
+        assert result["author"]["S"] == "jane-doe"
+        assert result["body_s3_key"]["S"] == f"content/{content_id}/body.md"
+
+    def test_query_by_category(self, dynamodb, content_table):
+        """Insert articles in multiple categories, query GSI for one category."""
+        articles = [
+            ("tech", "t1", "2026-01-01T01:00:00Z"),
+            ("tech", "t2", "2026-01-01T02:00:00Z"),
+            ("tech", "t3", "2026-01-01T03:00:00Z"),
+            ("business", "b1", "2026-01-01T04:00:00Z"),
+            ("business", "b2", "2026-01-01T05:00:00Z"),
+            ("health", "h1", "2026-01-01T06:00:00Z"),
+        ]
+        for category, cid, ts in articles:
+            dynamodb.put_item(
+                TableName=content_table,
+                Item={
+                    "content_id": {"S": cid},
+                    "category": {"S": category},
+                    "status": {"S": "draft"},
+                    "updated_at": {"S": ts},
+                    "title": {"S": f"Article {cid}"},
+                },
+            )
+
+        resp = dynamodb.query(
+            TableName=content_table,
+            IndexName="by-category",
+            KeyConditionExpression="category = :cat",
+            ExpressionAttributeValues={":cat": {"S": "tech"}},
+        )
+        assert resp["Count"] == 3
+
+    def test_editorial_workflow(self, dynamodb, content_table):
+        """Query GSI by status to find articles in review."""
+        items = [
+            ("draft-1", "draft", "2026-02-01T01:00:00Z"),
+            ("draft-2", "draft", "2026-02-01T02:00:00Z"),
+            ("review-1", "review", "2026-02-01T03:00:00Z"),
+            ("review-2", "review", "2026-02-01T04:00:00Z"),
+            ("pub-1", "published", "2026-02-01T05:00:00Z"),
+        ]
+        for cid, status, ts in items:
+            dynamodb.put_item(
+                TableName=content_table,
+                Item={
+                    "content_id": {"S": cid},
+                    "category": {"S": "general"},
+                    "status": {"S": status},
+                    "updated_at": {"S": ts},
+                    "title": {"S": f"Article {cid}"},
+                },
+            )
+
+        resp = dynamodb.query(
+            TableName=content_table,
+            IndexName="by-status",
+            KeyConditionExpression="#s = :status",
+            ExpressionAttributeNames={"#s": "status"},
+            ExpressionAttributeValues={":status": {"S": "review"}},
+        )
+        assert resp["Count"] == 2
+        returned_ids = {item["content_id"]["S"] for item in resp["Items"]}
+        assert returned_ids == {"review-1", "review-2"}
+
+    def test_update_content(self, dynamodb, content_table):
+        """Create draft, update title/body/status, verify changes."""
+        content_id = f"upd-{uuid.uuid4().hex[:8]}"
+        dynamodb.put_item(
+            TableName=content_table,
+            Item={
+                "content_id": {"S": content_id},
+                "title": {"S": "Original Title"},
+                "category": {"S": "tech"},
+                "status": {"S": "draft"},
+                "updated_at": {"S": "2026-03-01T10:00:00Z"},
+                "body_s3_key": {"S": "content/original.md"},
+            },
+        )
+
+        dynamodb.update_item(
+            TableName=content_table,
+            Key={"content_id": {"S": content_id}},
+            UpdateExpression=("SET title = :t, body_s3_key = :b, updated_at = :u, #s = :st"),
+            ExpressionAttributeNames={"#s": "status"},
+            ExpressionAttributeValues={
+                ":t": {"S": "Updated Title"},
+                ":b": {"S": "content/revised.md"},
+                ":u": {"S": "2026-03-01T12:00:00Z"},
+                ":st": {"S": "review"},
+            },
+        )
+
+        resp = dynamodb.get_item(
+            TableName=content_table,
+            Key={"content_id": {"S": content_id}},
+        )
+        item = resp["Item"]
+        assert item["title"]["S"] == "Updated Title"
+        assert item["body_s3_key"]["S"] == "content/revised.md"
+        assert item["status"]["S"] == "review"
+        assert item["updated_at"]["S"] == "2026-03-01T12:00:00Z"
+
+    def test_content_tags(self, dynamodb, content_table):
+        """Store tags as StringSet and verify retrieval."""
+        content_id = f"tag-{uuid.uuid4().hex[:8]}"
+        dynamodb.put_item(
+            TableName=content_table,
+            Item={
+                "content_id": {"S": content_id},
+                "title": {"S": "Tagged Article"},
+                "category": {"S": "tech"},
+                "status": {"S": "draft"},
+                "updated_at": {"S": "2026-03-01T10:00:00Z"},
+                "tags": {"SS": ["python", "aws", "serverless"]},
+            },
+        )
+
+        resp = dynamodb.get_item(
+            TableName=content_table,
+            Key={"content_id": {"S": content_id}},
+        )
+        tags = set(resp["Item"]["tags"]["SS"])
+        assert "python" in tags
+        assert "aws" in tags
+        assert "serverless" in tags
+
+
+class TestPublishWorkflow:
+    """SQS + SNS for the publication pipeline."""
+
+    def test_queue_for_publication(self, sqs, publish_queue):
+        """Send a publish request to SQS and verify the message body."""
+        message = json.dumps(
+            {
+                "content_id": "article-100",
+                "scheduled_time": "2026-03-08T18:00:00Z",
+                "author": "editor-bob",
+            }
+        )
+        sqs.send_message(QueueUrl=publish_queue, MessageBody=message)
+
+        resp = sqs.receive_message(
+            QueueUrl=publish_queue,
+            MaxNumberOfMessages=1,
+            WaitTimeSeconds=5,
+        )
+        messages = resp.get("Messages", [])
+        assert len(messages) == 1
+        body = json.loads(messages[0]["Body"])
+        assert body["content_id"] == "article-100"
+        assert body["author"] == "editor-bob"
+
+    def test_publish_notification(self, sns, sqs, webhook_topic, unique_name):
+        """Subscribe SQS to SNS topic, publish, verify delivery."""
+        # Create a subscriber queue
+        sub_queue_name = f"cms-sub-{unique_name}"
+        q_resp = sqs.create_queue(QueueName=sub_queue_name)
+        sub_queue_url = q_resp["QueueUrl"]
+        queue_arn = f"arn:aws:sqs:us-east-1:123456789012:{sub_queue_name}"
+
+        try:
+            sub_resp = sns.subscribe(
+                TopicArn=webhook_topic,
+                Protocol="sqs",
+                Endpoint=queue_arn,
+            )
+            assert "SubscriptionArn" in sub_resp
+
+            sns.publish(
+                TopicArn=webhook_topic,
+                Message=json.dumps(
+                    {
+                        "content_id": "article-200",
+                        "title": "Breaking News",
+                        "url": "https://cms.example.com/articles/200",
+                    }
+                ),
+                Subject="Content Published",
+            )
+
+            # Poll for the message
+            received = None
+            for _ in range(5):
+                resp = sqs.receive_message(
+                    QueueUrl=sub_queue_url,
+                    MaxNumberOfMessages=1,
+                    WaitTimeSeconds=2,
+                )
+                if resp.get("Messages"):
+                    received = resp["Messages"][0]
+                    break
+
+            assert received is not None
+            # SNS wraps the message in an envelope
+            envelope = json.loads(received["Body"])
+            inner = json.loads(envelope.get("Message", received["Body"]))
+            assert inner["content_id"] == "article-200"
+            assert inner["title"] == "Breaking News"
+        finally:
+            sqs.delete_queue(QueueUrl=sub_queue_url)
+
+    def test_batch_publish_queue(self, sqs, publish_queue):
+        """Send a batch of 5 articles to the publish queue."""
+        entries = [
+            {
+                "Id": f"msg-{i}",
+                "MessageBody": json.dumps(
+                    {
+                        "content_id": f"batch-article-{i}",
+                        "action": "publish",
+                    }
+                ),
+            }
+            for i in range(5)
+        ]
+        resp = sqs.send_message_batch(QueueUrl=publish_queue, Entries=entries)
+        assert len(resp.get("Successful", [])) == 5
+
+        # Receive all messages (may need multiple calls)
+        all_messages = []
+        for _ in range(5):
+            recv = sqs.receive_message(
+                QueueUrl=publish_queue,
+                MaxNumberOfMessages=10,
+                WaitTimeSeconds=2,
+            )
+            all_messages.extend(recv.get("Messages", []))
+            if len(all_messages) >= 5:
+                break
+
+        assert len(all_messages) == 5
+        received_ids = {json.loads(m["Body"])["content_id"] for m in all_messages}
+        expected_ids = {f"batch-article-{i}" for i in range(5)}
+        assert received_ids == expected_ids
+
+    def test_publish_with_attributes(self, sqs, publish_queue):
+        """Send message with MessageAttributes, verify they are returned."""
+        sqs.send_message(
+            QueueUrl=publish_queue,
+            MessageBody=json.dumps({"content_id": "featured-1"}),
+            MessageAttributes={
+                "content_type": {
+                    "DataType": "String",
+                    "StringValue": "article",
+                },
+                "priority": {
+                    "DataType": "String",
+                    "StringValue": "featured",
+                },
+            },
+        )
+
+        resp = sqs.receive_message(
+            QueueUrl=publish_queue,
+            MaxNumberOfMessages=1,
+            WaitTimeSeconds=5,
+            MessageAttributeNames=["All"],
+        )
+        messages = resp.get("Messages", [])
+        assert len(messages) == 1
+        attrs = messages[0].get("MessageAttributes", {})
+        assert attrs["content_type"]["StringValue"] == "article"
+        assert attrs["priority"]["StringValue"] == "featured"
+
+
+class TestContentAudit:
+    """CloudWatch Logs for content audit trail."""
+
+    def test_log_content_changes(self, logs, content_audit_log):
+        """Put 5 audit events and verify they are all returned in order."""
+        group_name, stream_name = content_audit_log
+        base_ts = int(time.time() * 1000)
+
+        events = [
+            {"action": "created", "content_id": "art-1"},
+            {"action": "edited", "content_id": "art-1"},
+            {"action": "reviewed", "content_id": "art-1"},
+            {"action": "approved", "content_id": "art-1"},
+            {"action": "published", "content_id": "art-1"},
+        ]
+        log_events = [
+            {
+                "timestamp": base_ts + i * 1000,
+                "message": json.dumps(evt),
+            }
+            for i, evt in enumerate(events)
+        ]
+
+        logs.put_log_events(
+            logGroupName=group_name,
+            logStreamName=stream_name,
+            logEvents=log_events,
+        )
+
+        resp = logs.get_log_events(
+            logGroupName=group_name,
+            logStreamName=stream_name,
+            startFromHead=True,
+        )
+        returned = resp.get("events", [])
+        assert len(returned) >= 5
+        actions = [json.loads(e["message"])["action"] for e in returned[:5]]
+        assert actions == ["created", "edited", "reviewed", "approved", "published"]
+
+    def test_filter_audit_by_action(self, logs, content_audit_log):
+        """Put mixed events, filter for 'published' only."""
+        group_name, stream_name = content_audit_log
+        base_ts = int(time.time() * 1000)
+
+        mixed_events = [
+            {"action": "created", "content_id": "art-10"},
+            {"action": "published", "content_id": "art-10"},
+            {"action": "created", "content_id": "art-11"},
+            {"action": "edited", "content_id": "art-11"},
+            {"action": "published", "content_id": "art-11"},
+        ]
+        log_events = [
+            {
+                "timestamp": base_ts + i * 1000,
+                "message": json.dumps(evt),
+            }
+            for i, evt in enumerate(mixed_events)
+        ]
+
+        logs.put_log_events(
+            logGroupName=group_name,
+            logStreamName=stream_name,
+            logEvents=log_events,
+        )
+
+        resp = logs.filter_log_events(
+            logGroupName=group_name,
+            filterPattern="published",
+        )
+        matched = resp.get("events", [])
+        assert len(matched) >= 2
+        for evt in matched:
+            assert "published" in evt["message"]
+
+
+class TestContentLifecycle:
+    """EventBridge rules and end-to-end content lifecycle."""
+
+    def test_create_eventbridge_rule(self, events, event_bus):
+        """Create a scheduled rule and verify it is ENABLED."""
+        rule_name = f"cms-schedule-{uuid.uuid4().hex[:8]}"
+        events.put_rule(
+            Name=rule_name,
+            ScheduleExpression="rate(1 hour)",
+            State="ENABLED",
+            EventBusName=event_bus,
+        )
+
+        try:
+            resp = events.describe_rule(Name=rule_name, EventBusName=event_bus)
+            assert resp["State"] == "ENABLED"
+            assert resp["ScheduleExpression"] == "rate(1 hour)"
+        finally:
+            events.delete_rule(Name=rule_name, EventBusName=event_bus)
+
+    def test_eventbridge_with_target(self, events, sqs, event_bus, unique_name):
+        """Create a rule with an SQS target, verify target is listed."""
+        rule_name = f"cms-rule-{unique_name}"
+        queue_name = f"cms-eb-target-{unique_name}"
+
+        q_resp = sqs.create_queue(QueueName=queue_name)
+        queue_url = q_resp["QueueUrl"]
+        queue_arn = f"arn:aws:sqs:us-east-1:123456789012:{queue_name}"
+
+        try:
+            events.put_rule(
+                Name=rule_name,
+                EventPattern=json.dumps(
+                    {
+                        "source": ["cms.content"],
+                        "detail-type": ["ContentPublished"],
+                    }
+                ),
+                State="ENABLED",
+                EventBusName=event_bus,
+            )
+
+            events.put_targets(
+                Rule=rule_name,
+                EventBusName=event_bus,
+                Targets=[{"Id": "sqs-target", "Arn": queue_arn}],
+            )
+
+            resp = events.list_targets_by_rule(Rule=rule_name, EventBusName=event_bus)
+            targets = resp.get("Targets", [])
+            assert len(targets) == 1
+            assert targets[0]["Arn"] == queue_arn
+            assert targets[0]["Id"] == "sqs-target"
+        finally:
+            events.remove_targets(Rule=rule_name, Ids=["sqs-target"], EventBusName=event_bus)
+            events.delete_rule(Name=rule_name, EventBusName=event_bus)
+            sqs.delete_queue(QueueUrl=queue_url)
+
+    def test_full_content_lifecycle(
+        self,
+        s3,
+        dynamodb,
+        sqs,
+        sns,
+        logs,
+        media_bucket,
+        content_table,
+        publish_queue,
+        webhook_topic,
+        content_audit_log,
+        unique_name,
+    ):
+        """End-to-end: draft -> media upload -> review -> queue -> publish -> notify -> audit."""
+        content_id = f"lifecycle-{uuid.uuid4().hex[:8]}"
+        group_name, stream_name = content_audit_log
+        base_ts = int(time.time() * 1000)
+
+        # 1. Create content metadata as draft
+        dynamodb.put_item(
+            TableName=content_table,
+            Item={
+                "content_id": {"S": content_id},
+                "title": {"S": "Lifecycle Test Article"},
+                "category": {"S": "tech"},
+                "status": {"S": "draft"},
+                "author": {"S": "alice"},
+                "created_at": {"S": "2026-03-08T10:00:00Z"},
+                "updated_at": {"S": "2026-03-08T10:00:00Z"},
+                "body_s3_key": {"S": f"content/{content_id}/body.md"},
+            },
+        )
+
+        # 2. Upload media to S3
+        media_key = f"media/{content_id}/hero.jpg"
+        s3.put_object(Bucket=media_bucket, Key=media_key, Body=b"hero-image-data")
+
+        # 3. Update status to review
+        dynamodb.update_item(
+            TableName=content_table,
+            Key={"content_id": {"S": content_id}},
+            UpdateExpression="SET #s = :st, updated_at = :u",
+            ExpressionAttributeNames={"#s": "status"},
+            ExpressionAttributeValues={
+                ":st": {"S": "review"},
+                ":u": {"S": "2026-03-08T11:00:00Z"},
+            },
+        )
+
+        # 4. Queue for publication
+        sqs.send_message(
+            QueueUrl=publish_queue,
+            MessageBody=json.dumps(
+                {
+                    "content_id": content_id,
+                    "action": "publish",
+                }
+            ),
+        )
+
+        # 5. Receive from queue (simulating publish worker)
+        recv = sqs.receive_message(
+            QueueUrl=publish_queue,
+            MaxNumberOfMessages=1,
+            WaitTimeSeconds=5,
+        )
+        assert len(recv.get("Messages", [])) >= 1
+        pub_msg = json.loads(recv["Messages"][0]["Body"])
+        assert pub_msg["content_id"] == content_id
+
+        # 6. Update status to published
+        dynamodb.update_item(
+            TableName=content_table,
+            Key={"content_id": {"S": content_id}},
+            UpdateExpression="SET #s = :st, updated_at = :u",
+            ExpressionAttributeNames={"#s": "status"},
+            ExpressionAttributeValues={
+                ":st": {"S": "published"},
+                ":u": {"S": "2026-03-08T12:00:00Z"},
+            },
+        )
+
+        # 7. Publish webhook via SNS
+        # Create subscriber queue for verification
+        sub_queue_name = f"cms-lifecycle-sub-{unique_name}"
+        sq = sqs.create_queue(QueueName=sub_queue_name)
+        sub_queue_url = sq["QueueUrl"]
+        sub_queue_arn = f"arn:aws:sqs:us-east-1:123456789012:{sub_queue_name}"
+
+        try:
+            sns.subscribe(
+                TopicArn=webhook_topic,
+                Protocol="sqs",
+                Endpoint=sub_queue_arn,
+            )
+
+            sns.publish(
+                TopicArn=webhook_topic,
+                Message=json.dumps(
+                    {
+                        "content_id": content_id,
+                        "title": "Lifecycle Test Article",
+                        "url": f"https://cms.example.com/articles/{content_id}",
+                    }
+                ),
+                Subject="Content Published",
+            )
+
+            # 8. Receive webhook notification
+            webhook_msg = None
+            for _ in range(5):
+                wr = sqs.receive_message(
+                    QueueUrl=sub_queue_url,
+                    MaxNumberOfMessages=1,
+                    WaitTimeSeconds=2,
+                )
+                if wr.get("Messages"):
+                    webhook_msg = wr["Messages"][0]
+                    break
+            assert webhook_msg is not None
+        finally:
+            sqs.delete_queue(QueueUrl=sub_queue_url)
+
+        # 9. Log audit events
+        audit_events = [
+            {"action": "created", "content_id": content_id},
+            {"action": "media_uploaded", "content_id": content_id},
+            {"action": "status_changed", "content_id": content_id, "to": "review"},
+            {"action": "published", "content_id": content_id},
+        ]
+        logs.put_log_events(
+            logGroupName=group_name,
+            logStreamName=stream_name,
+            logEvents=[
+                {
+                    "timestamp": base_ts + i * 1000,
+                    "message": json.dumps(evt),
+                }
+                for i, evt in enumerate(audit_events)
+            ],
+        )
+
+        # Verify final state
+        # S3: media exists
+        media_resp = s3.get_object(Bucket=media_bucket, Key=media_key)
+        assert media_resp["Body"].read() == b"hero-image-data"
+
+        # DynamoDB: status is published
+        db_resp = dynamodb.get_item(
+            TableName=content_table,
+            Key={"content_id": {"S": content_id}},
+        )
+        assert db_resp["Item"]["status"]["S"] == "published"
+
+        # CloudWatch Logs: audit trail
+        log_resp = logs.get_log_events(
+            logGroupName=group_name,
+            logStreamName=stream_name,
+            startFromHead=True,
+        )
+        log_actions = [json.loads(e["message"])["action"] for e in log_resp.get("events", [])]
+        assert "created" in log_actions
+        assert "published" in log_actions

--- a/tests/apps/test_ecommerce_order_app.py
+++ b/tests/apps/test_ecommerce_order_app.py
@@ -1,0 +1,717 @@
+"""
+E-Commerce Order Processing Application Tests
+
+Simulates an online store's order processing pipeline:
+- Orders arrive via SQS FIFO queue (exactly-once, ordered per customer)
+- Order data stored in DynamoDB (with GSIs for querying by status and customer)
+- Payment API credentials stored in Secrets Manager
+- Order confirmations sent via SNS
+- PDF receipts archived to S3
+"""
+
+import json
+import time
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from botocore.exceptions import ClientError
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def dead_letter_queue(sqs, unique_name):
+    """SQS FIFO dead-letter queue linked to the order queue."""
+    dlq_name = f"order-dlq-{unique_name}.fifo"
+    resp = sqs.create_queue(
+        QueueName=dlq_name,
+        Attributes={
+            "FifoQueue": "true",
+            "ContentBasedDeduplication": "false",
+        },
+    )
+    dlq_url = resp["QueueUrl"]
+    yield dlq_url
+    sqs.delete_queue(QueueUrl=dlq_url)
+
+
+@pytest.fixture
+def order_queue(sqs, unique_name, dead_letter_queue):
+    """SQS FIFO queue with content-based dedup, linked to a DLQ."""
+    dlq_arn = sqs.get_queue_attributes(QueueUrl=dead_letter_queue, AttributeNames=["QueueArn"])[
+        "Attributes"
+    ]["QueueArn"]
+
+    queue_name = f"orders-{unique_name}.fifo"
+    resp = sqs.create_queue(
+        QueueName=queue_name,
+        Attributes={
+            "FifoQueue": "true",
+            "ContentBasedDeduplication": "true",
+            "VisibilityTimeout": "1",
+            "RedrivePolicy": json.dumps({"deadLetterTargetArn": dlq_arn, "maxReceiveCount": "1"}),
+        },
+    )
+    url = resp["QueueUrl"]
+    yield url
+    sqs.delete_queue(QueueUrl=url)
+
+
+@pytest.fixture
+def orders_table(dynamodb, unique_name):
+    """DynamoDB table with GSIs for by-status and by-customer queries."""
+    table_name = f"orders-{unique_name}"
+    dynamodb.create_table(
+        TableName=table_name,
+        KeySchema=[{"AttributeName": "order_id", "KeyType": "HASH"}],
+        AttributeDefinitions=[
+            {"AttributeName": "order_id", "AttributeType": "S"},
+            {"AttributeName": "status", "AttributeType": "S"},
+            {"AttributeName": "created_at", "AttributeType": "S"},
+            {"AttributeName": "customer_id", "AttributeType": "S"},
+        ],
+        GlobalSecondaryIndexes=[
+            {
+                "IndexName": "by-status",
+                "KeySchema": [
+                    {"AttributeName": "status", "KeyType": "HASH"},
+                    {"AttributeName": "created_at", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+            {
+                "IndexName": "by-customer",
+                "KeySchema": [
+                    {"AttributeName": "customer_id", "KeyType": "HASH"},
+                    {"AttributeName": "created_at", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+        ],
+        BillingMode="PAY_PER_REQUEST",
+    )
+    yield table_name
+    dynamodb.delete_table(TableName=table_name)
+
+
+@pytest.fixture
+def payment_credentials(secretsmanager, unique_name):
+    """SecretsManager secret holding payment gateway credentials."""
+    secret_name = f"payment-creds-{unique_name}"
+    creds = {
+        "gateway_url": "https://payments.example.com/v2/charge",
+        "api_key": "sk_test_abc123original",
+        "merchant_id": "merch_9876",
+    }
+    secretsmanager.create_secret(
+        Name=secret_name,
+        SecretString=json.dumps(creds),
+    )
+    yield secret_name
+    secretsmanager.delete_secret(SecretId=secret_name, ForceDeleteWithoutRecovery=True)
+
+
+@pytest.fixture
+def confirmation_topic(sns, unique_name):
+    """SNS topic for order confirmation notifications."""
+    topic_name = f"order-confirm-{unique_name}"
+    resp = sns.create_topic(Name=topic_name)
+    arn = resp["TopicArn"]
+    yield arn
+    sns.delete_topic(TopicArn=arn)
+
+
+@pytest.fixture
+def receipt_bucket(s3, unique_name):
+    """S3 bucket for archiving order receipts."""
+    bucket = f"receipts-{unique_name}"
+    s3.create_bucket(Bucket=bucket)
+    yield bucket
+    # Cleanup: delete all objects then bucket
+    try:
+        objects = s3.list_objects_v2(Bucket=bucket).get("Contents", [])
+        for obj in objects:
+            s3.delete_object(Bucket=bucket, Key=obj["Key"])
+    except Exception:
+        pass
+    s3.delete_bucket(Bucket=bucket)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_order(order_id=None, customer_id=None, status="pending"):
+    """Build a sample order dict."""
+    now = datetime.now(UTC).isoformat()
+    return {
+        "order_id": order_id or f"ORD-{uuid.uuid4().hex[:8]}",
+        "customer_id": customer_id or f"CUST-{uuid.uuid4().hex[:6]}",
+        "status": status,
+        "items": [
+            {"sku": "WIDGET-001", "qty": 2, "price": "19.99"},
+            {"sku": "GADGET-042", "qty": 1, "price": "49.99"},
+        ],
+        "total": "89.97",
+        "created_at": now,
+    }
+
+
+def _put_order(dynamodb, table, order):
+    """Write an order dict to DynamoDB using native attribute types."""
+    dynamodb.put_item(
+        TableName=table,
+        Item={
+            "order_id": {"S": order["order_id"]},
+            "customer_id": {"S": order["customer_id"]},
+            "status": {"S": order["status"]},
+            "items": {"S": json.dumps(order["items"])},
+            "total": {"S": order["total"]},
+            "created_at": {"S": order["created_at"]},
+        },
+    )
+
+
+def _subscribe_sqs_to_sns(sns, sqs, topic_arn, queue_url):
+    """Subscribe an SQS queue to an SNS topic and return subscription ARN."""
+    queue_arn = sqs.get_queue_attributes(QueueUrl=queue_url, AttributeNames=["QueueArn"])[
+        "Attributes"
+    ]["QueueArn"]
+    resp = sns.subscribe(
+        TopicArn=topic_arn,
+        Protocol="sqs",
+        Endpoint=queue_arn,
+    )
+    return resp["SubscriptionArn"]
+
+
+def _receive_one(sqs, queue_url, wait=5):
+    """Receive a single message from a queue, returning the message dict or None."""
+    resp = sqs.receive_message(QueueUrl=queue_url, MaxNumberOfMessages=1, WaitTimeSeconds=wait)
+    msgs = resp.get("Messages", [])
+    return msgs[0] if msgs else None
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestOrderIngestion:
+    """SQS FIFO queue + DLQ tests."""
+
+    def test_submit_single_order(self, sqs, order_queue):
+        """Send a single order to the FIFO queue, receive and verify."""
+        order = _make_order(order_id="ORD-SINGLE-001", customer_id="CUST-alice")
+        sqs.send_message(
+            QueueUrl=order_queue,
+            MessageBody=json.dumps(order),
+            MessageGroupId=order["customer_id"],
+            MessageDeduplicationId=order["order_id"],
+        )
+
+        msg = _receive_one(sqs, order_queue)
+        assert msg is not None
+        body = json.loads(msg["Body"])
+        assert body["order_id"] == "ORD-SINGLE-001"
+        assert body["customer_id"] == "CUST-alice"
+        assert body["status"] == "pending"
+        assert len(body["items"]) == 2
+        sqs.delete_message(QueueUrl=order_queue, ReceiptHandle=msg["ReceiptHandle"])
+
+    def test_fifo_ordering_per_customer(self, sqs, order_queue):
+        """Send 5 orders for the same customer, verify arrival order."""
+        customer = "CUST-fifo-test"
+        order_ids = [f"ORD-SEQ-{i:03d}" for i in range(5)]
+
+        for oid in order_ids:
+            sqs.send_message(
+                QueueUrl=order_queue,
+                MessageBody=json.dumps({"order_id": oid, "seq": oid}),
+                MessageGroupId=customer,
+                MessageDeduplicationId=oid,
+            )
+
+        received_ids = []
+        for _ in range(5):
+            msg = _receive_one(sqs, order_queue)
+            assert msg is not None
+            received_ids.append(json.loads(msg["Body"])["order_id"])
+            sqs.delete_message(QueueUrl=order_queue, ReceiptHandle=msg["ReceiptHandle"])
+
+        assert received_ids == order_ids
+
+    def test_deduplication(self, sqs, order_queue):
+        """Send same order twice with identical dedup ID, verify only 1 delivered."""
+        body = json.dumps({"order_id": "ORD-DEDUP-001", "item": "widget"})
+        dedup_id = "ORD-DEDUP-001"
+        group_id = "CUST-dedup"
+
+        sqs.send_message(
+            QueueUrl=order_queue,
+            MessageBody=body,
+            MessageGroupId=group_id,
+            MessageDeduplicationId=dedup_id,
+        )
+        sqs.send_message(
+            QueueUrl=order_queue,
+            MessageBody=body,
+            MessageGroupId=group_id,
+            MessageDeduplicationId=dedup_id,
+        )
+
+        # Receive all available messages
+        messages = []
+        for _ in range(3):
+            resp = sqs.receive_message(
+                QueueUrl=order_queue, MaxNumberOfMessages=10, WaitTimeSeconds=2
+            )
+            batch = resp.get("Messages", [])
+            messages.extend(batch)
+            for m in batch:
+                sqs.delete_message(QueueUrl=order_queue, ReceiptHandle=m["ReceiptHandle"])
+            if not batch:
+                break
+
+        assert len(messages) == 1
+        assert json.loads(messages[0]["Body"])["order_id"] == "ORD-DEDUP-001"
+
+    def test_dead_letter_after_max_receives(self, sqs, order_queue, dead_letter_queue):
+        """Message exceeding maxReceiveCount=1 should land in DLQ."""
+        body = json.dumps({"order_id": "ORD-DLQ-001", "failing": True})
+        sqs.send_message(
+            QueueUrl=order_queue,
+            MessageBody=body,
+            MessageGroupId="CUST-dlq",
+            MessageDeduplicationId="ORD-DLQ-001",
+        )
+
+        # Receive once without deleting (maxReceiveCount=1, vis timeout=1s)
+        resp = sqs.receive_message(QueueUrl=order_queue, MaxNumberOfMessages=1, WaitTimeSeconds=5)
+        assert len(resp.get("Messages", [])) == 1
+
+        # Wait for visibility timeout to expire, then trigger redrive
+        time.sleep(3)
+        sqs.receive_message(QueueUrl=order_queue, MaxNumberOfMessages=1, WaitTimeSeconds=1)
+        time.sleep(2)
+
+        # Message should now be on the DLQ
+        dlq_msg = _receive_one(sqs, dead_letter_queue, wait=5)
+        assert dlq_msg is not None
+        dlq_body = json.loads(dlq_msg["Body"])
+        assert dlq_body["order_id"] == "ORD-DLQ-001"
+
+
+class TestOrderStorage:
+    """DynamoDB table + GSI tests."""
+
+    def test_create_order(self, dynamodb, orders_table):
+        """Create an order and read it back."""
+        order = _make_order(order_id="ORD-CREATE-001", customer_id="CUST-bob")
+        _put_order(dynamodb, orders_table, order)
+
+        result = dynamodb.get_item(
+            TableName=orders_table,
+            Key={"order_id": {"S": "ORD-CREATE-001"}},
+        )
+        item = result["Item"]
+        assert item["order_id"]["S"] == "ORD-CREATE-001"
+        assert item["customer_id"]["S"] == "CUST-bob"
+        assert item["status"]["S"] == "pending"
+        assert item["total"]["S"] == "89.97"
+        items_list = json.loads(item["items"]["S"])
+        assert len(items_list) == 2
+        assert items_list[0]["sku"] == "WIDGET-001"
+
+    def test_query_orders_by_status(self, dynamodb, orders_table):
+        """Insert orders with different statuses, query GSI by-status."""
+        base_time = "2026-03-08T"
+        orders = []
+        for i, status in enumerate(
+            ["pending", "pending", "pending", "shipped", "shipped", "delivered"]
+        ):
+            o = _make_order(
+                order_id=f"ORD-STATUS-{i:03d}",
+                customer_id=f"CUST-{i}",
+                status=status,
+            )
+            o["created_at"] = f"{base_time}{10 + i:02d}:00:00Z"
+            orders.append(o)
+            _put_order(dynamodb, orders_table, o)
+
+        resp = dynamodb.query(
+            TableName=orders_table,
+            IndexName="by-status",
+            KeyConditionExpression="#s = :status",
+            ExpressionAttributeNames={"#s": "status"},
+            ExpressionAttributeValues={":status": {"S": "pending"}},
+        )
+        assert resp["Count"] == 3
+        for item in resp["Items"]:
+            assert item["status"]["S"] == "pending"
+
+    def test_query_orders_by_customer(self, dynamodb, orders_table):
+        """Insert orders for 2 customers, query GSI by-customer."""
+        for i in range(3):
+            o = _make_order(order_id=f"ORD-ALICE-{i}", customer_id="CUST-alice")
+            o["created_at"] = f"2026-03-08T{10 + i}:00:00Z"
+            _put_order(dynamodb, orders_table, o)
+        for i in range(2):
+            o = _make_order(order_id=f"ORD-BOB-{i}", customer_id="CUST-bob")
+            o["created_at"] = f"2026-03-08T{10 + i}:00:00Z"
+            _put_order(dynamodb, orders_table, o)
+
+        resp = dynamodb.query(
+            TableName=orders_table,
+            IndexName="by-customer",
+            KeyConditionExpression="customer_id = :cid",
+            ExpressionAttributeValues={":cid": {"S": "CUST-alice"}},
+        )
+        assert resp["Count"] == 3
+        for item in resp["Items"]:
+            assert item["customer_id"]["S"] == "CUST-alice"
+
+    def test_update_order_status(self, dynamodb, orders_table):
+        """Create a pending order, update to shipped with tracking number."""
+        order = _make_order(order_id="ORD-UPD-001", customer_id="CUST-carol")
+        _put_order(dynamodb, orders_table, order)
+
+        dynamodb.update_item(
+            TableName=orders_table,
+            Key={"order_id": {"S": "ORD-UPD-001"}},
+            UpdateExpression="SET #s = :shipped, tracking_number = :tn",
+            ExpressionAttributeNames={"#s": "status"},
+            ExpressionAttributeValues={
+                ":shipped": {"S": "shipped"},
+                ":tn": {"S": "1Z999AA10123456784"},
+            },
+        )
+
+        result = dynamodb.get_item(
+            TableName=orders_table,
+            Key={"order_id": {"S": "ORD-UPD-001"}},
+        )
+        item = result["Item"]
+        assert item["status"]["S"] == "shipped"
+        assert item["tracking_number"]["S"] == "1Z999AA10123456784"
+
+    def test_conditional_update(self, dynamodb, orders_table):
+        """Conditional update succeeds when condition is met, fails otherwise."""
+        order = _make_order(order_id="ORD-COND-001", customer_id="CUST-dave")
+        _put_order(dynamodb, orders_table, order)
+
+        # First update: pending -> cancelled (should succeed)
+        dynamodb.update_item(
+            TableName=orders_table,
+            Key={"order_id": {"S": "ORD-COND-001"}},
+            UpdateExpression="SET #s = :cancelled",
+            ConditionExpression="#s = :pending",
+            ExpressionAttributeNames={"#s": "status"},
+            ExpressionAttributeValues={
+                ":cancelled": {"S": "cancelled"},
+                ":pending": {"S": "pending"},
+            },
+        )
+
+        result = dynamodb.get_item(
+            TableName=orders_table,
+            Key={"order_id": {"S": "ORD-COND-001"}},
+        )
+        assert result["Item"]["status"]["S"] == "cancelled"
+
+        # Second update: try to cancel again (should fail — status is now cancelled)
+        with pytest.raises(ClientError) as exc_info:
+            dynamodb.update_item(
+                TableName=orders_table,
+                Key={"order_id": {"S": "ORD-COND-001"}},
+                UpdateExpression="SET #s = :cancelled",
+                ConditionExpression="#s = :pending",
+                ExpressionAttributeNames={"#s": "status"},
+                ExpressionAttributeValues={
+                    ":cancelled": {"S": "cancelled"},
+                    ":pending": {"S": "pending"},
+                },
+            )
+        assert exc_info.value.response["Error"]["Code"] == "ConditionalCheckFailedException"
+
+
+class TestPaymentIntegration:
+    """SecretsManager tests for payment credentials."""
+
+    def test_retrieve_payment_credentials(self, secretsmanager, payment_credentials):
+        """Retrieve and parse payment gateway credentials."""
+        resp = secretsmanager.get_secret_value(SecretId=payment_credentials)
+        creds = json.loads(resp["SecretString"])
+        assert creds["gateway_url"] == "https://payments.example.com/v2/charge"
+        assert creds["api_key"] == "sk_test_abc123original"
+        assert creds["merchant_id"] == "merch_9876"
+
+    def test_rotate_api_key(self, secretsmanager, payment_credentials):
+        """Update the secret with a new API key and verify."""
+        new_creds = {
+            "gateway_url": "https://payments.example.com/v2/charge",
+            "api_key": "sk_test_xyz789rotated",
+            "merchant_id": "merch_9876",
+        }
+        secretsmanager.update_secret(
+            SecretId=payment_credentials,
+            SecretString=json.dumps(new_creds),
+        )
+
+        resp = secretsmanager.get_secret_value(SecretId=payment_credentials)
+        creds = json.loads(resp["SecretString"])
+        assert creds["api_key"] == "sk_test_xyz789rotated"
+
+    def test_credential_versioning(self, secretsmanager, payment_credentials):
+        """Create, update twice, verify version stages."""
+        # First update
+        secretsmanager.update_secret(
+            SecretId=payment_credentials,
+            SecretString=json.dumps({"api_key": "v2"}),
+        )
+        # Second update
+        secretsmanager.update_secret(
+            SecretId=payment_credentials,
+            SecretString=json.dumps({"api_key": "v3"}),
+        )
+
+        desc = secretsmanager.describe_secret(SecretId=payment_credentials)
+        version_stages = desc.get("VersionIdsToStages", {})
+        # There should be at least one version marked AWSCURRENT
+        current_versions = [vid for vid, stages in version_stages.items() if "AWSCURRENT" in stages]
+        assert len(current_versions) >= 1
+
+        # Verify the current value is the latest
+        resp = secretsmanager.get_secret_value(SecretId=payment_credentials)
+        creds = json.loads(resp["SecretString"])
+        assert creds["api_key"] == "v3"
+
+
+class TestOrderNotifications:
+    """SNS + SQS subscription tests."""
+
+    @pytest.fixture
+    def subscriber_queue(self, sqs, unique_name):
+        """A standard SQS queue to receive SNS notifications."""
+        name = f"order-notify-sub-{unique_name}"
+        resp = sqs.create_queue(QueueName=name)
+        url = resp["QueueUrl"]
+        yield url
+        sqs.delete_queue(QueueUrl=url)
+
+    def test_publish_order_confirmation(self, sns, sqs, confirmation_topic, subscriber_queue):
+        """Publish order confirmation to SNS, receive via SQS subscriber."""
+        _subscribe_sqs_to_sns(sns, sqs, confirmation_topic, subscriber_queue)
+
+        order_msg = {
+            "order_id": "ORD-CONFIRM-001",
+            "status": "confirmed",
+            "total": "89.97",
+        }
+        sns.publish(
+            TopicArn=confirmation_topic,
+            Message=json.dumps(order_msg),
+            Subject="Order Confirmation",
+        )
+
+        msg = _receive_one(sqs, subscriber_queue, wait=5)
+        assert msg is not None
+        # SNS wraps the message in an envelope
+        envelope = json.loads(msg["Body"])
+        inner = json.loads(envelope["Message"])
+        assert inner["order_id"] == "ORD-CONFIRM-001"
+        assert inner["status"] == "confirmed"
+
+    def test_message_attributes(self, sns, sqs, confirmation_topic, subscriber_queue):
+        """Publish with MessageAttributes, verify they reach the subscriber."""
+        _subscribe_sqs_to_sns(sns, sqs, confirmation_topic, subscriber_queue)
+
+        sns.publish(
+            TopicArn=confirmation_topic,
+            Message=json.dumps({"order_id": "ORD-ATTR-001"}),
+            MessageAttributes={
+                "order_type": {"DataType": "String", "StringValue": "express"},
+                "priority": {"DataType": "String", "StringValue": "high"},
+            },
+        )
+
+        msg = _receive_one(sqs, subscriber_queue, wait=5)
+        assert msg is not None
+        envelope = json.loads(msg["Body"])
+        # SNS includes MessageAttributes in the envelope
+        attrs = envelope.get("MessageAttributes", {})
+        assert attrs["order_type"]["Value"] == "express"
+        assert attrs["priority"]["Value"] == "high"
+
+    def test_multiple_subscribers(self, sns, sqs, confirmation_topic, unique_name):
+        """Publish once, verify message arrives in both subscriber queues."""
+        queues = []
+        for i in range(2):
+            name = f"multi-sub-{unique_name}-{i}"
+            resp = sqs.create_queue(QueueName=name)
+            queues.append(resp["QueueUrl"])
+            _subscribe_sqs_to_sns(sns, sqs, confirmation_topic, resp["QueueUrl"])
+
+        try:
+            sns.publish(
+                TopicArn=confirmation_topic,
+                Message=json.dumps({"order_id": "ORD-MULTI-001"}),
+            )
+
+            for queue_url in queues:
+                msg = _receive_one(sqs, queue_url, wait=5)
+                assert msg is not None
+                envelope = json.loads(msg["Body"])
+                inner = json.loads(envelope["Message"])
+                assert inner["order_id"] == "ORD-MULTI-001"
+        finally:
+            for q in queues:
+                sqs.delete_queue(QueueUrl=q)
+
+
+class TestOrderReceipts:
+    """S3 receipt storage and end-to-end tests."""
+
+    def test_store_receipt(self, s3, receipt_bucket):
+        """Upload a JSON receipt to S3 and download to verify content."""
+        receipt = {
+            "order_id": "ORD-RCPT-001",
+            "customer": "alice",
+            "items": [{"sku": "WIDGET-001", "qty": 2}],
+            "total": "39.98",
+            "paid_at": "2026-03-08T12:00:00Z",
+        }
+        key = "receipts/2026/03/ORD-RCPT-001.json"
+        s3.put_object(
+            Bucket=receipt_bucket,
+            Key=key,
+            Body=json.dumps(receipt),
+            ContentType="application/json",
+        )
+
+        obj = s3.get_object(Bucket=receipt_bucket, Key=key)
+        downloaded = json.loads(obj["Body"].read())
+        assert downloaded["order_id"] == "ORD-RCPT-001"
+        assert downloaded["total"] == "39.98"
+        assert downloaded["customer"] == "alice"
+
+    def test_list_receipts_by_month(self, s3, receipt_bucket):
+        """Upload receipts across months, verify prefix-based listing."""
+        for month, oid in [("01", "A"), ("01", "B"), ("02", "C"), ("03", "D")]:
+            s3.put_object(
+                Bucket=receipt_bucket,
+                Key=f"receipts/2026/{month}/ORD-{oid}.json",
+                Body=json.dumps({"order_id": f"ORD-{oid}"}),
+            )
+
+        resp = s3.list_objects_v2(Bucket=receipt_bucket, Prefix="receipts/2026/01/")
+        assert resp["KeyCount"] == 2
+        keys = {o["Key"] for o in resp["Contents"]}
+        assert keys == {
+            "receipts/2026/01/ORD-A.json",
+            "receipts/2026/01/ORD-B.json",
+        }
+
+    def test_full_order_lifecycle(
+        self,
+        sqs,
+        dynamodb,
+        secretsmanager,
+        sns,
+        s3,
+        orders_table,
+        order_queue,
+        payment_credentials,
+        confirmation_topic,
+        receipt_bucket,
+        unique_name,
+    ):
+        """End-to-end: submit order -> store -> confirm -> notify -> archive."""
+        order_id = f"ORD-E2E-{uuid.uuid4().hex[:6]}"
+        customer_id = "CUST-lifecycle"
+
+        # 1. Read payment credentials from SecretsManager
+        creds_resp = secretsmanager.get_secret_value(SecretId=payment_credentials)
+        creds = json.loads(creds_resp["SecretString"])
+        assert "api_key" in creds
+
+        # 2. Submit order to SQS FIFO
+        order = _make_order(order_id=order_id, customer_id=customer_id)
+        sqs.send_message(
+            QueueUrl=order_queue,
+            MessageBody=json.dumps(order),
+            MessageGroupId=customer_id,
+            MessageDeduplicationId=order_id,
+        )
+
+        # 3. Receive order from queue
+        msg = _receive_one(sqs, order_queue, wait=5)
+        assert msg is not None
+        received_order = json.loads(msg["Body"])
+        assert received_order["order_id"] == order_id
+        sqs.delete_message(QueueUrl=order_queue, ReceiptHandle=msg["ReceiptHandle"])
+
+        # 4. Store order in DynamoDB
+        _put_order(dynamodb, orders_table, received_order)
+
+        # 5. Update status to confirmed
+        dynamodb.update_item(
+            TableName=orders_table,
+            Key={"order_id": {"S": order_id}},
+            UpdateExpression="SET #s = :confirmed",
+            ExpressionAttributeNames={"#s": "status"},
+            ExpressionAttributeValues={":confirmed": {"S": "confirmed"}},
+        )
+
+        # 6. Publish SNS notification — subscribe a queue first
+        notify_queue_name = f"e2e-notify-{unique_name}"
+        notify_resp = sqs.create_queue(QueueName=notify_queue_name)
+        notify_queue_url = notify_resp["QueueUrl"]
+        try:
+            _subscribe_sqs_to_sns(sns, sqs, confirmation_topic, notify_queue_url)
+
+            sns.publish(
+                TopicArn=confirmation_topic,
+                Message=json.dumps({"order_id": order_id, "status": "confirmed"}),
+            )
+
+            # 7. Receive notification
+            notify_msg = _receive_one(sqs, notify_queue_url, wait=5)
+            assert notify_msg is not None
+            envelope = json.loads(notify_msg["Body"])
+            inner = json.loads(envelope["Message"])
+            assert inner["order_id"] == order_id
+            assert inner["status"] == "confirmed"
+        finally:
+            sqs.delete_queue(QueueUrl=notify_queue_url)
+
+        # 8. Archive receipt to S3
+        receipt = {
+            "order_id": order_id,
+            "customer_id": customer_id,
+            "total": received_order["total"],
+            "confirmed_at": datetime.now(UTC).isoformat(),
+        }
+        receipt_key = f"receipts/2026/03/{order_id}.json"
+        s3.put_object(
+            Bucket=receipt_bucket,
+            Key=receipt_key,
+            Body=json.dumps(receipt),
+        )
+
+        # 9. Verify receipt in S3
+        obj = s3.get_object(Bucket=receipt_bucket, Key=receipt_key)
+        stored_receipt = json.loads(obj["Body"].read())
+        assert stored_receipt["order_id"] == order_id
+
+        # 10. Verify final state in DynamoDB
+        final = dynamodb.get_item(
+            TableName=orders_table,
+            Key={"order_id": {"S": order_id}},
+        )
+        assert final["Item"]["status"]["S"] == "confirmed"
+        assert final["Item"]["customer_id"]["S"] == customer_id

--- a/tests/apps/test_multitenant_saas_app.py
+++ b/tests/apps/test_multitenant_saas_app.py
@@ -1,0 +1,732 @@
+"""
+Multi-Tenant SaaS Platform Tests
+
+Simulates a B2B SaaS platform with strict tenant isolation:
+- DynamoDB for tenant data (partition key prefix isolation)
+- SSM Parameter Store for per-tenant configuration
+- Secrets Manager for per-tenant database credentials
+- S3 for per-tenant file storage (prefix isolation)
+- SQS for tenant onboarding task queues
+- CloudWatch for per-tenant usage metrics
+"""
+
+import json
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def tenant_data_table(dynamodb, unique_name):
+    table_name = f"tenant-data-{unique_name}"
+    dynamodb.create_table(
+        TableName=table_name,
+        KeySchema=[
+            {"AttributeName": "tenant_id", "KeyType": "HASH"},
+            {"AttributeName": "entity_key", "KeyType": "RANGE"},
+        ],
+        AttributeDefinitions=[
+            {"AttributeName": "tenant_id", "AttributeType": "S"},
+            {"AttributeName": "entity_key", "AttributeType": "S"},
+            {"AttributeName": "entity_type", "AttributeType": "S"},
+            {"AttributeName": "created_at", "AttributeType": "S"},
+        ],
+        GlobalSecondaryIndexes=[
+            {
+                "IndexName": "by-entity-type",
+                "KeySchema": [
+                    {"AttributeName": "entity_type", "KeyType": "HASH"},
+                    {"AttributeName": "created_at", "KeyType": "RANGE"},
+                ],
+                "Projection": {"ProjectionType": "ALL"},
+            },
+        ],
+        BillingMode="PAY_PER_REQUEST",
+    )
+    yield table_name
+    dynamodb.delete_table(TableName=table_name)
+
+
+@pytest.fixture
+def tenant_bucket(s3, unique_name):
+    bucket_name = f"tenant-files-{unique_name}"
+    s3.create_bucket(Bucket=bucket_name)
+    yield bucket_name
+    # Cleanup: delete all objects then bucket
+    resp = s3.list_objects_v2(Bucket=bucket_name)
+    for obj in resp.get("Contents", []):
+        s3.delete_object(Bucket=bucket_name, Key=obj["Key"])
+    s3.delete_bucket(Bucket=bucket_name)
+
+
+@pytest.fixture
+def onboarding_queue(sqs, unique_name):
+    queue_name = f"onboarding-{unique_name}"
+    resp = sqs.create_queue(QueueName=queue_name)
+    url = resp["QueueUrl"]
+    yield url
+    sqs.delete_queue(QueueUrl=url)
+
+
+@pytest.fixture
+def tenant_configs(ssm, unique_name):
+    prefix = f"/tenants/{unique_name}"
+    params = []
+    configs = {
+        "tenant-a": {
+            "plan_tier": "starter",
+            "max_users": "10",
+            "features_enabled": "billing,reports",
+        },
+        "tenant-b": {
+            "plan_tier": "enterprise",
+            "max_users": "500",
+            "features_enabled": "billing,reports,sso,audit,api_access",
+        },
+    }
+    for tenant, settings in configs.items():
+        for key, value in settings.items():
+            param_name = f"{prefix}/{tenant}/{key}"
+            ssm.put_parameter(Name=param_name, Value=value, Type="String")
+            params.append(param_name)
+    yield prefix, configs
+    for param_name in params:
+        ssm.delete_parameter(Name=param_name)
+
+
+@pytest.fixture
+def tenant_secrets(secretsmanager, unique_name):
+    secrets = {}
+    for tenant in ("tenant-a", "tenant-b"):
+        name = f"{unique_name}/{tenant}/db-credentials"
+        value = json.dumps(
+            {
+                "host": f"{tenant}-db.internal.example.com",
+                "port": 5432,
+                "db_name": f"saas_{tenant.replace('-', '_')}",
+                "username": f"{tenant}_app",
+                "password": f"secret-{tenant}-initial",
+            }
+        )
+        secretsmanager.create_secret(Name=name, SecretString=value)
+        secrets[tenant] = name
+    yield secrets
+    for name in secrets.values():
+        secretsmanager.delete_secret(SecretId=name, ForceDeleteWithoutRecovery=True)
+
+
+@pytest.fixture
+def usage_namespace(unique_name):
+    return f"SaaS/{unique_name}"
+
+
+# ---------------------------------------------------------------------------
+# Test Classes
+# ---------------------------------------------------------------------------
+
+
+class TestTenantIsolation:
+    """DynamoDB tenant data isolation tests."""
+
+    def test_create_tenant_entities(self, dynamodb, tenant_data_table):
+        """Create entities for two tenants, verify correct counts per tenant."""
+        table = tenant_data_table
+        # Tenant A: 2 users + 1 project = 3 entities
+        for item in [
+            {
+                "tenant_id": {"S": "tenant-a"},
+                "entity_key": {"S": "USER#1"},
+                "entity_type": {"S": "USER"},
+                "created_at": {"S": "2026-01-01T00:00:00Z"},
+                "display_name": {"S": "Alice"},
+            },
+            {
+                "tenant_id": {"S": "tenant-a"},
+                "entity_key": {"S": "USER#2"},
+                "entity_type": {"S": "USER"},
+                "created_at": {"S": "2026-01-02T00:00:00Z"},
+                "display_name": {"S": "Bob"},
+            },
+            {
+                "tenant_id": {"S": "tenant-a"},
+                "entity_key": {"S": "PROJECT#1"},
+                "entity_type": {"S": "PROJECT"},
+                "created_at": {"S": "2026-01-03T00:00:00Z"},
+                "display_name": {"S": "Alpha Project"},
+            },
+        ]:
+            dynamodb.put_item(TableName=table, Item=item)
+
+        # Tenant B: 1 user + 1 project = 2 entities
+        for item in [
+            {
+                "tenant_id": {"S": "tenant-b"},
+                "entity_key": {"S": "USER#1"},
+                "entity_type": {"S": "USER"},
+                "created_at": {"S": "2026-01-01T00:00:00Z"},
+                "display_name": {"S": "Charlie"},
+            },
+            {
+                "tenant_id": {"S": "tenant-b"},
+                "entity_key": {"S": "PROJECT#1"},
+                "entity_type": {"S": "PROJECT"},
+                "created_at": {"S": "2026-01-02T00:00:00Z"},
+                "display_name": {"S": "Beta Project"},
+            },
+        ]:
+            dynamodb.put_item(TableName=table, Item=item)
+
+        # Query tenant-a
+        resp_a = dynamodb.query(
+            TableName=table,
+            KeyConditionExpression="tenant_id = :tid",
+            ExpressionAttributeValues={":tid": {"S": "tenant-a"}},
+        )
+        assert resp_a["Count"] == 3
+
+        # Query tenant-b
+        resp_b = dynamodb.query(
+            TableName=table,
+            KeyConditionExpression="tenant_id = :tid",
+            ExpressionAttributeValues={":tid": {"S": "tenant-b"}},
+        )
+        assert resp_b["Count"] == 2
+
+    def test_tenant_data_isolation(self, dynamodb, tenant_data_table):
+        """Query for one tenant must never return another tenant's data."""
+        table = tenant_data_table
+        dynamodb.put_item(
+            TableName=table,
+            Item={
+                "tenant_id": {"S": "tenant-a"},
+                "entity_key": {"S": "USER#1"},
+                "entity_type": {"S": "USER"},
+                "created_at": {"S": "2026-01-01T00:00:00Z"},
+                "secret_data": {"S": "tenant-a-confidential"},
+            },
+        )
+        dynamodb.put_item(
+            TableName=table,
+            Item={
+                "tenant_id": {"S": "tenant-b"},
+                "entity_key": {"S": "USER#1"},
+                "entity_type": {"S": "USER"},
+                "created_at": {"S": "2026-01-01T00:00:00Z"},
+                "secret_data": {"S": "tenant-b-confidential"},
+            },
+        )
+
+        resp = dynamodb.query(
+            TableName=table,
+            KeyConditionExpression="tenant_id = :tid",
+            ExpressionAttributeValues={":tid": {"S": "tenant-a"}},
+        )
+        tenant_ids = {item["tenant_id"]["S"] for item in resp["Items"]}
+        assert tenant_ids == {"tenant-a"}, "Tenant-b data leaked into tenant-a query"
+        assert resp["Items"][0]["secret_data"]["S"] == "tenant-a-confidential"
+
+    def test_cross_tenant_entity_query(self, dynamodb, tenant_data_table):
+        """GSI query by entity_type spans tenants (admin view), then filter by tenant."""
+        table = tenant_data_table
+        items = [
+            {
+                "tenant_id": {"S": "tenant-a"},
+                "entity_key": {"S": "USER#1"},
+                "entity_type": {"S": "USER"},
+                "created_at": {"S": "2026-01-01T00:00:00Z"},
+            },
+            {
+                "tenant_id": {"S": "tenant-a"},
+                "entity_key": {"S": "USER#2"},
+                "entity_type": {"S": "USER"},
+                "created_at": {"S": "2026-01-02T00:00:00Z"},
+            },
+            {
+                "tenant_id": {"S": "tenant-b"},
+                "entity_key": {"S": "USER#1"},
+                "entity_type": {"S": "USER"},
+                "created_at": {"S": "2026-01-03T00:00:00Z"},
+            },
+            {
+                "tenant_id": {"S": "tenant-a"},
+                "entity_key": {"S": "PROJECT#1"},
+                "entity_type": {"S": "PROJECT"},
+                "created_at": {"S": "2026-01-04T00:00:00Z"},
+            },
+        ]
+        for item in items:
+            dynamodb.put_item(TableName=table, Item=item)
+
+        # Admin view: all USERs across tenants via GSI
+        resp = dynamodb.query(
+            TableName=table,
+            IndexName="by-entity-type",
+            KeyConditionExpression="entity_type = :et",
+            ExpressionAttributeValues={":et": {"S": "USER"}},
+        )
+        assert resp["Count"] == 3
+        returned_tenants = {item["tenant_id"]["S"] for item in resp["Items"]}
+        assert returned_tenants == {"tenant-a", "tenant-b"}
+
+        # Filter to tenant-a only
+        resp_filtered = dynamodb.query(
+            TableName=table,
+            IndexName="by-entity-type",
+            KeyConditionExpression="entity_type = :et",
+            FilterExpression="tenant_id = :tid",
+            ExpressionAttributeValues={
+                ":et": {"S": "USER"},
+                ":tid": {"S": "tenant-a"},
+            },
+        )
+        assert resp_filtered["Count"] == 2
+        for item in resp_filtered["Items"]:
+            assert item["tenant_id"]["S"] == "tenant-a"
+
+    def test_tenant_entity_update(self, dynamodb, tenant_data_table):
+        """Update tenant-a entity without affecting tenant-b's same entity key."""
+        table = tenant_data_table
+        for tenant in ("tenant-a", "tenant-b"):
+            dynamodb.put_item(
+                TableName=table,
+                Item={
+                    "tenant_id": {"S": tenant},
+                    "entity_key": {"S": "USER#1"},
+                    "entity_type": {"S": "USER"},
+                    "created_at": {"S": "2026-01-01T00:00:00Z"},
+                    "display_name": {"S": f"Original-{tenant}"},
+                },
+            )
+
+        # Update tenant-a's USER#1
+        dynamodb.update_item(
+            TableName=table,
+            Key={"tenant_id": {"S": "tenant-a"}, "entity_key": {"S": "USER#1"}},
+            UpdateExpression="SET display_name = :dn",
+            ExpressionAttributeValues={":dn": {"S": "Updated-Alice"}},
+        )
+
+        # Verify tenant-a updated
+        resp_a = dynamodb.get_item(
+            TableName=table,
+            Key={"tenant_id": {"S": "tenant-a"}, "entity_key": {"S": "USER#1"}},
+        )
+        assert resp_a["Item"]["display_name"]["S"] == "Updated-Alice"
+
+        # Verify tenant-b unchanged
+        resp_b = dynamodb.get_item(
+            TableName=table,
+            Key={"tenant_id": {"S": "tenant-b"}, "entity_key": {"S": "USER#1"}},
+        )
+        assert resp_b["Item"]["display_name"]["S"] == "Original-tenant-b"
+
+
+class TestTenantConfiguration:
+    """SSM Parameter Store per-tenant configuration tests."""
+
+    def test_per_tenant_config_tree(self, ssm, tenant_configs):
+        """Each tenant has its own config subtree with correct values."""
+        prefix, expected = tenant_configs
+
+        for tenant, settings in expected.items():
+            resp = ssm.get_parameters_by_path(Path=f"{prefix}/{tenant}/", Recursive=False)
+            params = {p["Name"].split("/")[-1]: p["Value"] for p in resp["Parameters"]}
+            assert params["plan_tier"] == settings["plan_tier"]
+            assert params["max_users"] == settings["max_users"]
+            assert params["features_enabled"] == settings["features_enabled"]
+
+    def test_update_tenant_plan(self, ssm, tenant_configs):
+        """Overwrite a tenant's plan tier and verify the change."""
+        prefix, _ = tenant_configs
+        param_name = f"{prefix}/tenant-a/plan_tier"
+
+        ssm.put_parameter(Name=param_name, Value="business", Type="String", Overwrite=True)
+
+        resp = ssm.get_parameter(Name=param_name)
+        assert resp["Parameter"]["Value"] == "business"
+
+    def test_config_hierarchy(self, ssm, tenant_configs, unique_name):
+        """Global config params appear alongside tenant-specific params with recursive fetch."""
+        prefix, _ = tenant_configs
+        global_param = f"{prefix}/tenant-a/global/maintenance_mode"
+        ssm.put_parameter(Name=global_param, Value="false", Type="String")
+
+        try:
+            resp = ssm.get_parameters_by_path(Path=f"{prefix}/tenant-a/", Recursive=True)
+            param_names = {p["Name"] for p in resp["Parameters"]}
+            # Should include both regular config and the nested global param
+            assert global_param in param_names
+            assert f"{prefix}/tenant-a/plan_tier" in param_names
+            assert len(resp["Parameters"]) >= 4  # 3 config + 1 global
+        finally:
+            ssm.delete_parameter(Name=global_param)
+
+    def test_tenant_feature_flags(self, ssm, tenant_configs):
+        """Parse comma-separated feature flags from config, verify per-tenant features."""
+        prefix, expected = tenant_configs
+
+        for tenant, settings in expected.items():
+            resp = ssm.get_parameter(Name=f"{prefix}/{tenant}/features_enabled")
+            features = resp["Parameter"]["Value"].split(",")
+            expected_features = settings["features_enabled"].split(",")
+            assert set(features) == set(expected_features)
+
+        # Tenant-b (enterprise) has more features than tenant-a (starter)
+        resp_a = ssm.get_parameter(Name=f"{prefix}/tenant-a/features_enabled")
+        resp_b = ssm.get_parameter(Name=f"{prefix}/tenant-b/features_enabled")
+        features_a = set(resp_a["Parameter"]["Value"].split(","))
+        features_b = set(resp_b["Parameter"]["Value"].split(","))
+        assert features_a < features_b, "Enterprise should have superset of starter features"
+
+
+class TestTenantStorage:
+    """S3 prefix-based tenant file isolation tests."""
+
+    def test_tenant_file_upload(self, s3, tenant_bucket):
+        """Upload files per-tenant prefix, list verifies isolation."""
+        s3.put_object(
+            Bucket=tenant_bucket,
+            Key="tenant-a/docs/file1.txt",
+            Body=b"Tenant A document",
+        )
+        s3.put_object(
+            Bucket=tenant_bucket,
+            Key="tenant-b/docs/file1.txt",
+            Body=b"Tenant B document",
+        )
+
+        resp = s3.list_objects_v2(Bucket=tenant_bucket, Prefix="tenant-a/")
+        keys = [obj["Key"] for obj in resp["Contents"]]
+        assert keys == ["tenant-a/docs/file1.txt"]
+        assert resp["KeyCount"] == 1
+
+    def test_tenant_storage_quota(self, s3, tenant_bucket):
+        """Sum object sizes to compute per-tenant storage usage."""
+        sizes = [100, 200, 300, 400, 500]
+        for i, size in enumerate(sizes):
+            s3.put_object(
+                Bucket=tenant_bucket,
+                Key=f"tenant-a/data/file{i}.bin",
+                Body=b"x" * size,
+            )
+
+        resp = s3.list_objects_v2(Bucket=tenant_bucket, Prefix="tenant-a/")
+        total_size = sum(obj["Size"] for obj in resp["Contents"])
+        assert total_size == sum(sizes)
+        assert resp["KeyCount"] == 5
+
+    def test_cross_tenant_file_isolation(self, s3, tenant_bucket):
+        """Neither tenant can see the other's files via prefix listing."""
+        for tenant in ("tenant-a", "tenant-b"):
+            for i in range(3):
+                s3.put_object(
+                    Bucket=tenant_bucket,
+                    Key=f"{tenant}/files/item{i}.txt",
+                    Body=f"Data for {tenant} item {i}".encode(),
+                )
+
+        for tenant in ("tenant-a", "tenant-b"):
+            resp = s3.list_objects_v2(Bucket=tenant_bucket, Prefix=f"{tenant}/")
+            assert resp["KeyCount"] == 3
+            for obj in resp["Contents"]:
+                assert obj["Key"].startswith(f"{tenant}/"), (
+                    f"File {obj['Key']} leaked into {tenant} listing"
+                )
+
+
+class TestTenantOnboarding:
+    """SQS + SecretsManager onboarding workflow tests."""
+
+    def test_onboarding_task_queue(self, sqs, onboarding_queue):
+        """Send onboarding tasks as JSON messages, receive and verify all task types."""
+        tasks = ["create_db", "seed_data", "configure_dns"]
+        for task_type in tasks:
+            sqs.send_message(
+                QueueUrl=onboarding_queue,
+                MessageBody=json.dumps(
+                    {"task_type": task_type, "tenant_id": "tenant-new", "priority": "high"}
+                ),
+            )
+
+        received_tasks = []
+        for _ in range(5):  # poll a few times to collect all
+            resp = sqs.receive_message(
+                QueueUrl=onboarding_queue, MaxNumberOfMessages=10, WaitTimeSeconds=1
+            )
+            for msg in resp.get("Messages", []):
+                body = json.loads(msg["Body"])
+                received_tasks.append(body["task_type"])
+                sqs.delete_message(QueueUrl=onboarding_queue, ReceiptHandle=msg["ReceiptHandle"])
+            if len(received_tasks) >= 3:
+                break
+
+        assert set(received_tasks) == set(tasks)
+
+    def test_tenant_credential_provisioning(self, secretsmanager, tenant_secrets):
+        """Retrieve tenant-specific DB credentials, verify tenant-specific values."""
+        resp = secretsmanager.get_secret_value(SecretId=tenant_secrets["tenant-a"])
+        creds = json.loads(resp["SecretString"])
+
+        assert creds["host"] == "tenant-a-db.internal.example.com"
+        assert creds["port"] == 5432
+        assert creds["db_name"] == "saas_tenant_a"
+        assert creds["username"] == "tenant-a_app"
+
+    def test_rotate_tenant_credentials(self, secretsmanager, tenant_secrets):
+        """Update one tenant's secret, verify other tenant's is unchanged."""
+        # Rotate tenant-a password
+        new_creds = json.dumps(
+            {
+                "host": "tenant-a-db.internal.example.com",
+                "port": 5432,
+                "db_name": "saas_tenant_a",
+                "username": "tenant-a_app",
+                "password": "rotated-new-password",
+            }
+        )
+        secretsmanager.update_secret(SecretId=tenant_secrets["tenant-a"], SecretString=new_creds)
+
+        # Verify tenant-a has new password
+        resp_a = secretsmanager.get_secret_value(SecretId=tenant_secrets["tenant-a"])
+        assert json.loads(resp_a["SecretString"])["password"] == "rotated-new-password"
+
+        # Verify tenant-b is unchanged
+        resp_b = secretsmanager.get_secret_value(SecretId=tenant_secrets["tenant-b"])
+        assert json.loads(resp_b["SecretString"])["password"] == "secret-tenant-b-initial"
+
+
+class TestTenantMetrics:
+    """CloudWatch per-tenant usage metrics and end-to-end tests."""
+
+    def test_per_tenant_usage_metrics(self, cloudwatch, usage_namespace):
+        """Publish per-tenant metrics with dimensions, query back by tenant."""
+        cloudwatch.put_metric_data(
+            Namespace=usage_namespace,
+            MetricData=[
+                {
+                    "MetricName": "ApiCalls",
+                    "Dimensions": [{"Name": "TenantId", "Value": "tenant-a"}],
+                    "Value": 100,
+                    "Unit": "Count",
+                },
+                {
+                    "MetricName": "StorageBytes",
+                    "Dimensions": [{"Name": "TenantId", "Value": "tenant-a"}],
+                    "Value": 5000,
+                    "Unit": "Bytes",
+                },
+            ],
+        )
+        cloudwatch.put_metric_data(
+            Namespace=usage_namespace,
+            MetricData=[
+                {
+                    "MetricName": "ApiCalls",
+                    "Dimensions": [{"Name": "TenantId", "Value": "tenant-b"}],
+                    "Value": 50,
+                    "Unit": "Count",
+                },
+            ],
+        )
+
+        resp = cloudwatch.get_metric_statistics(
+            Namespace=usage_namespace,
+            MetricName="ApiCalls",
+            Dimensions=[{"Name": "TenantId", "Value": "tenant-a"}],
+            StartTime="2026-01-01T00:00:00Z",
+            EndTime="2027-01-01T00:00:00Z",
+            Period=86400,
+            Statistics=["Sum"],
+        )
+        assert len(resp["Datapoints"]) >= 1
+        total = sum(dp["Sum"] for dp in resp["Datapoints"])
+        assert total == 100
+
+    def test_aggregate_platform_metrics(self, cloudwatch, usage_namespace):
+        """Publish platform-wide metric (no tenant dimension), query it back."""
+        cloudwatch.put_metric_data(
+            Namespace=usage_namespace,
+            MetricData=[
+                {
+                    "MetricName": "TotalTenants",
+                    "Value": 2,
+                    "Unit": "Count",
+                },
+            ],
+        )
+
+        resp = cloudwatch.get_metric_statistics(
+            Namespace=usage_namespace,
+            MetricName="TotalTenants",
+            Dimensions=[],
+            StartTime="2026-01-01T00:00:00Z",
+            EndTime="2027-01-01T00:00:00Z",
+            Period=86400,
+            Statistics=["Sum"],
+        )
+        assert len(resp["Datapoints"]) >= 1
+        total = sum(dp["Sum"] for dp in resp["Datapoints"])
+        assert total == 2
+
+    def test_tenant_alarm(self, cloudwatch, usage_namespace):
+        """Create a per-tenant alarm, force it to ALARM state, verify."""
+        alarm_name = f"{usage_namespace}-tenant-a-high-api"
+        cloudwatch.put_metric_alarm(
+            AlarmName=alarm_name,
+            Namespace=usage_namespace,
+            MetricName="ApiCalls",
+            Dimensions=[{"Name": "TenantId", "Value": "tenant-a"}],
+            Statistic="Sum",
+            Period=300,
+            EvaluationPeriods=1,
+            Threshold=1000,
+            ComparisonOperator="GreaterThanThreshold",
+        )
+
+        cloudwatch.set_alarm_state(
+            AlarmName=alarm_name,
+            StateValue="ALARM",
+            StateReason="Testing tenant alarm",
+        )
+
+        resp = cloudwatch.describe_alarms(AlarmNames=[alarm_name])
+        alarms = resp["MetricAlarms"]
+        assert len(alarms) == 1
+        assert alarms[0]["AlarmName"] == alarm_name
+        assert alarms[0]["StateValue"] == "ALARM"
+
+        # Cleanup
+        cloudwatch.delete_alarms(AlarmNames=[alarm_name])
+
+    def test_full_tenant_onboarding(
+        self,
+        dynamodb,
+        tenant_data_table,
+        s3,
+        tenant_bucket,
+        sqs,
+        onboarding_queue,
+        ssm,
+        secretsmanager,
+        cloudwatch,
+        usage_namespace,
+        unique_name,
+    ):
+        """End-to-end: onboard a new tenant across all services, verify everything."""
+        tenant_id = "tenant-new"
+        prefix = f"/tenants/{unique_name}"
+
+        # Step 1: Create SSM config for new tenant
+        config_params = {
+            "plan_tier": "growth",
+            "max_users": "50",
+            "features_enabled": "billing,reports,api_access",
+        }
+        created_params = []
+        for key, value in config_params.items():
+            param_name = f"{prefix}/{tenant_id}/{key}"
+            ssm.put_parameter(Name=param_name, Value=value, Type="String")
+            created_params.append(param_name)
+
+        # Step 2: Create SecretsManager credentials
+        secret_name = f"{unique_name}/{tenant_id}/db-credentials"
+        db_creds = {
+            "host": f"{tenant_id}-db.internal.example.com",
+            "port": 5432,
+            "db_name": f"saas_{tenant_id.replace('-', '_')}",
+            "username": f"{tenant_id}_app",
+            "password": "initial-password",
+        }
+        secretsmanager.create_secret(Name=secret_name, SecretString=json.dumps(db_creds))
+
+        # Step 3: Create S3 prefix by uploading welcome doc
+        welcome_key = f"{tenant_id}/docs/welcome.txt"
+        s3.put_object(
+            Bucket=tenant_bucket,
+            Key=welcome_key,
+            Body=b"Welcome to the platform!",
+        )
+
+        # Step 4: Send onboarding tasks to SQS
+        task_types = ["create_db", "seed_data", "configure_dns"]
+        for task_type in task_types:
+            sqs.send_message(
+                QueueUrl=onboarding_queue,
+                MessageBody=json.dumps({"task_type": task_type, "tenant_id": tenant_id}),
+            )
+
+        # Step 5: "Process" onboarding tasks (receive and delete)
+        processed = []
+        for _ in range(5):
+            resp = sqs.receive_message(
+                QueueUrl=onboarding_queue, MaxNumberOfMessages=10, WaitTimeSeconds=1
+            )
+            for msg in resp.get("Messages", []):
+                body = json.loads(msg["Body"])
+                processed.append(body["task_type"])
+                sqs.delete_message(QueueUrl=onboarding_queue, ReceiptHandle=msg["ReceiptHandle"])
+            if len(processed) >= 3:
+                break
+        assert set(processed) == set(task_types)
+
+        # Step 6: Insert tenant entity in DynamoDB
+        dynamodb.put_item(
+            TableName=tenant_data_table,
+            Item={
+                "tenant_id": {"S": tenant_id},
+                "entity_key": {"S": "USER#1"},
+                "entity_type": {"S": "USER"},
+                "created_at": {"S": "2026-03-08T00:00:00Z"},
+                "display_name": {"S": "Admin User"},
+                "role": {"S": "admin"},
+            },
+        )
+
+        # Step 7: Publish usage metric
+        cloudwatch.put_metric_data(
+            Namespace=usage_namespace,
+            MetricData=[
+                {
+                    "MetricName": "ApiCalls",
+                    "Dimensions": [{"Name": "TenantId", "Value": tenant_id}],
+                    "Value": 1,
+                    "Unit": "Count",
+                },
+            ],
+        )
+
+        # ---- Verification ----
+
+        # Verify DynamoDB
+        ddb_resp = dynamodb.query(
+            TableName=tenant_data_table,
+            KeyConditionExpression="tenant_id = :tid",
+            ExpressionAttributeValues={":tid": {"S": tenant_id}},
+        )
+        assert ddb_resp["Count"] == 1
+        assert ddb_resp["Items"][0]["display_name"]["S"] == "Admin User"
+
+        # Verify S3
+        s3_resp = s3.list_objects_v2(Bucket=tenant_bucket, Prefix=f"{tenant_id}/")
+        assert s3_resp["KeyCount"] >= 1
+        assert any(obj["Key"] == welcome_key for obj in s3_resp["Contents"])
+
+        # Verify SSM
+        ssm_resp = ssm.get_parameters_by_path(Path=f"{prefix}/{tenant_id}/", Recursive=False)
+        ssm_params = {p["Name"].split("/")[-1]: p["Value"] for p in ssm_resp["Parameters"]}
+        assert ssm_params["plan_tier"] == "growth"
+        assert ssm_params["max_users"] == "50"
+
+        # Verify SecretsManager
+        secret_resp = secretsmanager.get_secret_value(SecretId=secret_name)
+        stored_creds = json.loads(secret_resp["SecretString"])
+        assert stored_creds["host"] == f"{tenant_id}-db.internal.example.com"
+        assert stored_creds["db_name"] == "saas_tenant_new"
+
+        # Cleanup test-specific resources
+        for param_name in created_params:
+            ssm.delete_parameter(Name=param_name)
+        secretsmanager.delete_secret(SecretId=secret_name, ForceDeleteWithoutRecovery=True)


### PR DESCRIPTION
## Summary
- Three integration test suites extracted from PRs #10/#11 (which had worktree isolation leaks)
- `test_ecommerce_order_app.py`: SQS FIFO ordering, dedup, DLQ, DynamoDB GSIs, SNS fan-out
- `test_content_mgmt_app.py`: S3 versioning/restore, DynamoDB content index, EventBridge rules
- `test_multitenant_saas_app.py`: DynamoDB tenant isolation, cross-tenant query prevention

Supersedes #10 and #11.

## Test plan
- [ ] App integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)