### PR TITLE
Add StepFunctions mock configuration support (SFN_MOCK_CONFIG)

### DIFF
--- a/prompts/20260310-1200-sfn-mock-config.md
+++ b/prompts/20260310-1200-sfn-mock-config.md
@@ -1,0 +1,28 @@
+---
+role: assistant
+timestamp: 2026-03-10T12:00:00Z
+session: sfn-mock-config
+sequence: 1
+---
+
+# StepFunctions Mock Configuration Support
+
+## Task
+Implement SFN_MOCK_CONFIG support for robotocore, matching LocalStack's mock configuration format for deterministic Step Functions testing.
+
+## Approach
+1. Created `mock_config.py` module for loading, parsing, validating, and hot-reloading JSON mock configs
+2. Extended ASLExecutor with `mock_test_case` parameter that intercepts Task state execution
+3. Integrated into provider.py: StartExecution and StartSyncExecution resolve mock test cases from execution name `#suffix` or `X-SFN-Mock-Config` header
+4. Mock test case propagates to child executors (Parallel/Map branches)
+
+## Key Design Decisions
+- **Mock only Task states**: Pass/Wait/Choice/Succeed/Fail execute normally since they don't call external services
+- **mtime-based hot reload**: Re-read config file when mtime changes, no filesystem watchers needed
+- **Test case selection priority**: Header > name suffix > no mock
+- **Clean execution name**: `#TestCase` suffix is stripped from the stored execution name/ARN
+
+## Test Coverage
+- 19 unit tests for mock_config.py (loading, parsing, lookup, hot-reload)
+- 12 semantic tests for mock execution (Return, Throw, Parallel, history, output)
+- All 48 stepfunctions unit tests pass (including 17 pre-existing)

--- a/src/robotocore/services/stepfunctions/asl.py
+++ b/src/robotocore/services/stepfunctions/asl.py
@@ -81,6 +81,7 @@ class ASLExecutor:
         region: str = "us-east-1",
         account_id: str = "123456789012",
         execution_arn: str = "",
+        mock_test_case: dict | None = None,
     ):
         self.definition = definition
         self.region = region
@@ -89,6 +90,8 @@ class ASLExecutor:
         self.start_at = definition.get("StartAt", "")
         self.max_steps = 1000  # Safety limit
         self.history = ExecutionHistory(execution_arn) if execution_arn else None
+        self.mock_test_case = mock_test_case
+        self._current_state_name: str = ""  # Set during state execution for mock lookup
 
     def execute(self, input_data: dict | None = None) -> dict:
         """Execute the state machine and return the output."""
@@ -123,6 +126,7 @@ class ASLExecutor:
                     current_state, state_type, json.dumps(data), last_event_id
                 )
 
+            self._current_state_name = current_state
             try:
                 data, next_state = self._execute_state(current_state, state_def, data)
             except ASLExecutionError as e:
@@ -216,7 +220,11 @@ class ASLExecutor:
         return input_data
 
     def _execute_task(self, state_def: dict, input_data: Any) -> Any:
-        """Execute a Task state — invoke an AWS service."""
+        """Execute a Task state — invoke an AWS service.
+
+        If a mock_test_case is set and contains a mock for the current state name,
+        the mock result is used instead of dispatching to the real service.
+        """
         resource = state_def.get("Resource", "")
 
         # Check for callback pattern (.waitForTaskCallback)
@@ -230,6 +238,22 @@ class ASLExecutor:
                 resource, json.dumps(input_data) if not isinstance(input_data, str) else input_data
             )
             self.history.task_started(resource)
+
+        # Check mock config for this state (state name is resolved from caller context)
+        mock_result = self._resolve_mock_for_current_state(state_def)
+        if mock_result is not None:
+            if mock_result.is_throw:
+                error = mock_result.throw_error or "MockError"
+                cause = mock_result.throw_cause or ""
+                if self.history:
+                    self.history.task_failed(resource, error, cause)
+                raise ASLExecutionError(error, cause)
+            result = mock_result.return_value
+            if self.history:
+                self.history.task_succeeded(
+                    resource, json.dumps(result) if not isinstance(result, str) else result
+                )
+            return result
 
         if is_callback:
             return self._execute_callback_task(resource, input_data, state_def)
@@ -249,6 +273,19 @@ class ASLExecutor:
             )
 
         return result
+
+    def _resolve_mock_for_current_state(self, state_def: dict) -> Any:
+        """Check if the current state has a mock definition.
+
+        Returns a MockStateResult if a mock is defined, or None if the state
+        should execute normally.
+        """
+        if self.mock_test_case is None:
+            return None
+
+        from robotocore.services.stepfunctions.mock_config import resolve_mock_state
+
+        return resolve_mock_state(self.mock_test_case, self._current_state_name)
 
     def _dispatch_task(self, resource: str, input_data: Any) -> Any:
         """Route task to the appropriate service integration."""
@@ -355,7 +392,9 @@ class ASLExecutor:
         branches = state_def.get("Branches", [])
         results = []
         for branch in branches:
-            executor = ASLExecutor(branch, self.region, self.account_id)
+            executor = ASLExecutor(
+                branch, self.region, self.account_id, mock_test_case=self.mock_test_case
+            )
             result = executor.execute(copy.deepcopy(input_data))
             results.append(result)
         return results
@@ -376,7 +415,9 @@ class ASLExecutor:
         results = []
         for idx, item in enumerate(items):
             exec_input = item
-            executor = ASLExecutor(iterator, self.region, self.account_id)
+            executor = ASLExecutor(
+                iterator, self.region, self.account_id, mock_test_case=self.mock_test_case
+            )
             result = executor.execute(exec_input)
             results.append(result)
         return results

--- a/src/robotocore/services/stepfunctions/mock_config.py
+++ b/src/robotocore/services/stepfunctions/mock_config.py
@@ -1,0 +1,214 @@
+"""StepFunctions mock configuration support.
+
+Loads a JSON mock config file (specified by the SFN_MOCK_CONFIG env var) that provides
+deterministic, pre-defined execution results for testing. Compatible with LocalStack's
+mock config format.
+
+Config format:
+{
+  "StateMachines": {
+    "MyStateMachine": {
+      "TestCases": {
+        "HappyPath": {
+          "StateA": {"Return": {"result": "success"}},
+          "StateB": {"Return": {"count": 42}}
+        },
+        "ErrorPath": {
+          "StateA": {"Return": {"result": "success"}},
+          "StateB": {"Throw": {"Error": "CustomError", "Cause": "Something failed"}}
+        }
+      }
+    }
+  }
+}
+
+Test case selection: pass '#TestCaseName' suffix in execution name or via X-SFN-Mock-Config header.
+"""
+
+import json
+import logging
+import os
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Module-level cached config
+_mock_config: dict | None = None
+_config_path: str | None = None
+_config_mtime: float = 0.0
+
+
+class MockStateResult:
+    """Result of a mock state lookup — either a Return value or a Throw error."""
+
+    def __init__(
+        self,
+        *,
+        return_value: Any = None,
+        throw_error: str | None = None,
+        throw_cause: str | None = None,
+        is_return: bool = True,
+    ):
+        self.return_value = return_value
+        self.throw_error = throw_error
+        self.throw_cause = throw_cause
+        self.is_return = is_return
+
+    @property
+    def is_throw(self) -> bool:
+        return not self.is_return
+
+
+def load_mock_config(path: str | None = None) -> dict | None:
+    """Load and return mock config from a JSON file.
+
+    Args:
+        path: Path to the JSON config file. If None, reads from SFN_MOCK_CONFIG env var.
+
+    Returns:
+        Parsed config dict, or None if no config file is specified/found.
+
+    Raises:
+        ValueError: If the file contains invalid JSON (with a helpful message).
+    """
+    if path is None:
+        path = os.environ.get("SFN_MOCK_CONFIG")
+
+    if not path:
+        return None
+
+    if not os.path.exists(path):
+        logger.warning("SFN_MOCK_CONFIG file not found: %s", path)
+        return None
+
+    try:
+        with open(path) as f:
+            config = json.load(f)
+    except json.JSONDecodeError as e:
+        raise ValueError(f"Invalid JSON in SFN_MOCK_CONFIG file '{path}': {e}") from e
+
+    _validate_config(config)
+    return config
+
+
+def _validate_config(config: dict) -> None:
+    """Basic structural validation of the mock config."""
+    if not isinstance(config, dict):
+        raise ValueError("Mock config must be a JSON object")
+    if "StateMachines" not in config:
+        raise ValueError("Mock config must contain a 'StateMachines' key")
+    sms = config["StateMachines"]
+    if not isinstance(sms, dict):
+        raise ValueError("'StateMachines' must be a JSON object")
+
+
+def get_mock_config() -> dict | None:
+    """Get the current mock config, reloading if the file has changed.
+
+    Uses mtime-based hot-reload: checks the file modification time on each call
+    and reloads if it has changed since the last read.
+    """
+    global _mock_config, _config_path, _config_mtime
+
+    path = os.environ.get("SFN_MOCK_CONFIG")
+    if not path:
+        _mock_config = None
+        _config_path = None
+        return None
+
+    # Check if file has changed
+    try:
+        current_mtime = os.path.getmtime(path)
+    except OSError:
+        logger.warning("SFN_MOCK_CONFIG file not accessible: %s", path)
+        return _mock_config  # Return cached if file temporarily unavailable
+
+    if path != _config_path or current_mtime != _config_mtime:
+        try:
+            _mock_config = load_mock_config(path)
+            _config_path = path
+            _config_mtime = current_mtime
+            logger.info("Loaded SFN mock config from %s", path)
+        except (ValueError, OSError) as e:
+            logger.error("Failed to reload SFN mock config: %s", e)
+            # Keep using the old config if reload fails
+
+    return _mock_config
+
+
+def reset_mock_config() -> None:
+    """Reset the cached mock config. Useful for testing."""
+    global _mock_config, _config_path, _config_mtime
+    _mock_config = None
+    _config_path = None
+    _config_mtime = 0.0
+
+
+def get_state_machine_names(config: dict) -> list[str]:
+    """Extract state machine names from the config."""
+    return list(config.get("StateMachines", {}).keys())
+
+
+def get_test_case_names(config: dict, state_machine_name: str) -> list[str]:
+    """Extract test case names for a given state machine."""
+    sm = config.get("StateMachines", {}).get(state_machine_name, {})
+    return list(sm.get("TestCases", {}).keys())
+
+
+def get_test_case(config: dict, state_machine_name: str, test_case_name: str) -> dict | None:
+    """Look up a test case by state machine name and test case name.
+
+    Returns:
+        Dict mapping state names to their mock definitions, or None if not found.
+    """
+    sm = config.get("StateMachines", {}).get(state_machine_name)
+    if sm is None:
+        return None
+    return sm.get("TestCases", {}).get(test_case_name)
+
+
+def resolve_mock_state(test_case: dict, state_name: str) -> MockStateResult | None:
+    """Resolve mock config for a specific state within a test case.
+
+    Args:
+        test_case: The test case dict (state_name -> mock definition).
+        state_name: The name of the state to look up.
+
+    Returns:
+        MockStateResult with Return or Throw data, or None if the state
+        is not in the mock config (should execute normally).
+    """
+    state_mock = test_case.get(state_name)
+    if state_mock is None:
+        return None
+
+    if "Return" in state_mock:
+        return MockStateResult(return_value=state_mock["Return"], is_return=True)
+    elif "Throw" in state_mock:
+        throw = state_mock["Throw"]
+        return MockStateResult(
+            throw_error=throw.get("Error", "MockError"),
+            throw_cause=throw.get("Cause", ""),
+            is_return=False,
+        )
+
+    return None
+
+
+def extract_test_case_from_name(execution_name: str) -> tuple[str, str | None]:
+    """Extract test case name from execution name.
+
+    If the execution name contains '#', everything after the last '#' is the
+    test case name.
+
+    Args:
+        execution_name: The execution name, possibly with '#TestCase' suffix.
+
+    Returns:
+        Tuple of (clean_name, test_case_name). test_case_name is None if no
+        '#' suffix was present.
+    """
+    if "#" in execution_name:
+        parts = execution_name.rsplit("#", 1)
+        return parts[0], parts[1]
+    return execution_name, None

--- a/src/robotocore/services/stepfunctions/provider.py
+++ b/src/robotocore/services/stepfunctions/provider.py
@@ -21,6 +21,11 @@ from robotocore.services.stepfunctions.asl import (
     send_task_heartbeat,
     send_task_success,
 )
+from robotocore.services.stepfunctions.mock_config import (
+    extract_test_case_from_name,
+    get_mock_config,
+    get_test_case,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -34,6 +39,30 @@ _abort_events: dict[str, threading.Event] = {}  # exec_arn -> abort signal
 _exec_lock = threading.Lock()
 
 
+def _resolve_mock_test_case(
+    sm_name: str, execution_name: str, header_test_case: str | None = None
+) -> dict | None:
+    """Resolve the mock test case for an execution.
+
+    Test case selection priority:
+    1. X-SFN-Mock-Config header value
+    2. '#TestCase' suffix in execution name
+    3. None (no mock)
+    """
+    config = get_mock_config()
+    if config is None:
+        return None
+
+    test_case_name = header_test_case
+    if test_case_name is None:
+        _, test_case_name = extract_test_case_from_name(execution_name)
+
+    if test_case_name is None:
+        return None
+
+    return get_test_case(config, sm_name, test_case_name)
+
+
 async def handle_stepfunctions_request(request: Request, region: str, account_id: str) -> Response:
     """Handle Step Functions API request (JSON protocol via X-Amz-Target)."""
     body = await request.body()
@@ -43,6 +72,11 @@ async def handle_stepfunctions_request(request: Request, region: str, account_id
     operation = target.split(".")[-1] if "." in target else target
 
     params = json.loads(body) if body else {}
+
+    # Pass mock config header for StartExecution / StartSyncExecution
+    mock_header = request.headers.get("x-sfn-mock-config")
+    if mock_header and operation in ("StartExecution", "StartSyncExecution"):
+        params["_mockTestCase"] = mock_header
 
     handler = _ACTION_MAP.get(operation)
     if handler is None:
@@ -169,13 +203,19 @@ def _start_execution(params: dict, region: str, account_id: str) -> dict:
     sm_arn = params.get("stateMachineArn", "")
     name = params.get("name", str(uuid.uuid4()))
     input_str = params.get("input", "{}")
+    mock_header = params.pop("_mockTestCase", None)
 
     with _exec_lock:
         sm = _state_machines.get(sm_arn)
     if not sm:
         raise SfnError("StateMachineDoesNotExist", f"State machine not found: {sm_arn}")
 
-    exec_arn = f"{sm_arn.replace(':stateMachine:', ':execution:')}:{name}"
+    # Strip test case suffix from execution name for the ARN
+    clean_name, _ = extract_test_case_from_name(name)
+    exec_arn = f"{sm_arn.replace(':stateMachine:', ':execution:')}:{clean_name}"
+
+    # Resolve mock test case
+    mock_test_case = _resolve_mock_test_case(sm["name"], name, mock_header)
 
     input_data = json.loads(input_str) if isinstance(input_str, str) else input_str
     start_time = time.time()
@@ -184,7 +224,7 @@ def _start_execution(params: dict, region: str, account_id: str) -> dict:
     exec_info = {
         "executionArn": exec_arn,
         "stateMachineArn": sm_arn,
-        "name": name,
+        "name": clean_name,
         "status": "RUNNING",
         "startDate": start_time,
         "stopDate": None,
@@ -205,7 +245,7 @@ def _start_execution(params: dict, region: str, account_id: str) -> dict:
     definition = sm["definition"]
     thread = threading.Thread(
         target=_run_execution_background,
-        args=(exec_arn, definition, input_data, region, account_id, abort_event),
+        args=(exec_arn, definition, input_data, region, account_id, abort_event, mock_test_case),
         daemon=True,
         name=f"sfn-exec-{name}",
     )
@@ -228,9 +268,12 @@ def _run_execution_background(
     region: str,
     account_id: str,
     abort_event: threading.Event,
+    mock_test_case: dict | None = None,
 ) -> None:
     """Execute a state machine in a background thread, updating status on completion."""
-    executor = ASLExecutor(definition, region, account_id, execution_arn=exec_arn)
+    executor = ASLExecutor(
+        definition, region, account_id, execution_arn=exec_arn, mock_test_case=mock_test_case
+    )
 
     try:
         output = executor.execute(input_data)
@@ -276,6 +319,7 @@ def _start_sync_execution(params: dict, region: str, account_id: str) -> dict:
     sm_arn = params.get("stateMachineArn", "")
     name = params.get("name", str(uuid.uuid4()))
     input_str = params.get("input", "{}")
+    mock_header = params.pop("_mockTestCase", None)
 
     with _exec_lock:
         sm = _state_machines.get(sm_arn)
@@ -288,10 +332,18 @@ def _start_sync_execution(params: dict, region: str, account_id: str) -> dict:
             "StartSyncExecution is only supported for EXPRESS state machines",
         )
 
-    exec_arn = f"{sm_arn.replace(':stateMachine:', ':express:')}:{name}"
+    clean_name, _ = extract_test_case_from_name(name)
+    exec_arn = f"{sm_arn.replace(':stateMachine:', ':express:')}:{clean_name}"
     input_data = json.loads(input_str) if isinstance(input_str, str) else input_str
 
-    executor = ASLExecutor(sm["definition"], region, account_id, execution_arn=exec_arn)
+    mock_test_case = _resolve_mock_test_case(sm["name"], name, mock_header)
+    executor = ASLExecutor(
+        sm["definition"],
+        region,
+        account_id,
+        execution_arn=exec_arn,
+        mock_test_case=mock_test_case,
+    )
     start_time = time.time()
 
     try:

--- a/tests/unit/services/stepfunctions/test_mock_config.py
+++ b/tests/unit/services/stepfunctions/test_mock_config.py
@@ -1,0 +1,203 @@
+"""Unit tests for StepFunctions mock configuration loading and parsing."""
+
+import json
+import os
+import time
+
+import pytest
+
+from robotocore.services.stepfunctions.mock_config import (
+    extract_test_case_from_name,
+    get_mock_config,
+    get_state_machine_names,
+    get_test_case,
+    get_test_case_names,
+    load_mock_config,
+    reset_mock_config,
+    resolve_mock_state,
+)
+
+VALID_CONFIG = {
+    "StateMachines": {
+        "MyStateMachine": {
+            "TestCases": {
+                "HappyPath": {
+                    "StateA": {"Return": {"result": "success"}},
+                    "StateB": {"Return": {"count": 42}},
+                },
+                "ErrorPath": {
+                    "StateA": {"Return": {"result": "success"}},
+                    "StateB": {
+                        "Throw": {
+                            "Error": "CustomError",
+                            "Cause": "Something failed",
+                        }
+                    },
+                },
+            }
+        },
+        "OtherMachine": {
+            "TestCases": {
+                "Simple": {
+                    "OnlyState": {"Return": {"ok": True}},
+                }
+            }
+        },
+    }
+}
+
+
+@pytest.fixture
+def config_file(tmp_path):
+    """Create a temp config file and return its path."""
+    path = tmp_path / "sfn_mock.json"
+    path.write_text(json.dumps(VALID_CONFIG))
+    return str(path)
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    """Ensure SFN_MOCK_CONFIG is not set and cached config is reset."""
+    monkeypatch.delenv("SFN_MOCK_CONFIG", raising=False)
+    reset_mock_config()
+    yield
+    reset_mock_config()
+
+
+class TestLoadMockConfig:
+    def test_load_valid_config(self, config_file):
+        config = load_mock_config(config_file)
+        assert config is not None
+        assert "StateMachines" in config
+        assert "MyStateMachine" in config["StateMachines"]
+
+    def test_load_invalid_json(self, tmp_path):
+        path = tmp_path / "bad.json"
+        path.write_text("{not valid json}")
+        with pytest.raises(ValueError, match="Invalid JSON"):
+            load_mock_config(str(path))
+
+    def test_load_nonexistent_file(self):
+        result = load_mock_config("/nonexistent/path/to/config.json")
+        assert result is None
+
+    def test_load_from_env_var(self, config_file, monkeypatch):
+        monkeypatch.setenv("SFN_MOCK_CONFIG", config_file)
+        config = load_mock_config()
+        assert config is not None
+        assert "StateMachines" in config
+
+    def test_load_no_path_no_env(self):
+        config = load_mock_config()
+        assert config is None
+
+
+class TestConfigParsing:
+    def test_get_state_machine_names(self):
+        names = get_state_machine_names(VALID_CONFIG)
+        assert sorted(names) == ["MyStateMachine", "OtherMachine"]
+
+    def test_get_test_case_names(self):
+        names = get_test_case_names(VALID_CONFIG, "MyStateMachine")
+        assert sorted(names) == ["ErrorPath", "HappyPath"]
+
+    def test_get_test_case_names_missing_machine(self):
+        names = get_test_case_names(VALID_CONFIG, "NonexistentMachine")
+        assert names == []
+
+    def test_get_state_return_values(self):
+        test_case = get_test_case(VALID_CONFIG, "MyStateMachine", "HappyPath")
+        assert test_case is not None
+        assert test_case["StateA"] == {"Return": {"result": "success"}}
+        assert test_case["StateB"] == {"Return": {"count": 42}}
+
+    def test_get_state_throw_values(self):
+        test_case = get_test_case(VALID_CONFIG, "MyStateMachine", "ErrorPath")
+        assert test_case is not None
+        assert test_case["StateB"]["Throw"]["Error"] == "CustomError"
+        assert test_case["StateB"]["Throw"]["Cause"] == "Something failed"
+
+
+class TestTestCaseLookup:
+    def test_lookup_by_name(self):
+        test_case = get_test_case(VALID_CONFIG, "MyStateMachine", "HappyPath")
+        assert test_case is not None
+        assert "StateA" in test_case
+
+    def test_lookup_missing_state_machine(self):
+        result = get_test_case(VALID_CONFIG, "NonexistentMachine", "HappyPath")
+        assert result is None
+
+    def test_lookup_missing_test_case(self):
+        result = get_test_case(VALID_CONFIG, "MyStateMachine", "NonexistentCase")
+        assert result is None
+
+
+class TestMockStateResolution:
+    def test_return_value(self):
+        test_case = get_test_case(VALID_CONFIG, "MyStateMachine", "HappyPath")
+        result = resolve_mock_state(test_case, "StateA")
+        assert result is not None
+        assert result.is_return
+        assert not result.is_throw
+        assert result.return_value == {"result": "success"}
+
+    def test_throw_error(self):
+        test_case = get_test_case(VALID_CONFIG, "MyStateMachine", "ErrorPath")
+        result = resolve_mock_state(test_case, "StateB")
+        assert result is not None
+        assert result.is_throw
+        assert not result.is_return
+        assert result.throw_error == "CustomError"
+        assert result.throw_cause == "Something failed"
+
+    def test_state_not_in_mock(self):
+        test_case = get_test_case(VALID_CONFIG, "MyStateMachine", "HappyPath")
+        result = resolve_mock_state(test_case, "UnknownState")
+        assert result is None
+
+
+class TestHotReload:
+    def test_file_change_detected(self, tmp_path, monkeypatch):
+        path = tmp_path / "sfn_mock.json"
+        initial_config = {
+            "StateMachines": {"Machine1": {"TestCases": {"T1": {"S1": {"Return": {"v": 1}}}}}}
+        }
+        path.write_text(json.dumps(initial_config))
+        monkeypatch.setenv("SFN_MOCK_CONFIG", str(path))
+
+        config1 = get_mock_config()
+        assert config1 is not None
+        assert "Machine1" in config1["StateMachines"]
+
+        # Ensure mtime changes (some filesystems have 1s granularity)
+        time.sleep(0.05)
+        updated_config = {
+            "StateMachines": {"Machine2": {"TestCases": {"T2": {"S2": {"Return": {"v": 2}}}}}}
+        }
+        path.write_text(json.dumps(updated_config))
+        # Force mtime change
+        future = time.time() + 10
+        os.utime(str(path), (future, future))
+
+        config2 = get_mock_config()
+        assert config2 is not None
+        assert "Machine2" in config2["StateMachines"]
+        assert "Machine1" not in config2["StateMachines"]
+
+
+class TestExtractTestCaseFromName:
+    def test_name_with_hash(self):
+        clean, tc = extract_test_case_from_name("my-exec#HappyPath")
+        assert clean == "my-exec"
+        assert tc == "HappyPath"
+
+    def test_name_without_hash(self):
+        clean, tc = extract_test_case_from_name("my-exec")
+        assert clean == "my-exec"
+        assert tc is None
+
+    def test_name_with_multiple_hashes(self):
+        clean, tc = extract_test_case_from_name("a#b#c")
+        assert clean == "a#b"
+        assert tc == "c"

--- a/tests/unit/services/stepfunctions/test_mock_execution.py
+++ b/tests/unit/services/stepfunctions/test_mock_execution.py
@@ -1,0 +1,285 @@
+"""Semantic tests for StepFunctions mock execution.
+
+Tests that the ASL executor correctly uses mock config to intercept Task states,
+returning pre-defined results or throwing pre-defined errors.
+"""
+
+import pytest
+
+from robotocore.services.stepfunctions.asl import ASLExecutionError, ASLExecutor
+
+REGION = "us-east-1"
+ACCOUNT_ID = "123456789012"
+
+
+def _make_executor(definition: dict, mock_test_case: dict | None = None) -> ASLExecutor:
+    """Create an ASLExecutor with optional mock test case."""
+    executor = ASLExecutor(definition, REGION, ACCOUNT_ID, execution_arn="arn:test")
+    if mock_test_case is not None:
+        executor.mock_test_case = mock_test_case
+    return executor
+
+
+class TestMockTaskReturn:
+    """Test that Task states return mock values when mock config is present."""
+
+    def test_simple_pass_task_succeed_with_mock(self):
+        """Pass -> Task (mocked) -> Succeed: Task returns mock value."""
+        definition = {
+            "StartAt": "PassState",
+            "States": {
+                "PassState": {
+                    "Type": "Pass",
+                    "Result": {"input": "data"},
+                    "Next": "TaskState",
+                },
+                "TaskState": {
+                    "Type": "Task",
+                    "Resource": "arn:aws:lambda:us-east-1:123456789012:function:MyFunc",
+                    "End": True,
+                },
+            },
+        }
+        mock_test_case = {
+            "TaskState": {"Return": {"result": "mocked_success"}},
+        }
+        executor = _make_executor(definition, mock_test_case)
+        output = executor.execute({})
+        assert output == {"result": "mocked_success"}
+
+    def test_task_throws_mock_error(self):
+        """Task with Throw mock -> execution fails with the specified error."""
+        definition = {
+            "StartAt": "TaskState",
+            "States": {
+                "TaskState": {
+                    "Type": "Task",
+                    "Resource": "arn:aws:lambda:us-east-1:123456789012:function:MyFunc",
+                    "End": True,
+                },
+            },
+        }
+        mock_test_case = {
+            "TaskState": {"Throw": {"Error": "CustomError", "Cause": "Something failed"}},
+        }
+        executor = _make_executor(definition, mock_test_case)
+        with pytest.raises(ASLExecutionError) as exc_info:
+            executor.execute({})
+        assert exc_info.value.error == "CustomError"
+        assert exc_info.value.cause == "Something failed"
+
+    def test_execution_name_hash_selects_test_case(self):
+        """Execution name with '#HappyPath' suffix selects correct test case."""
+        from robotocore.services.stepfunctions.mock_config import extract_test_case_from_name
+
+        clean, tc = extract_test_case_from_name("my-execution#HappyPath")
+        assert tc == "HappyPath"
+        assert clean == "my-execution"
+
+    def test_no_matching_test_case_executes_normally(self):
+        """With no mock test case, Pass state executes normally."""
+        definition = {
+            "StartAt": "PassState",
+            "States": {
+                "PassState": {
+                    "Type": "Pass",
+                    "Result": {"normal": "execution"},
+                    "End": True,
+                },
+            },
+        }
+        executor = _make_executor(definition, mock_test_case=None)
+        output = executor.execute({})
+        assert output == {"normal": "execution"}
+
+    def test_no_mock_config_executes_normally(self):
+        """With no mock config at all, Pass state executes normally."""
+        definition = {
+            "StartAt": "PassState",
+            "States": {
+                "PassState": {
+                    "Type": "Pass",
+                    "Result": {"normal": True},
+                    "End": True,
+                },
+            },
+        }
+        executor = ASLExecutor(definition, REGION, ACCOUNT_ID)
+        output = executor.execute({})
+        assert output == {"normal": True}
+
+
+class TestMockParallelState:
+    """Test that Parallel states apply mocks to nested Task states."""
+
+    def test_parallel_branches_use_mocks(self):
+        """Parallel state with Task states in branches should use mock config."""
+        definition = {
+            "StartAt": "ParallelState",
+            "States": {
+                "ParallelState": {
+                    "Type": "Parallel",
+                    "Branches": [
+                        {
+                            "StartAt": "BranchTask1",
+                            "States": {
+                                "BranchTask1": {
+                                    "Type": "Task",
+                                    "Resource": "arn:aws:lambda:us-east-1:123456789012:function:F1",
+                                    "End": True,
+                                },
+                            },
+                        },
+                        {
+                            "StartAt": "BranchTask2",
+                            "States": {
+                                "BranchTask2": {
+                                    "Type": "Task",
+                                    "Resource": "arn:aws:lambda:us-east-1:123456789012:function:F2",
+                                    "End": True,
+                                },
+                            },
+                        },
+                    ],
+                    "End": True,
+                },
+            },
+        }
+        mock_test_case = {
+            "BranchTask1": {"Return": {"branch": 1}},
+            "BranchTask2": {"Return": {"branch": 2}},
+        }
+        executor = _make_executor(definition, mock_test_case)
+        output = executor.execute({})
+        assert output == [{"branch": 1}, {"branch": 2}]
+
+
+class TestMockExecutionHistory:
+    """Test that mock execution produces correct history events."""
+
+    def test_mock_execution_has_history_events(self):
+        """Mock execution should record history events for traversed states."""
+        definition = {
+            "StartAt": "TaskState",
+            "States": {
+                "TaskState": {
+                    "Type": "Task",
+                    "Resource": "arn:aws:lambda:us-east-1:123456789012:function:MyFunc",
+                    "End": True,
+                },
+            },
+        }
+        mock_test_case = {
+            "TaskState": {"Return": {"result": "mocked"}},
+        }
+        executor = _make_executor(definition, mock_test_case)
+        executor.execute({})
+        assert executor.history is not None
+        events = executor.history.get_events()
+        event_types = [e["type"] for e in events]
+        assert "ExecutionStarted" in event_types
+        assert "TaskStateEntered" in event_types
+        assert "ExecutionSucceeded" in event_types
+
+
+class TestMockExecutionOutput:
+    """Test execution output matches mock values."""
+
+    def test_output_matches_final_state_return(self):
+        """Execution output should match the Return value of the final state."""
+        definition = {
+            "StartAt": "First",
+            "States": {
+                "First": {
+                    "Type": "Task",
+                    "Resource": "arn:aws:lambda:us-east-1:123456789012:function:F1",
+                    "Next": "Second",
+                },
+                "Second": {
+                    "Type": "Task",
+                    "Resource": "arn:aws:lambda:us-east-1:123456789012:function:F2",
+                    "End": True,
+                },
+            },
+        }
+        mock_test_case = {
+            "First": {"Return": {"step": 1}},
+            "Second": {"Return": {"final": "output"}},
+        }
+        executor = _make_executor(definition, mock_test_case)
+        output = executor.execute({})
+        assert output == {"final": "output"}
+
+    def test_failed_output_matches_throw(self):
+        """Failed execution should have error/cause matching Throw config."""
+        definition = {
+            "StartAt": "TaskState",
+            "States": {
+                "TaskState": {
+                    "Type": "Task",
+                    "Resource": "arn:aws:lambda:us-east-1:123456789012:function:F",
+                    "End": True,
+                },
+            },
+        }
+        mock_test_case = {
+            "TaskState": {"Throw": {"Error": "TestError", "Cause": "Test cause message"}},
+        }
+        executor = _make_executor(definition, mock_test_case)
+        with pytest.raises(ASLExecutionError) as exc_info:
+            executor.execute({})
+        assert exc_info.value.error == "TestError"
+        assert exc_info.value.cause == "Test cause message"
+
+
+class TestMultipleStateMachines:
+    """Test handling configs with multiple state machines."""
+
+    def test_different_machines_different_mocks(self):
+        """Each state machine can have independent mock configs."""
+        from robotocore.services.stepfunctions.mock_config import get_test_case
+
+        config = {
+            "StateMachines": {
+                "MachineA": {
+                    "TestCases": {
+                        "Case1": {"S1": {"Return": {"from": "A"}}},
+                    }
+                },
+                "MachineB": {
+                    "TestCases": {
+                        "Case1": {"S1": {"Return": {"from": "B"}}},
+                    }
+                },
+            }
+        }
+        tc_a = get_test_case(config, "MachineA", "Case1")
+        tc_b = get_test_case(config, "MachineB", "Case1")
+        assert tc_a is not None
+        assert tc_b is not None
+        assert tc_a["S1"]["Return"]["from"] == "A"
+        assert tc_b["S1"]["Return"]["from"] == "B"
+
+    def test_state_not_mocked_in_task_executes_normally(self):
+        """A state not in the mock test case should try to execute normally.
+
+        For non-Task states like Pass, this works fine. For Task states
+        with no real backend, it would normally fail, but Pass is safe.
+        """
+        definition = {
+            "StartAt": "PassState",
+            "States": {
+                "PassState": {
+                    "Type": "Pass",
+                    "Result": {"pass": "through"},
+                    "End": True,
+                },
+            },
+        }
+        mock_test_case = {
+            "SomeOtherState": {"Return": {"not": "relevant"}},
+        }
+        executor = _make_executor(definition, mock_test_case)
+        output = executor.execute({})
+        # Pass state is not a Task — mock doesn't apply; it runs normally
+        assert output == {"pass": "through"}


### PR DESCRIPTION
## Summary
- Add `SFN_MOCK_CONFIG` env var support for deterministic StepFunctions testing, matching LocalStack's mock config format
- JSON config maps state machine names to test cases, each defining Return/Throw results per state
- Test case selection via `#TestCase` suffix in execution name or `X-SFN-Mock-Config` header
- mtime-based hot-reload: config file changes are picked up on next execution start

## Files Changed
- **New**: `src/robotocore/services/stepfunctions/mock_config.py` -- config loading, parsing, validation, hot-reload
- **Modified**: `src/robotocore/services/stepfunctions/asl.py` -- ASLExecutor accepts `mock_test_case`, intercepts Task states
- **Modified**: `src/robotocore/services/stepfunctions/provider.py` -- resolves mock test case from name/header, passes to executor
- **New**: `tests/unit/services/stepfunctions/test_mock_config.py` -- 19 unit tests for config module
- **New**: `tests/unit/services/stepfunctions/test_mock_execution.py` -- 12 semantic tests for mock execution

## Test plan
- [x] 19 unit tests for mock config loading, parsing, lookup, hot-reload
- [x] 12 semantic tests for mock execution (Return, Throw, Parallel, history)
- [x] All 48 stepfunctions unit tests pass (including 17 pre-existing)
- [ ] Manual test with a sample SFN_MOCK_CONFIG file against running server

🤖 Generated with [Claude Code](https://claude.com/claude-code)