### PR TITLE
Add per-service state lifecycle hooks

### DIFF
--- a/prompts/20260311-053716-state-hooks.md
+++ b/prompts/20260311-053716-state-hooks.md
@@ -1,0 +1,41 @@
+---
+session: "agent-ad6b3286"
+timestamp: "2026-03-11T05:37:16Z"
+model: claude-opus-4-6
+---
+
+## Human
+
+Implement per-service state lifecycle hooks for robotocore's state management.
+Hooks for before/after save, load, and reset. Hook registry with register/unregister.
+Before hooks abort on exception, after hooks log warnings. Wire into StateManager,
+add management endpoint, add to plugin base class. Write tests first.
+
+## Assistant
+
+## Key decisions
+
+**Hook registry design**: Used a simple `StateHookRegistry` class with a dict mapping
+`HookType` enum values to ordered lists of callbacks. Chose a class over a module-level
+dict to support dependency injection in tests (pass a fresh registry to `StateManager`
+instead of polluting the global singleton).
+
+**Before vs after error handling**: Before hooks propagate exceptions (aborting the
+operation). After hooks catch exceptions and log warnings. This matches the spec and
+is the standard pattern for lifecycle hooks -- you want to gate entry but not fail
+after successful completion.
+
+**StateManager integration**: Added `hook_registry` parameter to `__init__` with
+lazy import of the global singleton as default. This avoids circular imports and
+makes testing clean (26 tests use isolated registries, no global state leakage).
+
+**Management endpoint**: `GET /_robotocore/state/hooks` returns a JSON dict of
+hook type -> list of callback qualified names. Uses `__qualname__` for useful
+introspection of bound methods (shows `MyPlugin.on_before_state_save` not just
+`on_before_state_save`).
+
+**Plugin base class**: Added six no-op methods to `RobotocorePlugin` matching
+the six hook types. These are not auto-registered -- plugin authors need to
+explicitly register them. This is intentional: auto-registration would require
+scanning all methods on load and would couple the extension registry to the
+state hook registry.

--- a/src/robotocore/extensions/base.py
+++ b/src/robotocore/extensions/base.py
@@ -94,6 +94,28 @@ class RobotocorePlugin:
         """
         return {}
 
+    # ------------------------------------------------------------------
+    # State lifecycle hooks (optional)
+    # ------------------------------------------------------------------
+
+    def on_before_state_save(self, context: dict) -> None:
+        """Called before state is saved. Raise to abort the save."""
+
+    def on_after_state_save(self, context: dict) -> None:
+        """Called after state is saved successfully."""
+
+    def on_before_state_load(self, context: dict) -> None:
+        """Called before state is loaded. Raise to abort the load."""
+
+    def on_after_state_load(self, context: dict) -> None:
+        """Called after state is loaded successfully."""
+
+    def on_before_state_reset(self, context: dict) -> None:
+        """Called before state is reset. Raise to abort the reset."""
+
+    def on_after_state_reset(self, context: dict) -> None:
+        """Called after state is reset successfully."""
+
     def get_custom_routes(self) -> list[tuple[str, str, callable]]:
         """Return custom HTTP routes to register.
 

--- a/src/robotocore/gateway/app.py
+++ b/src/robotocore/gateway/app.py
@@ -316,6 +316,13 @@ async def reset_state(request: Request) -> JSONResponse:
     return JSONResponse({"status": "reset"})
 
 
+async def list_state_hooks(request: Request) -> JSONResponse:
+    """List all registered state lifecycle hooks."""
+    from robotocore.state.hooks import state_hooks
+
+    return JSONResponse({"hooks": state_hooks.list_hooks()})
+
+
 async def export_state(request: Request) -> Response:
     """Export emulator state.
 
@@ -718,6 +725,7 @@ management_routes = [
     Route("/_robotocore/state/load", load_state, methods=["POST"]),
     Route("/_robotocore/state/snapshots", list_snapshots, methods=["GET"]),
     Route("/_robotocore/state/reset", reset_state, methods=["POST"]),
+    Route("/_robotocore/state/hooks", list_state_hooks, methods=["GET"]),
     Route("/_robotocore/state/export", export_state, methods=["GET"]),
     Route("/_robotocore/state/import", import_state, methods=["POST"]),
     # Chaos engineering

--- a/src/robotocore/state/hooks.py
+++ b/src/robotocore/state/hooks.py
@@ -1,0 +1,116 @@
+"""State lifecycle hooks for save/load/reset operations.
+
+Provides a registry for callbacks that fire before and after state operations.
+Hooks can be registered by plugins or programmatically for testing/integrations.
+
+Before hooks:
+    - Run synchronously in registration order
+    - If a before hook raises, the operation is aborted (exception propagates)
+
+After hooks:
+    - Run synchronously in registration order
+    - If an after hook raises, a warning is logged but the operation is not failed
+"""
+
+import enum
+import logging
+from collections.abc import Callable
+
+logger = logging.getLogger(__name__)
+
+
+class HookType(enum.Enum):
+    """Types of state lifecycle hooks."""
+
+    BEFORE_SAVE = "before_save"
+    AFTER_SAVE = "after_save"
+    BEFORE_LOAD = "before_load"
+    AFTER_LOAD = "after_load"
+    BEFORE_RESET = "before_reset"
+    AFTER_RESET = "after_reset"
+
+
+# Which hook types are "after" hooks (errors are logged, not propagated)
+_AFTER_HOOKS = {
+    HookType.AFTER_SAVE,
+    HookType.AFTER_LOAD,
+    HookType.AFTER_RESET,
+}
+
+
+class StateHookRegistry:
+    """Registry for state lifecycle hook callbacks.
+
+    Usage::
+
+        from robotocore.state.hooks import state_hooks, HookType
+
+        def my_hook(context: dict) -> None:
+            print(f"State saved to {context.get('snapshot_path')}")
+
+        state_hooks.register(HookType.AFTER_SAVE, my_hook)
+    """
+
+    def __init__(self) -> None:
+        self._hooks: dict[HookType, list[Callable[[dict], None]]] = {ht: [] for ht in HookType}
+
+    def register(self, hook_type: HookType, callback: Callable[[dict], None]) -> None:
+        """Register a callback for the given hook type."""
+        self._hooks[hook_type].append(callback)
+
+    def unregister(self, hook_type: HookType, callback: Callable[[dict], None]) -> None:
+        """Remove a previously registered callback."""
+        try:
+            self._hooks[hook_type].remove(callback)
+        except ValueError:
+            pass
+
+    def fire(self, hook_type: HookType, context: dict) -> None:
+        """Execute all callbacks registered for the given hook type.
+
+        For 'before' hooks: exceptions propagate (aborting the operation).
+        For 'after' hooks: exceptions are logged as warnings but don't propagate.
+
+        Args:
+            hook_type: Which hook to fire.
+            context: Dict with keys like services, snapshot_name, snapshot_path.
+        """
+        is_after = hook_type in _AFTER_HOOKS
+        for callback in self._hooks[hook_type]:
+            if is_after:
+                try:
+                    callback(context)
+                except Exception:
+                    logger.warning(
+                        "After-hook %s raised an exception",
+                        _callback_name(callback),
+                        exc_info=True,
+                    )
+            else:
+                # Before hooks: let exceptions propagate to abort the operation
+                callback(context)
+
+    def list_hooks(self) -> dict[str, list[str]]:
+        """Return a summary of all registered hooks for introspection.
+
+        Returns:
+            Dict mapping hook type value to list of callback descriptions.
+        """
+        result: dict[str, list[str]] = {}
+        for hook_type, callbacks in self._hooks.items():
+            if callbacks:
+                result[hook_type.value] = [_callback_name(cb) for cb in callbacks]
+        return result
+
+
+def _callback_name(callback: Callable) -> str:
+    """Get a human-readable name for a callback."""
+    if hasattr(callback, "__qualname__"):
+        return callback.__qualname__
+    if hasattr(callback, "__name__"):
+        return callback.__name__
+    return repr(callback)
+
+
+# Global singleton
+state_hooks = StateHookRegistry()

--- a/src/robotocore/state/manager.py
+++ b/src/robotocore/state/manager.py
@@ -11,6 +11,8 @@ Configuration via environment variables:
     ROBOTOCORE_RESTORE_SNAPSHOT=<name|latest>    Auto-restore snapshot on startup
 """
 
+from __future__ import annotations
+
 import io
 import json
 import logging
@@ -20,6 +22,10 @@ import tarfile
 import threading
 import time
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from robotocore.state.hooks import StateHookRegistry
 
 logger = logging.getLogger(__name__)
 
@@ -27,12 +33,23 @@ logger = logging.getLogger(__name__)
 class StateManager:
     """Manages save/restore of emulator state."""
 
-    def __init__(self, state_dir: str | None = None) -> None:
+    def __init__(
+        self,
+        state_dir: str | None = None,
+        hook_registry: StateHookRegistry | None = None,
+    ) -> None:
         self.state_dir = Path(state_dir) if state_dir else None
         self._native_handlers: dict[str, tuple] = {}
         self._last_save_time: float = 0.0
         self._save_lock = threading.Lock()
         self._debounce_interval: float = 1.0  # seconds
+
+        if hook_registry is not None:
+            self._hooks = hook_registry
+        else:
+            from robotocore.state.hooks import state_hooks
+
+            self._hooks = state_hooks
 
     def register_native_handler(
         self,
@@ -58,6 +75,8 @@ class StateManager:
             services: If provided, only save these services.
             compress: If True, create a .tar.gz archive instead of a directory.
         """
+        from robotocore.state.hooks import HookType
+
         if name:
             base = Path(path) if path else self.state_dir
             if not base:
@@ -70,6 +89,14 @@ class StateManager:
             save_dir = Path(path) if path else self.state_dir
         if not save_dir:
             raise ValueError("No state directory configured")
+
+        # Fire before-save hook (may abort by raising)
+        hook_ctx = {
+            "services": services,
+            "snapshot_name": name,
+            "snapshot_path": str(save_dir),
+        }
+        self._hooks.fire(HookType.BEFORE_SAVE, hook_ctx)
 
         save_dir.mkdir(parents=True, exist_ok=True)
         timestamp = time.strftime("%Y%m%dT%H%M%S")
@@ -110,11 +137,17 @@ class StateManager:
             shutil.rmtree(save_dir)
             self._last_save_time = time.monotonic()
             logger.info("State saved (compressed) to %s", archive_path)
-            return str(archive_path)
+            result_path = str(archive_path)
+            hook_ctx["snapshot_path"] = result_path
+            self._hooks.fire(HookType.AFTER_SAVE, hook_ctx)
+            return result_path
 
         self._last_save_time = time.monotonic()
         logger.info("State saved to %s", save_dir)
-        return str(save_dir)
+        result_path = str(save_dir)
+        hook_ctx["snapshot_path"] = result_path
+        self._hooks.fire(HookType.AFTER_SAVE, hook_ctx)
+        return result_path
 
     def save_debounced(self) -> bool:
         """Save state with debouncing -- at most once per debounce_interval.
@@ -189,6 +222,8 @@ class StateManager:
                   Use "latest" to load the most recently saved snapshot.
             services: If provided, only load these services.
         """
+        from robotocore.state.hooks import HookType
+
         if name:
             base = Path(path) if path else self.state_dir
             if not base:
@@ -223,6 +258,14 @@ class StateManager:
             logger.warning("No metadata.json in %s -- skipping load", load_dir)
             return False
 
+        # Fire before-load hook (may abort by raising)
+        hook_ctx = {
+            "services": services,
+            "snapshot_name": name,
+            "snapshot_path": str(load_dir),
+        }
+        self._hooks.fire(HookType.BEFORE_LOAD, hook_ctx)
+
         meta = json.loads(meta_path.read_text())
         logger.info(
             "Loading state from %s (saved at %s)",
@@ -241,10 +284,16 @@ class StateManager:
             self._load_native_state(native_path, services=services)
 
         logger.info("State loaded successfully")
+        self._hooks.fire(HookType.AFTER_LOAD, hook_ctx)
         return True
 
-    def reset(self) -> None:
+    def reset(self, services: list[str] | None = None) -> None:
         """Reset all state to empty."""
+        from robotocore.state.hooks import HookType
+
+        hook_ctx: dict = {"services": services}
+        self._hooks.fire(HookType.BEFORE_RESET, hook_ctx)
+
         self._reset_moto_state()
         for service, (_, load_fn) in self._native_handlers.items():
             try:
@@ -252,6 +301,8 @@ class StateManager:
             except Exception:
                 logger.debug("Failed to reset native state for %s", service, exc_info=True)
         logger.info("All state reset")
+
+        self._hooks.fire(HookType.AFTER_RESET, hook_ctx)
 
     def export_json(self) -> dict:
         """Export native provider state as a JSON-serializable dict."""

--- a/tests/unit/state/test_hooks.py
+++ b/tests/unit/state/test_hooks.py
@@ -1,0 +1,177 @@
+"""Tests for state lifecycle hooks."""
+
+import logging
+
+import pytest
+
+from robotocore.state.hooks import (
+    HookType,
+    StateHookRegistry,
+    state_hooks,
+)
+
+
+class TestHookRegistration:
+    def test_register_hook(self):
+        """Register a callback and verify it's stored."""
+        registry = StateHookRegistry()
+        calls = []
+        registry.register(HookType.BEFORE_SAVE, lambda ctx: calls.append("called"))
+        # Trigger to verify
+        registry.fire(HookType.BEFORE_SAVE, {})
+        assert calls == ["called"]
+
+    def test_unregister_hook(self):
+        """Unregister a callback and verify it's no longer called."""
+        registry = StateHookRegistry()
+        calls = []
+
+        def my_hook(ctx):
+            calls.append("called")
+
+        registry.register(HookType.BEFORE_SAVE, my_hook)
+        registry.unregister(HookType.BEFORE_SAVE, my_hook)
+        registry.fire(HookType.BEFORE_SAVE, {})
+        assert calls == []
+
+    def test_unregistered_hook_not_called(self):
+        """A hook that was never registered should not fire."""
+        registry = StateHookRegistry()
+        calls = []
+        registry.fire(HookType.BEFORE_SAVE, {})
+        assert calls == []
+
+    def test_registry_independent_per_hook_type(self):
+        """Hooks registered for one type don't fire for another."""
+        registry = StateHookRegistry()
+        calls = []
+
+        registry.register(HookType.BEFORE_SAVE, lambda ctx: calls.append("save"))
+        registry.fire(HookType.BEFORE_LOAD, {})
+        assert calls == []
+        registry.fire(HookType.BEFORE_SAVE, {})
+        assert calls == ["save"]
+
+    def test_global_singleton_works(self):
+        """The global state_hooks singleton should be a StateHookRegistry."""
+        assert isinstance(state_hooks, StateHookRegistry)
+
+
+class TestHookExecution:
+    def test_multiple_hooks_called_in_order(self):
+        """Multiple hooks for same type fire in registration order."""
+        registry = StateHookRegistry()
+        calls = []
+
+        registry.register(HookType.BEFORE_SAVE, lambda ctx: calls.append("first"))
+        registry.register(HookType.BEFORE_SAVE, lambda ctx: calls.append("second"))
+        registry.register(HookType.BEFORE_SAVE, lambda ctx: calls.append("third"))
+        registry.fire(HookType.BEFORE_SAVE, {})
+        assert calls == ["first", "second", "third"]
+
+    def test_before_hook_exception_aborts(self):
+        """If a before hook raises, fire() should propagate the exception."""
+        registry = StateHookRegistry()
+
+        def bad_hook(ctx):
+            raise ValueError("abort!")
+
+        registry.register(HookType.BEFORE_SAVE, bad_hook)
+        with pytest.raises(ValueError, match="abort!"):
+            registry.fire(HookType.BEFORE_SAVE, {})
+
+    def test_after_hook_exception_logs_warning(self, caplog):
+        """If an after hook raises, it should log a warning but not propagate."""
+        registry = StateHookRegistry()
+
+        def bad_hook(ctx):
+            raise RuntimeError("oops")
+
+        registry.register(HookType.AFTER_SAVE, bad_hook)
+        with caplog.at_level(logging.WARNING):
+            registry.fire(HookType.AFTER_SAVE, {})
+        assert "oops" in caplog.text
+
+    def test_hook_receives_context(self):
+        """Hooks should receive the context dict passed to fire()."""
+        registry = StateHookRegistry()
+        received = []
+
+        registry.register(HookType.BEFORE_SAVE, lambda ctx: received.append(ctx))
+        context = {"services": ["s3"], "snapshot_name": "test"}
+        registry.fire(HookType.BEFORE_SAVE, context)
+        assert received == [context]
+
+    def test_hook_with_services_filter(self):
+        """Hook receives services list from context."""
+        registry = StateHookRegistry()
+        received = []
+
+        registry.register(HookType.BEFORE_SAVE, lambda ctx: received.append(ctx))
+        registry.fire(HookType.BEFORE_SAVE, {"services": ["s3", "dynamodb"]})
+        assert received[0]["services"] == ["s3", "dynamodb"]
+
+
+class TestHookTypeCoverage:
+    """Verify all six hook types fire correctly."""
+
+    def test_before_save_fires(self):
+        registry = StateHookRegistry()
+        calls = []
+        registry.register(HookType.BEFORE_SAVE, lambda ctx: calls.append("before_save"))
+        registry.fire(HookType.BEFORE_SAVE, {})
+        assert calls == ["before_save"]
+
+    def test_after_save_fires(self):
+        registry = StateHookRegistry()
+        calls = []
+        registry.register(HookType.AFTER_SAVE, lambda ctx: calls.append("after_save"))
+        registry.fire(HookType.AFTER_SAVE, {})
+        assert calls == ["after_save"]
+
+    def test_before_load_fires(self):
+        registry = StateHookRegistry()
+        calls = []
+        registry.register(HookType.BEFORE_LOAD, lambda ctx: calls.append("before_load"))
+        registry.fire(HookType.BEFORE_LOAD, {})
+        assert calls == ["before_load"]
+
+    def test_after_load_fires(self):
+        registry = StateHookRegistry()
+        calls = []
+        registry.register(HookType.AFTER_LOAD, lambda ctx: calls.append("after_load"))
+        registry.fire(HookType.AFTER_LOAD, {})
+        assert calls == ["after_load"]
+
+    def test_before_reset_fires(self):
+        registry = StateHookRegistry()
+        calls = []
+        registry.register(HookType.BEFORE_RESET, lambda ctx: calls.append("before_reset"))
+        registry.fire(HookType.BEFORE_RESET, {})
+        assert calls == ["before_reset"]
+
+    def test_after_reset_fires(self):
+        registry = StateHookRegistry()
+        calls = []
+        registry.register(HookType.AFTER_RESET, lambda ctx: calls.append("after_reset"))
+        registry.fire(HookType.AFTER_RESET, {})
+        assert calls == ["after_reset"]
+
+
+class TestListHooks:
+    def test_list_hooks_empty(self):
+        registry = StateHookRegistry()
+        result = registry.list_hooks()
+        assert result == {}
+
+    def test_list_hooks_with_registrations(self):
+        registry = StateHookRegistry()
+
+        def my_hook(ctx):
+            pass
+
+        registry.register(HookType.BEFORE_SAVE, my_hook)
+        result = registry.list_hooks()
+        assert HookType.BEFORE_SAVE.value in result
+        assert len(result[HookType.BEFORE_SAVE.value]) == 1
+        assert "my_hook" in result[HookType.BEFORE_SAVE.value][0]

--- a/tests/unit/state/test_hooks_integration.py
+++ b/tests/unit/state/test_hooks_integration.py
@@ -1,0 +1,143 @@
+"""Integration tests for state lifecycle hooks wired into StateManager."""
+
+import logging
+import tempfile
+
+import pytest
+
+from robotocore.state.hooks import HookType, StateHookRegistry
+from robotocore.state.manager import StateManager
+
+
+class TestStateManagerHooksEndToEnd:
+    def test_save_fires_before_and_after_hooks(self):
+        """Register hooks, save state, verify both before and after fired with path."""
+        registry = StateHookRegistry()
+        calls = []
+
+        registry.register(HookType.BEFORE_SAVE, lambda ctx: calls.append(("before", ctx)))
+        registry.register(HookType.AFTER_SAVE, lambda ctx: calls.append(("after", ctx)))
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = StateManager(state_dir=tmpdir, hook_registry=registry)
+            saved_path = manager.save(name="hook-test")
+
+        assert len(calls) == 2
+        assert calls[0][0] == "before"
+        assert calls[1][0] == "after"
+        assert calls[1][1]["snapshot_path"] == saved_path
+
+    def test_before_save_exception_aborts_save(self):
+        """If before_save hook raises, save should not proceed."""
+        registry = StateHookRegistry()
+
+        def abort_hook(ctx):
+            raise ValueError("no saving allowed")
+
+        registry.register(HookType.BEFORE_SAVE, abort_hook)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = StateManager(state_dir=tmpdir, hook_registry=registry)
+            with pytest.raises(ValueError, match="no saving allowed"):
+                manager.save(name="should-not-exist")
+
+    def test_load_fires_before_and_after_hooks(self):
+        """Register hooks, load state, verify both before and after fired."""
+        registry = StateHookRegistry()
+        calls = []
+
+        registry.register(HookType.BEFORE_LOAD, lambda ctx: calls.append(("before", ctx)))
+        registry.register(HookType.AFTER_LOAD, lambda ctx: calls.append(("after", ctx)))
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = StateManager(state_dir=tmpdir, hook_registry=registry)
+            # Save first so there's something to load
+            manager.save(name="load-test")
+            calls.clear()
+            manager.load(name="load-test")
+
+        assert len(calls) == 2
+        assert calls[0][0] == "before"
+        assert calls[1][0] == "after"
+
+    def test_reset_fires_before_and_after_hooks(self):
+        """Register hooks, reset state, verify hooks fire."""
+        registry = StateHookRegistry()
+        calls = []
+
+        registry.register(HookType.BEFORE_RESET, lambda ctx: calls.append("before"))
+        registry.register(HookType.AFTER_RESET, lambda ctx: calls.append("after"))
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = StateManager(state_dir=tmpdir, hook_registry=registry)
+            manager.reset()
+
+        assert calls == ["before", "after"]
+
+    def test_selective_save_passes_services_to_hooks(self):
+        """When saving with services filter, hooks receive the service list."""
+        registry = StateHookRegistry()
+        received = []
+
+        registry.register(HookType.BEFORE_SAVE, lambda ctx: received.append(ctx))
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = StateManager(state_dir=tmpdir, hook_registry=registry)
+            manager.save(services=["s3", "dynamodb"])
+
+        assert received[0]["services"] == ["s3", "dynamodb"]
+
+    def test_plugin_like_hook_registration(self):
+        """Simulate plugin registering a hook and verify it fires."""
+        registry = StateHookRegistry()
+        plugin_calls = []
+
+        # Simulating what a plugin would do
+        class MyPlugin:
+            def on_before_state_save(self, ctx):
+                plugin_calls.append(f"plugin saw save for {ctx.get('services')}")
+
+        plugin = MyPlugin()
+        registry.register(HookType.BEFORE_SAVE, plugin.on_before_state_save)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = StateManager(state_dir=tmpdir, hook_registry=registry)
+            manager.save(services=["sqs"])
+
+        assert len(plugin_calls) == 1
+        assert "sqs" in plugin_calls[0]
+
+    def test_after_hook_failure_does_not_fail_save(self, caplog):
+        """After-save hook failure should log but not raise."""
+        registry = StateHookRegistry()
+
+        def bad_after_hook(ctx):
+            raise RuntimeError("after hook boom")
+
+        registry.register(HookType.AFTER_SAVE, bad_after_hook)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = StateManager(state_dir=tmpdir, hook_registry=registry)
+            with caplog.at_level(logging.WARNING):
+                saved_path = manager.save(name="still-saves")
+            # Save should have succeeded despite the hook error
+            assert "still-saves" in saved_path
+            assert "after hook boom" in caplog.text
+
+
+class TestHooksManagementEndpoint:
+    def test_list_hooks_endpoint(self):
+        """The management endpoint should return registered hooks."""
+        from robotocore.state.hooks import state_hooks
+
+        def temp_hook(ctx):
+            pass
+
+        state_hooks.register(HookType.BEFORE_SAVE, temp_hook)
+        try:
+            result = state_hooks.list_hooks()
+            assert HookType.BEFORE_SAVE.value in result
+            hook_names = result[HookType.BEFORE_SAVE.value]
+            assert any("temp_hook" in name for name in hook_names)
+        finally:
+            state_hooks.unregister(HookType.BEFORE_SAVE, temp_hook)


### PR DESCRIPTION
## Summary
- Adds a `StateHookRegistry` with before/after hooks for save, load, and reset operations on emulator state
- Before-hooks can abort operations by raising exceptions; after-hook errors are logged but non-fatal
- New management endpoint `GET /_robotocore/state/hooks` for introspecting registered hooks
- `RobotocorePlugin` base class gains optional state lifecycle hook methods
- 26 new unit tests covering registration, execution order, error handling, and end-to-end integration

## Test plan
- [x] 26 new tests in `tests/unit/state/test_hooks.py` and `test_hooks_integration.py`
- [x] All 67 existing + new state tests pass with zero regressions
- [x] Lint clean (ruff check + format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)