### PR TITLE
Implement DynamoDB TTL automatic item removal

### DIFF
--- a/prompts/20260310-170000-dynamodb-ttl.md
+++ b/prompts/20260310-170000-dynamodb-ttl.md
@@ -1,0 +1,23 @@
+---
+session: "dynamodb-ttl-auto-removal"
+timestamp: "2026-03-10T17:00:00Z"
+model: claude-opus-4-6
+---
+
+## Human
+
+Implement DynamoDB TTL (Time-to-Live) automatic item removal for robotocore. Background daemon thread that scans tables for expired TTL items. Emit REMOVE stream events with userIdentity: {type: "Service", principalId: "dynamodb.amazonaws.com"}. Controlled by DYNAMODB_REMOVE_EXPIRED_ITEMS env var. Write tests first.
+
+## Assistant
+
+## Key decisions
+
+**Architecture**: Follows the same pattern as other background engines (Lambda ESM, CloudWatch alarm scheduler, Synthetics canary scheduler). A `TTLScanner` class with daemon thread, started/stopped via `_start_background_engines()` / `_shutdown()` in `app.py`.
+
+**Moto integration**: Reads TTL config from `table.ttl` dict (set by Moto's `update_time_to_live`). Iterates `table.items` directly to check item attributes. Calls `table.delete_item()` for removal to keep Moto's internal state consistent.
+
+**Stream events**: Instead of going through `notify_table_change()` (which doesn't support userIdentity), directly writes to the DynamoDBStreamsStore with the TTL-specific `userIdentity` field in the dynamodb payload, matching real AWS behavior.
+
+**Scanning strategy**: Iterates all Moto backend account/region combos, snapshots table names before iterating to handle concurrent deletions gracefully. 60-second interval is fast enough for local dev while matching the periodic nature of AWS TTL (which is "typically within 48 hours").
+
+**20 tests**: 13 unit tests covering all edge cases (expired/non-expired, missing attr, wrong type, disabled, multi-table, table deletion during scan, thread lifecycle) + 7 integration tests covering end-to-end flows including stream event verification.

--- a/src/robotocore/gateway/app.py
+++ b/src/robotocore/gateway/app.py
@@ -712,6 +712,11 @@ def _start_background_engines():
 
     get_canary_scheduler().start()
 
+    # Start DynamoDB TTL scanner
+    from robotocore.services.dynamodb.ttl import get_ttl_scanner
+
+    get_ttl_scanner().start()
+
     # Auto-load state if configured
     if os.environ.get("ROBOTOCORE_STATE_DIR"):
         from robotocore.state.manager import get_state_manager
@@ -739,6 +744,11 @@ def _shutdown():
         manager = get_state_manager()
         if manager.state_dir:
             manager.save()
+
+    # Stop DynamoDB TTL scanner
+    from robotocore.services.dynamodb.ttl import get_ttl_scanner
+
+    get_ttl_scanner().stop()
 
     # Stop SMTP server
     from robotocore.services.ses.smtp_server import stop_smtp_server

--- a/src/robotocore/services/dynamodb/ttl.py
+++ b/src/robotocore/services/dynamodb/ttl.py
@@ -1,0 +1,316 @@
+"""DynamoDB TTL (Time-to-Live) automatic item removal engine.
+
+Background daemon thread that periodically scans DynamoDB tables for expired TTL items
+and removes them, matching AWS behavior. When streams are enabled, emits REMOVE events
+with userIdentity: {type: "Service", principalId: "dynamodb.amazonaws.com"}.
+
+Controlled by:
+    DYNAMODB_REMOVE_EXPIRED_ITEMS  (default "true") -- enable/disable TTL removal
+"""
+
+import logging
+import os
+import threading
+import time
+
+logger = logging.getLogger(__name__)
+
+# Scan interval in seconds (not configurable -- fast for local dev)
+_SCAN_INTERVAL = 60
+
+# Default account/region pairs to scan
+_DEFAULT_ACCOUNT_ID = "123456789012"
+_DEFAULT_REGIONS = [
+    "us-east-1",
+    "us-east-2",
+    "us-west-1",
+    "us-west-2",
+    "eu-west-1",
+    "eu-central-1",
+    "ap-southeast-1",
+    "ap-northeast-1",
+]
+
+
+def _is_ttl_enabled() -> bool:
+    """Check if TTL removal is enabled via environment variable."""
+    return os.environ.get("DYNAMODB_REMOVE_EXPIRED_ITEMS", "true").lower() in (
+        "true",
+        "1",
+        "yes",
+    )
+
+
+def scan_and_remove_expired_items() -> int:
+    """Scan all DynamoDB tables across all accounts/regions for expired TTL items.
+
+    Returns the total number of items removed.
+    """
+    if not _is_ttl_enabled():
+        return 0
+
+    total_removed = 0
+
+    try:
+        from moto.backends import get_backend
+    except ImportError:
+        logger.debug("Moto not available, skipping TTL scan")
+        return 0
+
+    try:
+        dynamodb_backends = get_backend("dynamodb")
+    except Exception:
+        logger.debug("Could not get dynamodb backend", exc_info=True)
+        return 0
+
+    # Iterate all account/region combos that have backends
+    for account_id, regions in dynamodb_backends.items():
+        if not isinstance(regions, dict):
+            continue
+        for region, backend in regions.items():
+            try:
+                removed = _scan_backend(backend, region, account_id)
+                total_removed += removed
+            except Exception:
+                logger.debug(
+                    "Error scanning TTL for account=%s region=%s",
+                    account_id,
+                    region,
+                    exc_info=True,
+                )
+
+    if total_removed > 0:
+        logger.info("TTL scan removed %d expired items", total_removed)
+
+    return total_removed
+
+
+def _scan_backend(backend, region: str, account_id: str) -> int:
+    """Scan a single Moto DynamoDB backend for expired TTL items."""
+    removed = 0
+    now = int(time.time())
+
+    # Get a snapshot of table names to avoid mutation during iteration
+    try:
+        table_names = list(backend.tables.keys())
+    except Exception:
+        return 0
+
+    for table_name in table_names:
+        try:
+            table = backend.get_table(table_name)
+        except Exception:
+            # Table may have been deleted between listing and access
+            continue
+
+        if table is None:
+            continue
+
+        # Check if TTL is enabled on this table
+        ttl_config = table.ttl
+        if ttl_config.get("TimeToLiveStatus") != "ENABLED":
+            continue
+
+        ttl_attr = ttl_config.get("AttributeName")
+        if not ttl_attr:
+            continue
+
+        removed += _remove_expired_items(
+            backend, table, table_name, ttl_attr, now, region, account_id
+        )
+
+    return removed
+
+
+def _remove_expired_items(
+    backend,
+    table,
+    table_name: str,
+    ttl_attr: str,
+    now: int,
+    region: str,
+    account_id: str,
+) -> int:
+    """Remove expired items from a single table. Returns count of items removed."""
+    removed = 0
+
+    # Collect expired item keys first to avoid mutating dict during iteration
+    expired_keys: list[tuple] = []  # list of (hash_key, range_key_or_None)
+
+    try:
+        for hash_key, val in list(table.items.items()):
+            if isinstance(val, dict):
+                # Table has range key -- val is {range_key: Item}
+                for range_key, item in list(val.items()):
+                    if _is_item_expired(item, ttl_attr, now):
+                        expired_keys.append((hash_key, range_key))
+            else:
+                # Hash-only table -- val is the Item directly
+                if _is_item_expired(val, ttl_attr, now):
+                    expired_keys.append((hash_key, None))
+    except Exception:
+        logger.debug("Error iterating items in table %s", table_name, exc_info=True)
+        return 0
+
+    # Delete expired items
+    for hash_key, range_key in expired_keys:
+        try:
+            table.delete_item(hash_key, range_key)
+            removed += 1
+
+            # Emit stream event if streams are enabled
+            _emit_ttl_stream_event(
+                backend, table, table_name, hash_key, range_key, region, account_id
+            )
+
+            logger.debug(
+                "TTL removed item from table %s (hash=%s, range=%s)",
+                table_name,
+                hash_key,
+                range_key,
+            )
+        except Exception:
+            logger.debug("Failed to delete expired item from %s", table_name, exc_info=True)
+
+    return removed
+
+
+def _is_item_expired(item, ttl_attr: str, now: int) -> bool:
+    """Check if an item's TTL attribute indicates it has expired."""
+    if not hasattr(item, "attrs"):
+        return False
+
+    attr = item.attrs.get(ttl_attr)
+    if attr is None:
+        return False
+
+    # TTL attribute must be a Number type
+    if attr.type != "N":
+        return False
+
+    try:
+        ttl_value = int(float(str(attr.value)))
+    except (ValueError, TypeError):
+        return False
+
+    return ttl_value <= now
+
+
+def _emit_ttl_stream_event(
+    backend,
+    table,
+    table_name: str,
+    hash_key,
+    range_key,
+    region: str,
+    account_id: str,
+) -> None:
+    """Emit a REMOVE stream event for a TTL-deleted item, with Service userIdentity."""
+    if not table.latest_stream_label:
+        return  # No stream on this table
+
+    try:
+        from robotocore.services.dynamodbstreams.hooks import get_store
+
+        stream_arn = f"{table.table_arn}/stream/{table.latest_stream_label}"
+        view_type = table.stream_specification.get("StreamViewType", "NEW_AND_OLD_IMAGES")
+
+        # Build keys dict in DynamoDB format
+        keys: dict = {}
+        if hasattr(hash_key, "to_json"):
+            key_json = hash_key.to_json()
+            if table.hash_key_attr:
+                keys[table.hash_key_attr] = key_json
+        if range_key is not None and hasattr(range_key, "to_json"):
+            key_json = range_key.to_json()
+            if table.range_key_attr:
+                keys[table.range_key_attr] = key_json
+
+        store = get_store(region)
+
+        # Build the dynamodb payload with userIdentity for TTL-triggered removal
+        seq = 0
+        with store._lock:
+            if stream_arn not in store._hook_records:
+                store._hook_records[stream_arn] = []
+            records = store._hook_records[stream_arn]
+            seq = len(records) + 1
+            seq_str = str(seq).zfill(21)
+
+            from robotocore.services.dynamodbstreams.models import StreamRecord
+
+            dynamodb_payload: dict = {
+                "Keys": keys,
+                "SequenceNumber": seq_str,
+                "SizeBytes": 0,
+                "StreamViewType": view_type,
+                "userIdentity": {
+                    "type": "Service",
+                    "principalId": "dynamodb.amazonaws.com",
+                },
+            }
+
+            record = StreamRecord(
+                event_id=seq_str,
+                event_name="REMOVE",
+                dynamodb=dynamodb_payload,
+                event_source_arn=stream_arn,
+                aws_region=region,
+            )
+            records.append(record)
+
+    except Exception:
+        logger.debug("Failed to emit TTL stream event for %s", table_name, exc_info=True)
+
+
+class TTLScanner:
+    """Background daemon thread that periodically scans for expired TTL items."""
+
+    def __init__(self, interval: float = _SCAN_INTERVAL):
+        self._interval = interval
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def start(self) -> None:
+        """Start the TTL scanner daemon thread."""
+        if self._thread is not None and self._thread.is_alive():
+            return
+
+        self._stop_event.clear()
+        self._thread = threading.Thread(target=self._run, daemon=True, name="ttl-scanner")
+        self._thread.start()
+        logger.info("DynamoDB TTL scanner started (interval=%ss)", self._interval)
+
+    def stop(self) -> None:
+        """Signal the scanner thread to stop."""
+        self._stop_event.set()
+
+    def join(self, timeout: float | None = None) -> None:
+        """Wait for the scanner thread to finish."""
+        if self._thread is not None:
+            self._thread.join(timeout=timeout)
+
+    def is_alive(self) -> bool:
+        """Check if the scanner thread is running."""
+        return self._thread is not None and self._thread.is_alive()
+
+    def _run(self) -> None:
+        """Main loop: scan periodically until stopped."""
+        while not self._stop_event.is_set():
+            try:
+                scan_and_remove_expired_items()
+            except Exception:
+                logger.debug("TTL scan iteration failed", exc_info=True)
+            self._stop_event.wait(self._interval)
+
+
+# Module-level singleton
+_scanner: TTLScanner | None = None
+
+
+def get_ttl_scanner() -> TTLScanner:
+    """Get or create the global TTL scanner singleton."""
+    global _scanner
+    if _scanner is None:
+        _scanner = TTLScanner()
+    return _scanner

--- a/tests/unit/services/dynamodb/test_ttl.py
+++ b/tests/unit/services/dynamodb/test_ttl.py
@@ -1,0 +1,248 @@
+"""Unit tests for DynamoDB TTL (Time-to-Live) automatic item removal."""
+
+import os
+import time
+
+import pytest
+from moto import mock_aws
+
+from robotocore.services.dynamodb.ttl import (
+    TTLScanner,
+    scan_and_remove_expired_items,
+)
+
+
+@pytest.fixture(autouse=True)
+def _mock_aws():
+    with mock_aws():
+        yield
+
+
+@pytest.fixture()
+def _ttl_enabled():
+    """Ensure TTL removal is enabled via env var."""
+    old = os.environ.get("DYNAMODB_REMOVE_EXPIRED_ITEMS")
+    os.environ["DYNAMODB_REMOVE_EXPIRED_ITEMS"] = "true"
+    yield
+    if old is None:
+        os.environ.pop("DYNAMODB_REMOVE_EXPIRED_ITEMS", None)
+    else:
+        os.environ["DYNAMODB_REMOVE_EXPIRED_ITEMS"] = old
+
+
+@pytest.fixture()
+def _ttl_disabled():
+    """Ensure TTL removal is disabled via env var."""
+    old = os.environ.get("DYNAMODB_REMOVE_EXPIRED_ITEMS")
+    os.environ["DYNAMODB_REMOVE_EXPIRED_ITEMS"] = "false"
+    yield
+    if old is None:
+        os.environ.pop("DYNAMODB_REMOVE_EXPIRED_ITEMS", None)
+    else:
+        os.environ["DYNAMODB_REMOVE_EXPIRED_ITEMS"] = old
+
+
+def _get_backend(region: str = "us-east-1"):
+    from moto.backends import get_backend
+    from moto.core import DEFAULT_ACCOUNT_ID
+
+    return get_backend("dynamodb")[DEFAULT_ACCOUNT_ID][region]
+
+
+def _create_table(
+    region: str = "us-east-1",
+    table_name: str = "TestTable",
+    enable_ttl: bool = False,
+    ttl_attr: str = "expiry",
+):
+    backend = _get_backend(region)
+    backend.create_table(
+        table_name,
+        schema=[{"AttributeName": "pk", "KeyType": "HASH"}],
+        throughput=None,
+        attr=[{"AttributeName": "pk", "AttributeType": "S"}],
+        global_indexes=None,
+        indexes=None,
+        streams=None,
+        billing_mode="PAY_PER_REQUEST",
+        sse_specification=None,
+        tags=[],
+        deletion_protection_enabled=None,
+        warm_throughput=None,
+    )
+    if enable_ttl:
+        backend.update_time_to_live(table_name, {"Enabled": True, "AttributeName": ttl_attr})
+    return backend
+
+
+def _put_item(backend, table_name: str, item: dict):
+    backend.put_item(table_name, item)
+
+
+def _get_item(backend, table_name: str, key: dict):
+    from moto.dynamodb.models.dynamo_type import DynamoType
+
+    hash_key = DynamoType(key["pk"])
+    table = backend.get_table(table_name)
+    return table.items.get(hash_key)
+
+
+def _count_items(backend, table_name: str) -> int:
+    table = backend.get_table(table_name)
+    count = 0
+    for key, val in table.items.items():
+        if isinstance(val, dict):
+            count += len(val)
+        else:
+            count += 1
+    return count
+
+
+class TestTTLScannerIdentifiesExpiredItems:
+    """Test that TTL scanner correctly identifies and removes expired items."""
+
+    @pytest.mark.usefixtures("_ttl_enabled")
+    def test_removes_expired_items(self):
+        """Items with TTL attribute < current time should be removed."""
+        backend = _create_table(enable_ttl=True, ttl_attr="expiry")
+        past = str(int(time.time()) - 3600)
+        _put_item(backend, "TestTable", {"pk": {"S": "item1"}, "expiry": {"N": past}})
+
+        assert _count_items(backend, "TestTable") == 1
+        scan_and_remove_expired_items()
+        assert _count_items(backend, "TestTable") == 0
+
+    @pytest.mark.usefixtures("_ttl_enabled")
+    def test_keeps_non_expired_items(self):
+        """Items with TTL attribute > current time should NOT be removed."""
+        backend = _create_table(enable_ttl=True, ttl_attr="expiry")
+        future = str(int(time.time()) + 3600)
+        _put_item(backend, "TestTable", {"pk": {"S": "item1"}, "expiry": {"N": future}})
+
+        scan_and_remove_expired_items()
+        assert _count_items(backend, "TestTable") == 1
+
+    @pytest.mark.usefixtures("_ttl_enabled")
+    def test_ignores_items_without_ttl_attribute(self):
+        """Items without the TTL attribute should NOT be removed."""
+        backend = _create_table(enable_ttl=True, ttl_attr="expiry")
+        _put_item(backend, "TestTable", {"pk": {"S": "item1"}, "other": {"S": "value"}})
+
+        scan_and_remove_expired_items()
+        assert _count_items(backend, "TestTable") == 1
+
+    @pytest.mark.usefixtures("_ttl_enabled")
+    def test_ignores_items_where_ttl_not_number(self):
+        """Items where TTL attribute is not a Number type should NOT be removed."""
+        backend = _create_table(enable_ttl=True, ttl_attr="expiry")
+        _put_item(
+            backend,
+            "TestTable",
+            {"pk": {"S": "item1"}, "expiry": {"S": "not-a-number"}},
+        )
+
+        scan_and_remove_expired_items()
+        assert _count_items(backend, "TestTable") == 1
+
+    @pytest.mark.usefixtures("_ttl_enabled")
+    def test_only_processes_tables_with_ttl_enabled(self):
+        """Tables with TTL enabled should have items scanned."""
+        backend_ttl = _create_table(table_name="WithTTL", enable_ttl=True, ttl_attr="expiry")
+        past = str(int(time.time()) - 3600)
+        _put_item(backend_ttl, "WithTTL", {"pk": {"S": "item1"}, "expiry": {"N": past}})
+
+        # Also create a table without TTL
+        backend_no_ttl = _create_table(table_name="NoTTL", enable_ttl=False)
+        _put_item(backend_no_ttl, "NoTTL", {"pk": {"S": "item1"}, "expiry": {"N": past}})
+
+        scan_and_remove_expired_items()
+        assert _count_items(backend_ttl, "WithTTL") == 0
+        assert _count_items(backend_no_ttl, "NoTTL") == 1
+
+    @pytest.mark.usefixtures("_ttl_enabled")
+    def test_skips_tables_without_ttl_configuration(self):
+        """Tables that never had TTL configured should be skipped entirely."""
+        backend = _create_table(enable_ttl=False)
+        past = str(int(time.time()) - 3600)
+        _put_item(backend, "TestTable", {"pk": {"S": "item1"}, "expiry": {"N": past}})
+
+        scan_and_remove_expired_items()
+        assert _count_items(backend, "TestTable") == 1
+
+    @pytest.mark.usefixtures("_ttl_enabled")
+    def test_handles_empty_tables(self):
+        """Empty tables should be scanned without error."""
+        _create_table(enable_ttl=True, ttl_attr="expiry")
+        # Should not raise
+        scan_and_remove_expired_items()
+
+    @pytest.mark.usefixtures("_ttl_enabled")
+    def test_handles_table_deletion_during_scan(self):
+        """If a table is deleted during scan, skip gracefully."""
+        backend = _create_table(enable_ttl=True, ttl_attr="expiry")
+        past = str(int(time.time()) - 3600)
+        _put_item(backend, "TestTable", {"pk": {"S": "item1"}, "expiry": {"N": past}})
+
+        # Delete the table before scanning
+        backend.delete_table("TestTable")
+
+        # Should not raise
+        scan_and_remove_expired_items()
+
+    @pytest.mark.usefixtures("_ttl_disabled")
+    def test_disabled_via_env_var(self):
+        """When DYNAMODB_REMOVE_EXPIRED_ITEMS=false, no items should be removed."""
+        backend = _create_table(enable_ttl=True, ttl_attr="expiry")
+        past = str(int(time.time()) - 3600)
+        _put_item(backend, "TestTable", {"pk": {"S": "item1"}, "expiry": {"N": past}})
+
+        scan_and_remove_expired_items()
+        assert _count_items(backend, "TestTable") == 1
+
+    @pytest.mark.usefixtures("_ttl_enabled")
+    def test_handles_multiple_tables(self):
+        """Scanner should process all tables with TTL enabled."""
+        backend = _create_table(table_name="Table1", enable_ttl=True, ttl_attr="exp")
+        _create_table(table_name="Table2", enable_ttl=True, ttl_attr="ttl")
+        past = str(int(time.time()) - 3600)
+        _put_item(backend, "Table1", {"pk": {"S": "a"}, "exp": {"N": past}})
+        _put_item(backend, "Table2", {"pk": {"S": "b"}, "ttl": {"N": past}})
+
+        scan_and_remove_expired_items()
+        assert _count_items(backend, "Table1") == 0
+        assert _count_items(backend, "Table2") == 0
+
+    @pytest.mark.usefixtures("_ttl_enabled")
+    def test_removes_from_correct_table(self):
+        """Expired items should be removed from their own table, not others."""
+        backend = _create_table(table_name="Table1", enable_ttl=True, ttl_attr="expiry")
+        _create_table(table_name="Table2", enable_ttl=True, ttl_attr="expiry")
+        past = str(int(time.time()) - 3600)
+        future = str(int(time.time()) + 3600)
+
+        _put_item(backend, "Table1", {"pk": {"S": "expired"}, "expiry": {"N": past}})
+        _put_item(backend, "Table2", {"pk": {"S": "alive"}, "expiry": {"N": future}})
+
+        scan_and_remove_expired_items()
+        assert _count_items(backend, "Table1") == 0
+        assert _count_items(backend, "Table2") == 1
+
+
+class TestTTLScannerThread:
+    """Test TTL scanner daemon thread lifecycle."""
+
+    def test_starts_and_stops_cleanly(self):
+        scanner = TTLScanner(interval=0.1)
+        scanner.start()
+        assert scanner.is_alive()
+        scanner.stop()
+        scanner.join(timeout=2)
+        assert not scanner.is_alive()
+
+    def test_stop_is_idempotent(self):
+        scanner = TTLScanner(interval=0.1)
+        scanner.start()
+        scanner.stop()
+        scanner.join(timeout=2)
+        # Calling stop again should not raise
+        scanner.stop()

--- a/tests/unit/services/dynamodb/test_ttl_integration.py
+++ b/tests/unit/services/dynamodb/test_ttl_integration.py
@@ -1,0 +1,191 @@
+"""Integration tests for DynamoDB TTL — end-to-end scenarios with Moto backends."""
+
+import os
+import time
+
+import pytest
+from moto import mock_aws
+
+from robotocore.services.dynamodb.ttl import scan_and_remove_expired_items
+
+
+@pytest.fixture(autouse=True)
+def _mock_aws():
+    with mock_aws():
+        yield
+
+
+@pytest.fixture(autouse=True)
+def _ttl_enabled():
+    """Ensure TTL removal is enabled via env var."""
+    old = os.environ.get("DYNAMODB_REMOVE_EXPIRED_ITEMS")
+    os.environ["DYNAMODB_REMOVE_EXPIRED_ITEMS"] = "true"
+    yield
+    if old is None:
+        os.environ.pop("DYNAMODB_REMOVE_EXPIRED_ITEMS", None)
+    else:
+        os.environ["DYNAMODB_REMOVE_EXPIRED_ITEMS"] = old
+
+
+def _get_backend(region: str = "us-east-1"):
+    from moto.backends import get_backend
+    from moto.core import DEFAULT_ACCOUNT_ID
+
+    return get_backend("dynamodb")[DEFAULT_ACCOUNT_ID][region]
+
+
+def _create_table(
+    table_name: str = "TestTable",
+    enable_ttl: bool = False,
+    ttl_attr: str = "expiry",
+    enable_streams: bool = False,
+    region: str = "us-east-1",
+):
+    backend = _get_backend(region)
+    streams = None
+    if enable_streams:
+        streams = {"StreamEnabled": True, "StreamViewType": "NEW_AND_OLD_IMAGES"}
+    backend.create_table(
+        table_name,
+        schema=[{"AttributeName": "pk", "KeyType": "HASH"}],
+        throughput=None,
+        attr=[{"AttributeName": "pk", "AttributeType": "S"}],
+        global_indexes=None,
+        indexes=None,
+        streams=streams,
+        billing_mode="PAY_PER_REQUEST",
+        sse_specification=None,
+        tags=[],
+        deletion_protection_enabled=None,
+        warm_throughput=None,
+    )
+    if enable_ttl:
+        backend.update_time_to_live(table_name, {"Enabled": True, "AttributeName": ttl_attr})
+    return backend
+
+
+def _count_items(backend, table_name: str) -> int:
+    table = backend.get_table(table_name)
+    count = 0
+    for key, val in table.items.items():
+        if isinstance(val, dict):
+            count += len(val)
+        else:
+            count += 1
+    return count
+
+
+class TestEndToEndTTLRemoval:
+    """End-to-end tests: create table -> enable TTL -> put items -> scan -> verify."""
+
+    def test_expired_item_removed(self):
+        """Create table, enable TTL, put expired item, scan -> item removed."""
+        backend = _create_table(enable_ttl=True, ttl_attr="expiry")
+        past = str(int(time.time()) - 3600)
+        backend.put_item("TestTable", {"pk": {"S": "item1"}, "expiry": {"N": past}})
+
+        assert _count_items(backend, "TestTable") == 1
+        scan_and_remove_expired_items()
+        assert _count_items(backend, "TestTable") == 0
+
+    def test_future_item_kept(self):
+        """Create table, enable TTL, put future-expiry item, scan -> item still exists."""
+        backend = _create_table(enable_ttl=True, ttl_attr="expiry")
+        future = str(int(time.time()) + 3600)
+        backend.put_item("TestTable", {"pk": {"S": "item1"}, "expiry": {"N": future}})
+
+        scan_and_remove_expired_items()
+        assert _count_items(backend, "TestTable") == 1
+
+    def test_no_ttl_enabled_items_kept(self):
+        """Create table without TTL, put expired item, scan -> item still exists."""
+        backend = _create_table(enable_ttl=False)
+        past = str(int(time.time()) - 3600)
+        backend.put_item("TestTable", {"pk": {"S": "item1"}, "expiry": {"N": past}})
+
+        scan_and_remove_expired_items()
+        assert _count_items(backend, "TestTable") == 1
+
+    def test_stream_event_on_ttl_removal(self):
+        """TTL removal should emit a REMOVE stream event with Service userIdentity."""
+        from robotocore.services.dynamodbstreams.hooks import get_store
+
+        backend = _create_table(enable_ttl=True, ttl_attr="expiry", enable_streams=True)
+        past = str(int(time.time()) - 3600)
+        backend.put_item("TestTable", {"pk": {"S": "item1"}, "expiry": {"N": past}})
+
+        scan_and_remove_expired_items()
+        assert _count_items(backend, "TestTable") == 0
+
+        # Check the stream store for the REMOVE event
+        store = get_store("us-east-1")
+        all_records = []
+        for arn, records in store._hook_records.items():
+            all_records.extend(records)
+
+        # Find REMOVE events
+        remove_events = [r for r in all_records if r.event_name == "REMOVE"]
+        assert len(remove_events) >= 1
+
+        evt = remove_events[-1]
+        assert evt.event_name == "REMOVE"
+        # Check userIdentity is set for TTL-triggered removal
+        assert evt.dynamodb.get("userIdentity") == {
+            "type": "Service",
+            "principalId": "dynamodb.amazonaws.com",
+        }
+
+    def test_stream_event_user_identity(self):
+        """TTL removal stream events must have userIdentity type=Service."""
+        from robotocore.services.dynamodbstreams.hooks import get_store
+
+        backend = _create_table(
+            table_name="IdentityTable",
+            enable_ttl=True,
+            ttl_attr="ttl_field",
+            enable_streams=True,
+        )
+        past = str(int(time.time()) - 3600)
+        backend.put_item("IdentityTable", {"pk": {"S": "x"}, "ttl_field": {"N": past}})
+
+        scan_and_remove_expired_items()
+
+        store = get_store("us-east-1")
+        all_records = []
+        for arn, records in store._hook_records.items():
+            all_records.extend(records)
+
+        remove_events = [r for r in all_records if r.event_name == "REMOVE"]
+        assert len(remove_events) >= 1
+        identity = remove_events[-1].dynamodb.get("userIdentity")
+        assert identity is not None
+        assert identity["type"] == "Service"
+        assert identity["principalId"] == "dynamodb.amazonaws.com"
+
+    def test_mixed_items_only_expired_removed(self):
+        """Multiple items: some expired, some not -- only expired removed."""
+        backend = _create_table(enable_ttl=True, ttl_attr="expiry")
+        past = str(int(time.time()) - 3600)
+        future = str(int(time.time()) + 3600)
+
+        backend.put_item("TestTable", {"pk": {"S": "expired1"}, "expiry": {"N": past}})
+        backend.put_item("TestTable", {"pk": {"S": "expired2"}, "expiry": {"N": past}})
+        backend.put_item("TestTable", {"pk": {"S": "alive"}, "expiry": {"N": future}})
+        backend.put_item("TestTable", {"pk": {"S": "no_ttl"}, "other": {"S": "value"}})
+
+        assert _count_items(backend, "TestTable") == 4
+        scan_and_remove_expired_items()
+        assert _count_items(backend, "TestTable") == 2  # alive + no_ttl remain
+
+    def test_different_ttl_attribute_names_per_table(self):
+        """Each table can have a different TTL attribute name."""
+        backend = _create_table(table_name="Table1", enable_ttl=True, ttl_attr="exp_at")
+        _create_table(table_name="Table2", enable_ttl=True, ttl_attr="delete_after")
+        past = str(int(time.time()) - 3600)
+
+        backend.put_item("Table1", {"pk": {"S": "item1"}, "exp_at": {"N": past}})
+        backend.put_item("Table2", {"pk": {"S": "item2"}, "delete_after": {"N": past}})
+
+        scan_and_remove_expired_items()
+        assert _count_items(backend, "Table1") == 0
+        assert _count_items(backend, "Table2") == 0


### PR DESCRIPTION
## Summary
- Add background daemon thread (`TTLScanner`) that scans DynamoDB tables every 60s for expired TTL items and removes them
- Emit `REMOVE` stream events with `userIdentity: {type: "Service", principalId: "dynamodb.amazonaws.com"}` matching AWS behavior
- Controlled by `DYNAMODB_REMOVE_EXPIRED_ITEMS` env var (default `true`)
- Wired into server startup/shutdown in `app.py` alongside other background engines

## Test plan
- [x] 13 unit tests covering: expired/non-expired items, missing TTL attr, wrong type, disabled env var, multi-table, table deletion during scan, thread lifecycle
- [x] 7 integration tests covering: end-to-end TTL removal, stream event emission with correct userIdentity, mixed items, different TTL attribute names per table
- [x] All 20 tests passing
- [x] Lint clean (ruff check + format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)