### PR TITLE
Rebrand endpoint hostnames: robotocore.cloud default, localstack.cloud alias

### DIFF
--- a/src/robotocore/gateway/router.py
+++ b/src/robotocore/gateway/router.py
@@ -260,13 +260,18 @@ def route_to_service(request: Request) -> str | None:
     host = request.headers.get("host", "")
     if ".s3." in host or host.startswith("s3.") or host.startswith("s3-"):
         return "s3"
-    # SQS endpoint strategy host patterns
-    if ".queue.localhost.localstack.cloud" in host or (
-        host.startswith("sqs.") and ".localhost.localstack.cloud" in host
+    # SQS endpoint strategy host patterns (robotocore.cloud primary, localstack.cloud alias)
+    if (
+        ".queue.localhost.robotocore.cloud" in host
+        or (host.startswith("sqs.") and ".localhost.robotocore.cloud" in host)
+        or ".queue.localhost.localstack.cloud" in host
+        or (host.startswith("sqs.") and ".localhost.localstack.cloud" in host)
     ):
         return "sqs"
-    # OpenSearch endpoint strategy host patterns
-    if ".opensearch.localhost.localstack.cloud" in host:
+    # OpenSearch endpoint strategy host patterns (robotocore.cloud primary, localstack.cloud alias)
+    if ".opensearch.localhost.robotocore.cloud" in host or (
+        ".opensearch.localhost.localstack.cloud" in host
+    ):
         return "opensearch"
 
     # 6. Query string action parameter (used by EC2, SQS, SNS, etc.)

--- a/src/robotocore/services/opensearch/endpoint_strategy.py
+++ b/src/robotocore/services/opensearch/endpoint_strategy.py
@@ -1,7 +1,7 @@
-"""OpenSearch endpoint strategies matching LocalStack's OPENSEARCH_ENDPOINT_STRATEGY.
+"""OpenSearch endpoint strategies matching OPENSEARCH_ENDPOINT_STRATEGY.
 
 Supports 3 strategies controlled by the OPENSEARCH_ENDPOINT_STRATEGY env var:
-- domain (default): http://{domain_name}.{region}.opensearch.localhost.localstack.cloud:4566
+- domain (default): http://{domain_name}.{region}.opensearch.localhost.robotocore.cloud:4566
 - path: http://localhost:4566/opensearch/{region}/{domain_name}
 - port: Allocate a unique port per domain from range 4510-4559
 """
@@ -13,7 +13,8 @@ from enum import StrEnum
 
 GATEWAY_PORT = 4566
 GATEWAY_HOST = "localhost"
-LOCALSTACK_HOST = "localhost.localstack.cloud"
+ROBOTOCORE_HOST = "localhost.robotocore.cloud"
+LOCALSTACK_HOST_ALIAS = "localhost.localstack.cloud"
 
 # Port-strategy allocation range
 PORT_RANGE_START = 4510
@@ -86,7 +87,7 @@ def opensearch_endpoint(
     port = int(os.environ.get("GATEWAY_PORT", str(GATEWAY_PORT)))
 
     if strategy == OpenSearchEndpointStrategy.DOMAIN:
-        return f"http://{domain_name}.{region}.opensearch.{LOCALSTACK_HOST}:{port}"
+        return f"http://{domain_name}.{region}.opensearch.{ROBOTOCORE_HOST}:{port}"
     elif strategy == OpenSearchEndpointStrategy.PATH:
         return f"http://{GATEWAY_HOST}:{port}/opensearch/{region}/{domain_name}"
     elif strategy == OpenSearchEndpointStrategy.PORT:
@@ -105,10 +106,10 @@ PATH_STYLE_RE = re.compile(
     r"^/opensearch/(?P<region>[a-z0-9-]+)/(?P<domain_name>[A-Za-z0-9-]+)(?P<rest>/.*)?$"
 )
 
-# Matches Host: {domain_name}.{region}.opensearch.localhost.localstack.cloud
+# Matches Host: {domain_name}.{region}.opensearch.localhost.robotocore.cloud (or localstack.cloud)
+_HOST_ALT = r"(?:" + re.escape(ROBOTOCORE_HOST) + r"|" + re.escape(LOCALSTACK_HOST_ALIAS) + r")"
 DOMAIN_HOST_RE = re.compile(
-    r"^(?P<domain_name>[A-Za-z0-9-]+)\.(?P<region>[a-z0-9-]+)\.opensearch\."
-    + re.escape(LOCALSTACK_HOST)
+    r"^(?P<domain_name>[A-Za-z0-9-]+)\.(?P<region>[a-z0-9-]+)\.opensearch\." + _HOST_ALT
 )
 
 

--- a/src/robotocore/services/sqs/endpoint_strategy.py
+++ b/src/robotocore/services/sqs/endpoint_strategy.py
@@ -1,8 +1,8 @@
-"""SQS endpoint URL strategies matching LocalStack's SQS_ENDPOINT_STRATEGY.
+"""SQS endpoint URL strategies matching SQS_ENDPOINT_STRATEGY.
 
 Supports 4 strategies controlled by the SQS_ENDPOINT_STRATEGY env var:
-- standard (default): http://sqs.{region}.localhost.localstack.cloud:4566/{account_id}/{queue_name}
-- domain: http://{region}.queue.localhost.localstack.cloud:4566/{account_id}/{queue_name}
+- standard (default): http://sqs.{region}.localhost.robotocore.cloud:4566/{account_id}/{queue_name}
+- domain: http://{region}.queue.localhost.robotocore.cloud:4566/{account_id}/{queue_name}
 - path: http://localhost:4566/queue/{region}/{account_id}/{queue_name}
 - dynamic: Returns path-style URLs but accepts all formats for incoming requests
 """
@@ -14,7 +14,8 @@ from enum import StrEnum
 # Default gateway port
 GATEWAY_PORT = 4566
 GATEWAY_HOST = "localhost"
-LOCALSTACK_HOST = "localhost.localstack.cloud"
+ROBOTOCORE_HOST = "localhost.robotocore.cloud"
+LOCALSTACK_HOST_ALIAS = "localhost.localstack.cloud"
 
 
 class SqsEndpointStrategy(StrEnum):
@@ -46,9 +47,9 @@ def sqs_queue_url(
     port = int(os.environ.get("GATEWAY_PORT", str(GATEWAY_PORT)))
 
     if strategy == SqsEndpointStrategy.STANDARD:
-        return f"http://sqs.{region}.{LOCALSTACK_HOST}:{port}/{account_id}/{queue_name}"
+        return f"http://sqs.{region}.{ROBOTOCORE_HOST}:{port}/{account_id}/{queue_name}"
     elif strategy == SqsEndpointStrategy.DOMAIN:
-        return f"http://{region}.queue.{LOCALSTACK_HOST}:{port}/{account_id}/{queue_name}"
+        return f"http://{region}.queue.{ROBOTOCORE_HOST}:{port}/{account_id}/{queue_name}"
     elif strategy in (SqsEndpointStrategy.PATH, SqsEndpointStrategy.DYNAMIC):
         return f"http://{GATEWAY_HOST}:{port}/queue/{region}/{account_id}/{queue_name}"
     # Fallback (should not be reached)
@@ -64,11 +65,12 @@ PATH_STYLE_RE = re.compile(
     r"^/queue/(?P<region>[a-z0-9-]+)/(?P<account_id>\d+)/(?P<queue_name>[A-Za-z0-9_.-]+)$"
 )
 
-# Matches Host: sqs.{region}.localhost.localstack.cloud
-STANDARD_HOST_RE = re.compile(r"^sqs\.(?P<region>[a-z0-9-]+)\." + re.escape(LOCALSTACK_HOST))
+# Matches Host: sqs.{region}.localhost.robotocore.cloud (or localstack.cloud alias)
+_HOST_ALT = r"(?:" + re.escape(ROBOTOCORE_HOST) + r"|" + re.escape(LOCALSTACK_HOST_ALIAS) + r")"
+STANDARD_HOST_RE = re.compile(r"^sqs\.(?P<region>[a-z0-9-]+)\." + _HOST_ALT)
 
-# Matches Host: {region}.queue.localhost.localstack.cloud
-DOMAIN_HOST_RE = re.compile(r"^(?P<region>[a-z0-9-]+)\.queue\." + re.escape(LOCALSTACK_HOST))
+# Matches Host: {region}.queue.localhost.robotocore.cloud (or localstack.cloud alias)
+DOMAIN_HOST_RE = re.compile(r"^(?P<region>[a-z0-9-]+)\.queue\." + _HOST_ALT)
 
 
 def parse_sqs_url(path: str, host: str) -> dict | None:
@@ -81,7 +83,7 @@ def parse_sqs_url(path: str, host: str) -> dict | None:
     if m:
         return m.groupdict()
 
-    # 2. Standard host: sqs.{region}.localhost.localstack.cloud + /{account_id}/{queue_name}
+    # 2. Standard host: sqs.{region}.localhost.robotocore.cloud + /{account_id}/{queue_name}
     m = STANDARD_HOST_RE.match(host)
     if m:
         parts = path.strip("/").split("/")
@@ -92,7 +94,7 @@ def parse_sqs_url(path: str, host: str) -> dict | None:
                 "queue_name": parts[1],
             }
 
-    # 3. Domain host: {region}.queue.localhost.localstack.cloud + /{account_id}/{queue_name}
+    # 3. Domain host: {region}.queue.localhost.robotocore.cloud + /{account_id}/{queue_name}
     m = DOMAIN_HOST_RE.match(host)
     if m:
         parts = path.strip("/").split("/")

--- a/tests/unit/gateway/test_endpoint_routing.py
+++ b/tests/unit/gateway/test_endpoint_routing.py
@@ -31,7 +31,7 @@ class TestSqsDomainStyleRouting:
     def test_standard_host_routes_to_sqs(self):
         result = parse_sqs_url(
             "/123456789012/my-queue",
-            "sqs.us-east-1.localhost.localstack.cloud:4566",
+            "sqs.us-east-1.localhost.robotocore.cloud:4566",
         )
         assert result is not None
         assert result["region"] == "us-east-1"
@@ -40,7 +40,7 @@ class TestSqsDomainStyleRouting:
     def test_domain_host_routes_to_sqs(self):
         result = parse_sqs_url(
             "/123456789012/my-queue",
-            "us-east-1.queue.localhost.localstack.cloud:4566",
+            "us-east-1.queue.localhost.robotocore.cloud:4566",
         )
         assert result is not None
         assert result["region"] == "us-east-1"
@@ -68,7 +68,7 @@ class TestOpenSearchDomainStyleRouting:
     def test_domain_host_routes_to_opensearch(self):
         result = parse_opensearch_url(
             "/",
-            "my-domain.us-east-1.opensearch.localhost.localstack.cloud:4566",
+            "my-domain.us-east-1.opensearch.localhost.robotocore.cloud:4566",
         )
         assert result is not None
         assert result["region"] == "us-east-1"
@@ -83,9 +83,30 @@ class TestDynamicStrategyAcceptsAllFormats:
         assert result is not None
 
     def test_accepts_standard_host(self):
-        result = parse_sqs_url("/123/my-q", "sqs.us-east-1.localhost.localstack.cloud:4566")
+        result = parse_sqs_url("/123/my-q", "sqs.us-east-1.localhost.robotocore.cloud:4566")
         assert result is not None
 
     def test_accepts_domain_host(self):
+        result = parse_sqs_url("/123/my-q", "us-east-1.queue.localhost.robotocore.cloud:4566")
+        assert result is not None
+
+
+class TestLocalstackCloudAlias:
+    """localstack.cloud hostnames must be accepted as backward-compat aliases."""
+
+    def test_sqs_standard_host_localstack_alias(self):
+        result = parse_sqs_url("/123/my-q", "sqs.us-east-1.localhost.localstack.cloud:4566")
+        assert result is not None
+        assert result["region"] == "us-east-1"
+
+    def test_sqs_domain_host_localstack_alias(self):
         result = parse_sqs_url("/123/my-q", "us-east-1.queue.localhost.localstack.cloud:4566")
         assert result is not None
+        assert result["region"] == "us-east-1"
+
+    def test_opensearch_domain_host_localstack_alias(self):
+        result = parse_opensearch_url(
+            "/", "my-domain.us-east-1.opensearch.localhost.localstack.cloud:4566"
+        )
+        assert result is not None
+        assert result["domain_name"] == "my-domain"

--- a/tests/unit/services/opensearch/test_endpoint_integration.py
+++ b/tests/unit/services/opensearch/test_endpoint_integration.py
@@ -16,7 +16,7 @@ class TestCreateDomainReturnsStrategyEndpoint:
     def test_domain_strategy(self, monkeypatch):
         monkeypatch.delenv("OPENSEARCH_ENDPOINT_STRATEGY", raising=False)
         ep = opensearch_endpoint("my-domain", "us-east-1")
-        assert "my-domain.us-east-1.opensearch.localhost.localstack.cloud" in ep
+        assert "my-domain.us-east-1.opensearch.localhost.robotocore.cloud" in ep
 
     def test_path_strategy(self, monkeypatch):
         monkeypatch.setenv("OPENSEARCH_ENDPOINT_STRATEGY", "path")

--- a/tests/unit/services/opensearch/test_endpoint_strategy.py
+++ b/tests/unit/services/opensearch/test_endpoint_strategy.py
@@ -40,7 +40,7 @@ class TestDomainStrategy:
 
     def test_endpoint_format(self):
         ep = opensearch_endpoint("my-domain", "us-east-1", OpenSearchEndpointStrategy.DOMAIN)
-        assert ep == ("http://my-domain.us-east-1.opensearch.localhost.localstack.cloud:4566")
+        assert ep == ("http://my-domain.us-east-1.opensearch.localhost.robotocore.cloud:4566")
 
     def test_includes_correct_region(self):
         ep = opensearch_endpoint("d", "eu-west-1", OpenSearchEndpointStrategy.DOMAIN)
@@ -107,6 +107,16 @@ class TestParseOpenSearchUrl:
         assert result["domain_name"] == "my-domain"
 
     def test_domain_host_parsing(self):
+        result = parse_opensearch_url(
+            "/",
+            "my-domain.us-east-1.opensearch.localhost.robotocore.cloud:4566",
+        )
+        assert result is not None
+        assert result["region"] == "us-east-1"
+        assert result["domain_name"] == "my-domain"
+
+    def test_domain_host_localstack_alias(self):
+        """localstack.cloud must be accepted as a backward-compat alias."""
         result = parse_opensearch_url(
             "/",
             "my-domain.us-east-1.opensearch.localhost.localstack.cloud:4566",

--- a/tests/unit/services/sqs/test_endpoint_integration.py
+++ b/tests/unit/services/sqs/test_endpoint_integration.py
@@ -55,7 +55,7 @@ class TestGetQueueUrlReturnsStrategyUrl:
         store.create_queue("test-q", "us-east-1", "123456789012")
         queue = store.get_queue("test-q")
         assert queue is not None
-        assert "sqs.us-east-1.localhost.localstack.cloud" in queue.url
+        assert "sqs.us-east-1.localhost.robotocore.cloud" in queue.url
 
     def test_get_queue_url_path(self, monkeypatch):
         monkeypatch.setenv("SQS_ENDPOINT_STRATEGY", "path")
@@ -77,7 +77,7 @@ class TestListQueuesReturnsStrategyUrls:
         queues = store.list_queues()
         assert len(queues) == 2
         for q in queues:
-            assert "sqs.us-east-1.localhost.localstack.cloud" in q.url
+            assert "sqs.us-east-1.localhost.robotocore.cloud" in q.url
 
     def test_list_queues_path(self, monkeypatch):
         monkeypatch.setenv("SQS_ENDPOINT_STRATEGY", "path")

--- a/tests/unit/services/sqs/test_endpoint_strategy.py
+++ b/tests/unit/services/sqs/test_endpoint_strategy.py
@@ -43,7 +43,7 @@ class TestStandardStrategy:
 
     def test_url_format(self):
         url = sqs_queue_url("my-queue", "us-east-1", "123456789012", SqsEndpointStrategy.STANDARD)
-        assert url == ("http://sqs.us-east-1.localhost.localstack.cloud:4566/123456789012/my-queue")
+        assert url == ("http://sqs.us-east-1.localhost.robotocore.cloud:4566/123456789012/my-queue")
 
     def test_includes_correct_region(self):
         url = sqs_queue_url("q", "eu-west-1", "111111111111", SqsEndpointStrategy.STANDARD)
@@ -77,7 +77,7 @@ class TestDomainStrategy:
     def test_url_format(self):
         url = sqs_queue_url("my-queue", "us-east-1", "123456789012", SqsEndpointStrategy.DOMAIN)
         assert url == (
-            "http://us-east-1.queue.localhost.localstack.cloud:4566/123456789012/my-queue"
+            "http://us-east-1.queue.localhost.robotocore.cloud:4566/123456789012/my-queue"
         )
 
     def test_includes_correct_region(self):
@@ -163,7 +163,7 @@ class TestParseSqsUrl:
     def test_standard_host_parsing(self):
         result = parse_sqs_url(
             "/123456789012/my-queue",
-            "sqs.us-east-1.localhost.localstack.cloud:4566",
+            "sqs.us-east-1.localhost.robotocore.cloud:4566",
         )
         assert result is not None
         assert result["region"] == "us-east-1"
@@ -173,7 +173,7 @@ class TestParseSqsUrl:
     def test_domain_host_parsing(self):
         result = parse_sqs_url(
             "/123456789012/my-queue",
-            "us-east-1.queue.localhost.localstack.cloud:4566",
+            "us-east-1.queue.localhost.robotocore.cloud:4566",
         )
         assert result is not None
         assert result["region"] == "us-east-1"
@@ -188,3 +188,23 @@ class TestParseSqsUrl:
         result = parse_sqs_url("/queue/us-east-1/123/my-queue.fifo", "localhost:4566")
         assert result is not None
         assert result["queue_name"] == "my-queue.fifo"
+
+    def test_standard_host_localstack_alias(self):
+        """localstack.cloud must be accepted as a backward-compat alias."""
+        result = parse_sqs_url(
+            "/123456789012/my-queue",
+            "sqs.us-east-1.localhost.localstack.cloud:4566",
+        )
+        assert result is not None
+        assert result["region"] == "us-east-1"
+        assert result["queue_name"] == "my-queue"
+
+    def test_domain_host_localstack_alias(self):
+        """localstack.cloud must be accepted as a backward-compat alias."""
+        result = parse_sqs_url(
+            "/123456789012/my-queue",
+            "us-east-1.queue.localhost.localstack.cloud:4566",
+        )
+        assert result is not None
+        assert result["region"] == "us-east-1"
+        assert result["queue_name"] == "my-queue"


### PR DESCRIPTION
## Summary
- All URL generation in SQS and OpenSearch endpoint strategies now uses `localhost.robotocore.cloud` as the primary hostname
- `localhost.localstack.cloud` accepted everywhere as a backward-compat alias (regex patterns, gateway router host matching, URL parsing)
- Updated all unit tests to expect `robotocore.cloud` in default outputs and added tests verifying the `localstack.cloud` alias works

## Test plan
- [x] All 82 endpoint strategy tests pass (`tests/unit/services/sqs/`, `tests/unit/services/opensearch/`, `tests/unit/gateway/test_endpoint_routing.py`)
- [x] New alias tests verify `localstack.cloud` hostnames are still parsed correctly
- [x] Ruff lint and format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)