### PR TITLE
Add 120 unit tests for infrastructure coverage gaps

### DIFF
--- a/prompts/20260311-054600-test-coverage-gaps.md
+++ b/prompts/20260311-054600-test-coverage-gaps.md
@@ -1,0 +1,38 @@
+---
+session: "a13ea6ec"
+timestamp: "2026-03-11T05:46:00Z"
+model: claude-opus-4-6
+---
+
+## Human
+
+Find test coverage gaps in robotocore's existing infrastructure features and fill them.
+Focus on: gateway app, router, state manager, chaos, audit log, resource browser,
+extensions, observability, IAM engine, Lambda invoke, CloudFormation engine, EventBridge.
+Write at least 50 new meaningful tests. Commit and create a PR.
+
+## Assistant
+
+## Key decisions
+
+**Audit approach**: Read every source file in the target areas and every corresponding
+test file, then identified functions/methods with zero test coverage. Prioritized by
+complexity (more logic = more value in testing).
+
+**Biggest gaps found**:
+- State manager: export_snapshot_bytes, import_snapshot_bytes, compressed save/load,
+  path traversal protection, restore_on_startup, find_latest_snapshot, selective load
+- Resource browser: get_resource_counts (zero tests), generic fallback path, list collections
+- Audit log: thread safety under concurrent access, singleton behavior
+- Init hooks: actual script execution (only existed as code, no tests)
+- Tracing middleware: request ID generation, header injection
+- Extensions: directory discovery, env var discovery, all error-handling paths
+- Handler chain: exception handler failures (handler itself throws)
+- Fault rules: regex matching, probability clamping, thread safety
+
+**Already well-tested** (skipped): IAM conditions (comprehensive), IAM policy engine
+(comprehensive), chaos middleware (already 30+ tests), observability logging/metrics.
+
+**Test quality**: Every test asserts something meaningful. No mock-everything tests.
+Thread safety tests use actual threading with error collection. Extension discovery
+tests create real Python files in tmp_path and verify they load correctly.

--- a/tests/unit/observability/test_hooks_advanced.py
+++ b/tests/unit/observability/test_hooks_advanced.py
@@ -1,0 +1,127 @@
+"""Advanced tests for init hooks: script execution, timeouts, ordering,
+error handling, and env var configuration."""
+
+import os
+import stat
+from unittest.mock import patch
+
+from robotocore.observability.hooks import get_hook_base, run_init_hooks
+
+
+class TestGetHookBase:
+    def test_default_base(self):
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("ROBOTOCORE_INIT_DIR", None)
+            assert get_hook_base() == "/etc/robotocore/init"
+
+    def test_custom_base(self):
+        with patch.dict(os.environ, {"ROBOTOCORE_INIT_DIR": "/custom/hooks"}):
+            assert get_hook_base() == "/custom/hooks"
+
+
+class TestRunInitHooks:
+    def test_nonexistent_directory_returns_empty(self, tmp_path):
+        with patch.dict(os.environ, {"ROBOTOCORE_INIT_DIR": str(tmp_path / "nonexistent")}):
+            results = run_init_hooks("boot")
+        assert results == []
+
+    def test_empty_directory_returns_empty(self, tmp_path):
+        hook_dir = tmp_path / "boot.d"
+        hook_dir.mkdir(parents=True)
+        with patch.dict(os.environ, {"ROBOTOCORE_INIT_DIR": str(tmp_path)}):
+            results = run_init_hooks("boot")
+        assert results == []
+
+    def test_successful_script_execution(self, tmp_path):
+        hook_dir = tmp_path / "ready.d"
+        hook_dir.mkdir(parents=True)
+        script = hook_dir / "01-test.sh"
+        script.write_text("#!/bin/bash\necho 'hello from hook'")
+        script.chmod(stat.S_IRWXU)
+
+        with patch.dict(os.environ, {"ROBOTOCORE_INIT_DIR": str(tmp_path)}):
+            results = run_init_hooks("ready")
+
+        assert len(results) == 1
+        assert results[0]["script"] == "01-test.sh"
+        assert results[0]["returncode"] == 0
+        assert "hello from hook" in results[0]["stdout"]
+
+    def test_failing_script_captured(self, tmp_path):
+        hook_dir = tmp_path / "boot.d"
+        hook_dir.mkdir(parents=True)
+        script = hook_dir / "01-fail.sh"
+        script.write_text("#!/bin/bash\necho 'error' >&2\nexit 1")
+        script.chmod(stat.S_IRWXU)
+
+        with patch.dict(os.environ, {"ROBOTOCORE_INIT_DIR": str(tmp_path)}):
+            results = run_init_hooks("boot")
+
+        assert len(results) == 1
+        assert results[0]["returncode"] == 1
+        assert "error" in results[0]["stderr"]
+
+    def test_scripts_run_in_sorted_order(self, tmp_path):
+        hook_dir = tmp_path / "boot.d"
+        hook_dir.mkdir(parents=True)
+        for name in ["03-third.sh", "01-first.sh", "02-second.sh"]:
+            script = hook_dir / name
+            script.write_text(f"#!/bin/bash\necho '{name}'")
+            script.chmod(stat.S_IRWXU)
+
+        with patch.dict(os.environ, {"ROBOTOCORE_INIT_DIR": str(tmp_path)}):
+            results = run_init_hooks("boot")
+
+        assert len(results) == 3
+        assert results[0]["script"] == "01-first.sh"
+        assert results[1]["script"] == "02-second.sh"
+        assert results[2]["script"] == "03-third.sh"
+
+    def test_all_sh_files_run_including_underscored(self, tmp_path):
+        """The hooks module runs ALL *.sh files, including underscore-prefixed ones."""
+        hook_dir = tmp_path / "boot.d"
+        hook_dir.mkdir(parents=True)
+        helper = hook_dir / "_helper.sh"
+        helper.write_text("#!/bin/bash\necho 'helper ran'")
+        helper.chmod(stat.S_IRWXU)
+        regular = hook_dir / "01-run.sh"
+        regular.write_text("#!/bin/bash\necho 'running'")
+        regular.chmod(stat.S_IRWXU)
+
+        with patch.dict(os.environ, {"ROBOTOCORE_INIT_DIR": str(tmp_path)}):
+            results = run_init_hooks("boot")
+
+        assert len(results) == 2
+        scripts = [r["script"] for r in results]
+        assert "01-run.sh" in scripts
+        assert "_helper.sh" in scripts
+
+    def test_non_sh_files_skipped(self, tmp_path):
+        hook_dir = tmp_path / "boot.d"
+        hook_dir.mkdir(parents=True)
+        # .py file should be skipped
+        (hook_dir / "test.py").write_text("print('hi')")
+        # .sh file should run
+        sh = hook_dir / "01-test.sh"
+        sh.write_text("#!/bin/bash\necho 'ok'")
+        sh.chmod(stat.S_IRWXU)
+
+        with patch.dict(os.environ, {"ROBOTOCORE_INIT_DIR": str(tmp_path)}):
+            results = run_init_hooks("boot")
+
+        assert len(results) == 1
+        assert results[0]["script"] == "01-test.sh"
+
+    def test_different_stages(self, tmp_path):
+        for stage in ["boot", "ready", "shutdown"]:
+            hook_dir = tmp_path / f"{stage}.d"
+            hook_dir.mkdir(parents=True)
+            script = hook_dir / f"01-{stage}.sh"
+            script.write_text(f"#!/bin/bash\necho '{stage}'")
+            script.chmod(stat.S_IRWXU)
+
+        with patch.dict(os.environ, {"ROBOTOCORE_INIT_DIR": str(tmp_path)}):
+            for stage in ["boot", "ready", "shutdown"]:
+                results = run_init_hooks(stage)
+                assert len(results) == 1
+                assert stage in results[0]["stdout"]

--- a/tests/unit/observability/test_tracing_advanced.py
+++ b/tests/unit/observability/test_tracing_advanced.py
@@ -1,0 +1,117 @@
+"""Advanced tests for the tracing module: request ID generation,
+TracingMiddleware behavior."""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from robotocore.observability.tracing import TracingMiddleware, generate_request_id
+
+
+class TestGenerateRequestId:
+    def test_returns_string(self):
+        rid = generate_request_id()
+        assert isinstance(rid, str)
+
+    def test_unique_ids(self):
+        ids = {generate_request_id() for _ in range(100)}
+        assert len(ids) == 100
+
+    def test_uuid_format(self):
+        """Request IDs should be valid UUIDs (contain hyphens, 36 chars)."""
+        rid = generate_request_id()
+        assert len(rid) == 36
+        assert rid.count("-") == 4
+
+
+class TestTracingMiddleware:
+    def test_adds_request_id_header(self):
+        middleware = TracingMiddleware(app=MagicMock())
+
+        async def _run():
+            request = MagicMock()
+            request.method = "POST"
+            request.url.path = "/"
+            request.headers = {}
+            request.body = AsyncMock(return_value=b"")
+            request.state = MagicMock()
+
+            response = MagicMock()
+            response.status_code = 200
+            response.headers = {}
+
+            async def call_next(_req):
+                return response
+
+            with patch("robotocore.observability.tracing.log_request"):
+                with patch("robotocore.observability.tracing.log_response"):
+                    result = await middleware.dispatch(request, call_next)
+
+            assert "X-Amz-Request-Id" in result.headers
+            assert "X-Robotocore-Request-Id" in result.headers
+            # Both headers should have the same value
+            assert result.headers["X-Amz-Request-Id"] == result.headers["X-Robotocore-Request-Id"]
+
+        asyncio.get_event_loop().run_until_complete(_run())
+
+    def test_sets_request_state(self):
+        middleware = TracingMiddleware(app=MagicMock())
+
+        async def _run():
+            request = MagicMock()
+            request.method = "GET"
+            request.url.path = "/test"
+            request.headers = {}
+            request.body = AsyncMock(return_value=b"")
+
+            class State:
+                pass
+
+            request.state = State()
+
+            response = MagicMock()
+            response.status_code = 200
+            response.headers = {}
+
+            async def call_next(_req):
+                return response
+
+            with patch("robotocore.observability.tracing.log_request"):
+                with patch("robotocore.observability.tracing.log_response"):
+                    await middleware.dispatch(request, call_next)
+
+            assert hasattr(request.state, "request_id")
+            assert hasattr(request.state, "start_time")
+            assert isinstance(request.state.request_id, str)
+
+        asyncio.get_event_loop().run_until_complete(_run())
+
+    def test_calls_log_request_and_log_response(self):
+        middleware = TracingMiddleware(app=MagicMock())
+
+        async def _run():
+            request = MagicMock()
+            request.method = "POST"
+            request.url.path = "/"
+            request.headers = {"content-type": "application/json"}
+            request.body = AsyncMock(return_value=b'{"key": "value"}')
+            request.state = MagicMock()
+
+            response = MagicMock()
+            response.status_code = 200
+            response.headers = {"content-length": "42"}
+
+            async def call_next(_req):
+                return response
+
+            with patch("robotocore.observability.tracing.log_request") as mock_log_req:
+                with patch("robotocore.observability.tracing.log_response") as mock_log_resp:
+                    await middleware.dispatch(request, call_next)
+
+            mock_log_req.assert_called_once()
+            mock_log_resp.assert_called_once()
+            # log_response should include status_code and body_size
+            call_kwargs = mock_log_resp.call_args
+            assert call_kwargs.kwargs["status_code"] == 200
+            assert call_kwargs.kwargs["body_size"] == 42
+
+        asyncio.get_event_loop().run_until_complete(_run())

--- a/tests/unit/test_audit_log_advanced.py
+++ b/tests/unit/test_audit_log_advanced.py
@@ -1,0 +1,136 @@
+"""Advanced audit log tests: thread safety, singleton, edge cases."""
+
+import threading
+
+from robotocore.audit.log import AuditLog, get_audit_log
+
+
+class TestAuditLogThreadSafety:
+    def test_concurrent_record_and_recent(self):
+        """Multiple threads recording simultaneously should not lose or corrupt entries."""
+        log = AuditLog(max_size=5000)
+        errors = []
+
+        def record_many(thread_id):
+            try:
+                for i in range(200):
+                    log.record(service=f"svc-{thread_id}", operation=f"Op{i}", status_code=200)
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=record_many, args=(i,)) for i in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors
+        entries = log.recent(limit=5000)
+        assert len(entries) == 2000  # 10 threads * 200 each
+
+    def test_concurrent_record_and_clear(self):
+        """Recording and clearing simultaneously should not crash."""
+        log = AuditLog(max_size=100)
+        errors = []
+
+        def record_loop():
+            try:
+                for i in range(500):
+                    log.record(service="s3", operation=f"Op{i}")
+            except Exception as e:
+                errors.append(e)
+
+        def clear_loop():
+            try:
+                for _ in range(50):
+                    log.clear()
+            except Exception as e:
+                errors.append(e)
+
+        t1 = threading.Thread(target=record_loop)
+        t2 = threading.Thread(target=clear_loop)
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+        assert not errors
+
+    def test_concurrent_record_with_ring_buffer_overflow(self):
+        """Ring buffer overflow during concurrent access should not corrupt data."""
+        log = AuditLog(max_size=50)
+        errors = []
+
+        def record_many(thread_id):
+            try:
+                for i in range(100):
+                    log.record(service=f"svc-{thread_id}", operation=f"Op{i}")
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=record_many, args=(i,)) for i in range(5)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors
+        entries = log.recent()
+        assert len(entries) == 50  # max_size enforced
+
+
+class TestAuditLogSingleton:
+    def test_get_audit_log_returns_same_instance(self):
+        log1 = get_audit_log()
+        log2 = get_audit_log()
+        assert log1 is log2
+
+    def test_singleton_is_functional(self):
+        log = get_audit_log()
+        initial_count = len(log.recent(limit=10000))
+        log.record(service="test-singleton", operation="TestOp")
+        new_count = len(log.recent(limit=10000))
+        assert new_count >= initial_count  # At least one more entry
+
+
+class TestAuditLogEdgeCases:
+    def test_max_size_one(self):
+        log = AuditLog(max_size=1)
+        log.record(service="s3", operation="First")
+        log.record(service="s3", operation="Second")
+        entries = log.recent()
+        assert len(entries) == 1
+        assert entries[0]["operation"] == "Second"
+
+    def test_recent_with_zero_limit(self):
+        log = AuditLog(max_size=100)
+        log.record(service="s3", operation="Test")
+        entries = log.recent(limit=0)
+        assert entries == []
+
+    def test_record_empty_error_string(self):
+        """Empty string error should not add 'error' key (falsy)."""
+        log = AuditLog(max_size=100)
+        log.record(service="s3", operation="Test", error="")
+        entry = log.recent()[0]
+        assert "error" not in entry
+
+    def test_duration_ms_rounding(self):
+        log = AuditLog(max_size=100)
+        log.record(service="s3", duration_ms=1.23456789)
+        entry = log.recent()[0]
+        assert entry["duration_ms"] == 1.23
+
+    def test_large_duration_preserved(self):
+        log = AuditLog(max_size=100)
+        log.record(service="s3", duration_ms=99999.99)
+        entry = log.recent()[0]
+        assert entry["duration_ms"] == 99999.99
+
+    def test_many_entries_ordering_preserved(self):
+        log = AuditLog(max_size=1000)
+        for i in range(500):
+            log.record(service=f"svc-{i:04d}", operation=f"Op{i}")
+        entries = log.recent(limit=500)
+        # Newest first
+        assert entries[0]["service"] == "svc-0499"
+        assert entries[-1]["service"] == "svc-0000"

--- a/tests/unit/test_extensions_advanced.py
+++ b/tests/unit/test_extensions_advanced.py
@@ -1,0 +1,294 @@
+"""Advanced tests for the extension system: directory discovery,
+env var discovery, error handling, lifecycle hooks."""
+
+import os
+from unittest.mock import MagicMock, patch
+
+from starlette.responses import Response
+
+from robotocore.extensions.base import RobotocorePlugin
+from robotocore.extensions.registry import (
+    ExtensionRegistry,
+    _discover_from_directory,
+    _discover_from_env,
+)
+
+
+class TestDiscoverFromDirectory:
+    def test_directory_with_plugin_file(self, tmp_path):
+        plugin_file = tmp_path / "my_plugin.py"
+        plugin_file.write_text(
+            """
+from robotocore.extensions.base import RobotocorePlugin
+
+class MyPlugin(RobotocorePlugin):
+    name = "my-dir-plugin"
+    version = "1.0"
+"""
+        )
+        plugins = _discover_from_directory(str(tmp_path))
+        assert len(plugins) == 1
+        assert plugins[0].name == "my-dir-plugin"
+
+    def test_directory_nonexistent(self):
+        plugins = _discover_from_directory("/nonexistent/path/xyz")
+        assert plugins == []
+
+    def test_directory_skips_underscored_files(self, tmp_path):
+        (tmp_path / "__init__.py").write_text("")
+        (tmp_path / "_helper.py").write_text(
+            """
+from robotocore.extensions.base import RobotocorePlugin
+class Helper(RobotocorePlugin):
+    name = "helper"
+"""
+        )
+        plugins = _discover_from_directory(str(tmp_path))
+        assert len(plugins) == 0
+
+    def test_directory_handles_import_error(self, tmp_path):
+        bad_file = tmp_path / "bad_plugin.py"
+        bad_file.write_text("raise ImportError('broken')")
+        # Should not crash
+        plugins = _discover_from_directory(str(tmp_path))
+        assert plugins == []
+
+    def test_directory_with_multiple_plugins(self, tmp_path):
+        for i in range(3):
+            (tmp_path / f"plugin_{i}.py").write_text(
+                f"""
+from robotocore.extensions.base import RobotocorePlugin
+class Plugin{i}(RobotocorePlugin):
+    name = "plugin-{i}"
+"""
+            )
+        plugins = _discover_from_directory(str(tmp_path))
+        assert len(plugins) == 3
+        names = {p.name for p in plugins}
+        assert names == {"plugin-0", "plugin-1", "plugin-2"}
+
+
+class TestDiscoverFromEnv:
+    def test_empty_env_returns_empty(self):
+        with patch.dict(os.environ, {"ROBOTOCORE_EXTENSIONS": ""}):
+            plugins = _discover_from_env()
+        assert plugins == []
+
+    def test_no_env_returns_empty(self):
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("ROBOTOCORE_EXTENSIONS", None)
+            plugins = _discover_from_env()
+        assert plugins == []
+
+    def test_invalid_module_path_handled(self):
+        with patch.dict(os.environ, {"ROBOTOCORE_EXTENSIONS": "nonexistent.module.path"}):
+            # Should not crash
+            plugins = _discover_from_env()
+        assert plugins == []
+
+    def test_whitespace_module_paths_handled(self):
+        with patch.dict(os.environ, {"ROBOTOCORE_EXTENSIONS": " , , "}):
+            plugins = _discover_from_env()
+        assert plugins == []
+
+
+class TestExtensionRegistryOnErrorHook:
+    def test_on_error_first_plugin_handles(self):
+        reg = ExtensionRegistry()
+
+        class ErrorHandler(RobotocorePlugin):
+            name = "err-handler"
+
+            def on_error(self, request, error, context):
+                return Response(content="handled", status_code=500)
+
+        reg.register(ErrorHandler())
+        result = reg.on_error(MagicMock(), RuntimeError("boom"), {})
+        assert isinstance(result, Response)
+        assert result.body == b"handled"
+
+    def test_on_error_plugin_exception_swallowed(self):
+        reg = ExtensionRegistry()
+
+        class BadErrorHandler(RobotocorePlugin):
+            name = "bad-err"
+
+            def on_error(self, request, error, context):
+                raise RuntimeError("handler itself crashed")
+
+        reg.register(BadErrorHandler())
+        # Should not raise
+        result = reg.on_error(MagicMock(), ValueError("original"), {})
+        assert result is None
+
+    def test_on_error_multiple_plugins_first_wins(self):
+        reg = ExtensionRegistry()
+
+        class First(RobotocorePlugin):
+            name = "first"
+            priority = 10
+
+            def on_error(self, request, error, context):
+                return Response(content="first handler", status_code=500)
+
+        class Second(RobotocorePlugin):
+            name = "second"
+            priority = 20
+
+            def on_error(self, request, error, context):
+                return Response(content="second handler", status_code=500)
+
+        reg.register(First())
+        reg.register(Second())
+        result = reg.on_error(MagicMock(), ValueError("err"), {})
+        assert result.body == b"first handler"
+
+
+class TestExtensionRegistryOnRequestHook:
+    def test_on_request_returns_modified_request(self):
+        reg = ExtensionRegistry()
+
+        class Modifier(RobotocorePlugin):
+            name = "modifier"
+
+            def on_request(self, request, context):
+                modified = MagicMock()
+                modified.modified = True
+                return modified
+
+        reg.register(Modifier())
+        result = reg.on_request(MagicMock(), {})
+        assert result.modified is True
+
+    def test_on_request_plugin_error_swallowed(self):
+        reg = ExtensionRegistry()
+
+        class Crasher(RobotocorePlugin):
+            name = "crasher"
+
+            def on_request(self, request, context):
+                raise RuntimeError("crash!")
+
+        reg.register(Crasher())
+        req = MagicMock()
+        # Should not raise
+        result = reg.on_request(req, {})
+        assert result is req  # Original request returned
+
+
+class TestExtensionRegistryOnResponseHook:
+    def test_on_response_multiple_plugins_chain(self):
+        """Multiple plugins can each modify the response."""
+        reg = ExtensionRegistry()
+
+        class AddHeader1(RobotocorePlugin):
+            name = "header1"
+            priority = 10
+
+            def on_response(self, request, response, context):
+                response.headers["X-Plugin-1"] = "true"
+                return response
+
+        class AddHeader2(RobotocorePlugin):
+            name = "header2"
+            priority = 20
+
+            def on_response(self, request, response, context):
+                response.headers["X-Plugin-2"] = "true"
+                return response
+
+        reg.register(AddHeader1())
+        reg.register(AddHeader2())
+
+        response = Response(content="ok")
+        result = reg.on_response(MagicMock(), response, {})
+        assert result.headers.get("X-Plugin-1") == "true"
+        assert result.headers.get("X-Plugin-2") == "true"
+
+
+class TestExtensionRegistryOnShutdownError:
+    def test_on_shutdown_error_doesnt_crash(self):
+        reg = ExtensionRegistry()
+
+        class Crasher(RobotocorePlugin):
+            name = "crasher"
+
+            def on_shutdown(self):
+                raise RuntimeError("shutdown crash")
+
+        reg.register(Crasher())
+        # Should not raise
+        reg.on_shutdown()
+
+    def test_on_shutdown_error_doesnt_prevent_other_plugins(self):
+        order = []
+        reg = ExtensionRegistry()
+
+        class Good(RobotocorePlugin):
+            name = "good"
+            priority = 20
+
+            def on_shutdown(self):
+                order.append("good")
+
+        class Bad(RobotocorePlugin):
+            name = "bad"
+            priority = 10  # runs second in reverse order since priority=10 < 20
+
+            def on_shutdown(self):
+                order.append("bad")
+                raise RuntimeError("crash")
+
+        reg.register(Good())
+        reg.register(Bad())
+        reg.on_shutdown()
+        # Both should have been called (reverse order: good first since higher priority)
+        assert "good" in order
+        assert "bad" in order
+
+
+class TestExtensionRegistryGetCustomRoutes:
+    def test_empty_registry_returns_no_routes(self):
+        reg = ExtensionRegistry()
+        assert reg.get_custom_routes() == []
+
+    def test_multiple_plugins_routes_merged(self):
+        reg = ExtensionRegistry()
+
+        class Plugin1(RobotocorePlugin):
+            name = "p1"
+
+            def get_custom_routes(self):
+                return [("/_ext/p1/status", "GET", lambda: "ok")]
+
+        class Plugin2(RobotocorePlugin):
+            name = "p2"
+
+            def get_custom_routes(self):
+                return [
+                    ("/_ext/p2/a", "GET", lambda: "a"),
+                    ("/_ext/p2/b", "POST", lambda: "b"),
+                ]
+
+        reg.register(Plugin1())
+        reg.register(Plugin2())
+        routes = reg.get_custom_routes()
+        assert len(routes) == 3
+        paths = [r[0] for r in routes]
+        assert "/_ext/p1/status" in paths
+        assert "/_ext/p2/a" in paths
+        assert "/_ext/p2/b" in paths
+
+    def test_plugin_route_error_handled(self):
+        reg = ExtensionRegistry()
+
+        class BadRoutes(RobotocorePlugin):
+            name = "bad-routes"
+
+            def get_custom_routes(self):
+                raise RuntimeError("route error")
+
+        reg.register(BadRoutes())
+        # Should not raise, just returns empty
+        routes = reg.get_custom_routes()
+        assert routes == []

--- a/tests/unit/test_fault_rules_advanced.py
+++ b/tests/unit/test_fault_rules_advanced.py
@@ -1,0 +1,258 @@
+"""Advanced tests for fault rules: regex matching, probability, thread safety,
+serialization roundtrip, store operations."""
+
+import threading
+
+import pytest
+
+from robotocore.chaos.fault_rules import FaultRule, FaultRuleStore, get_fault_store
+
+
+class TestFaultRuleRegexMatching:
+    def test_regex_operation_pattern(self):
+        rule = FaultRule(service="s3", operation="Put.*", error_code="InternalError")
+        assert rule.matches("s3", "PutObject", "us-east-1") is True
+        assert rule.matches("s3", "PutBucketPolicy", "us-east-1") is True
+        assert rule.matches("s3", "GetObject", "us-east-1") is False
+
+    def test_regex_partial_match(self):
+        """Regex uses search(), so partial matches work."""
+        rule = FaultRule(service="s3", operation="Item", error_code="Err")
+        assert rule.matches("s3", "PutItem", "us-east-1") is True
+        assert rule.matches("s3", "GetItem", "us-east-1") is True
+        assert rule.matches("s3", "CreateTable", "us-east-1") is False
+
+    def test_invalid_regex_raises(self):
+        with pytest.raises(ValueError, match="Invalid regex"):
+            FaultRule(operation="[invalid")
+
+    def test_no_operation_pattern_matches_any_operation(self):
+        rule = FaultRule(service="s3", error_code="Err")
+        assert rule.matches("s3", "PutObject", "us-east-1") is True
+        assert rule.matches("s3", "GetObject", "us-east-1") is True
+        assert rule.matches("s3", None, "us-east-1") is True
+
+    def test_operation_pattern_with_no_operation_in_request(self):
+        """If rule has operation pattern but request has no operation, no match."""
+        rule = FaultRule(service="s3", operation="Put.*", error_code="Err")
+        assert rule.matches("s3", None, "us-east-1") is False
+
+
+class TestFaultRuleProbability:
+    def test_probability_zero_never_matches(self):
+        rule = FaultRule(service="s3", probability=0.0, error_code="Err")
+        matches = sum(1 for _ in range(100) if rule.matches("s3", "Put", "us-east-1"))
+        assert matches == 0
+
+    def test_probability_one_always_matches(self):
+        rule = FaultRule(service="s3", probability=1.0, error_code="Err")
+        matches = sum(1 for _ in range(100) if rule.matches("s3", "Put", "us-east-1"))
+        assert matches == 100
+
+    def test_probability_clamped_above_one(self):
+        rule = FaultRule(probability=1.5)
+        assert rule.probability == 1.0
+
+    def test_probability_clamped_below_zero(self):
+        rule = FaultRule(probability=-0.5)
+        assert rule.probability == 0.0
+
+
+class TestFaultRuleDisabled:
+    def test_disabled_rule_never_matches(self):
+        rule = FaultRule(service="s3", error_code="Err", enabled=False)
+        assert rule.matches("s3", "Put", "us-east-1") is False
+
+    def test_enable_disable_toggle(self):
+        rule = FaultRule(service="s3", error_code="Err", enabled=True)
+        assert rule.matches("s3", "Put", "us-east-1") is True
+        rule.enabled = False
+        assert rule.matches("s3", "Put", "us-east-1") is False
+        rule.enabled = True
+        assert rule.matches("s3", "Put", "us-east-1") is True
+
+
+class TestFaultRuleMatchCount:
+    def test_match_count_increments(self):
+        rule = FaultRule(service="s3", error_code="Err")
+        assert rule.match_count == 0
+        rule.matches("s3", "Put", "us-east-1")
+        assert rule.match_count == 1
+        rule.matches("s3", "Get", "us-east-1")
+        assert rule.match_count == 2
+
+    def test_non_match_does_not_increment(self):
+        rule = FaultRule(service="s3", error_code="Err")
+        rule.matches("dynamodb", "Put", "us-east-1")
+        assert rule.match_count == 0
+
+
+class TestFaultRuleSerializationRoundtrip:
+    def test_to_dict_and_from_dict(self):
+        original = FaultRule(
+            rule_id="test-123",
+            service="s3",
+            operation="Put.*",
+            region="us-west-2",
+            error_code="ThrottlingException",
+            error_message="slow down",
+            status_code=429,
+            latency_ms=200,
+            probability=0.5,
+            enabled=True,
+        )
+        d = original.to_dict()
+        restored = FaultRule.from_dict(d)
+
+        assert restored.rule_id == "test-123"
+        assert restored.service == "s3"
+        assert restored.operation == "Put.*"
+        assert restored.region == "us-west-2"
+        assert restored.error_code == "ThrottlingException"
+        assert restored.error_message == "slow down"
+        assert restored.status_code == 429
+        assert restored.latency_ms == 200
+        assert restored.probability == 0.5
+        assert restored.enabled is True
+
+    def test_from_dict_preserves_timestamps(self):
+        d = {
+            "rule_id": "abc",
+            "service": "s3",
+            "created_at": 1000.0,
+            "match_count": 42,
+        }
+        rule = FaultRule.from_dict(d)
+        assert rule.created_at == 1000.0
+        assert rule.match_count == 42
+
+    def test_from_dict_defaults(self):
+        rule = FaultRule.from_dict({})
+        assert rule.latency_ms == 0
+        assert rule.probability == 1.0
+        assert rule.enabled is True
+
+
+class TestFaultRuleDefaultStatusCode:
+    def test_throttling_gets_429(self):
+        rule = FaultRule(error_code="ThrottlingException")
+        assert rule.status_code == 429
+
+    def test_other_error_gets_500(self):
+        rule = FaultRule(error_code="InternalError")
+        assert rule.status_code == 500
+
+    def test_no_error_code_gets_500(self):
+        rule = FaultRule()
+        assert rule.status_code == 500
+
+    def test_explicit_status_code_overrides(self):
+        rule = FaultRule(error_code="ThrottlingException", status_code=503)
+        assert rule.status_code == 503
+
+
+class TestFaultRuleStoreThreadSafety:
+    def test_concurrent_add_and_find(self):
+        store = FaultRuleStore()
+        errors = []
+
+        def add_rules():
+            try:
+                for i in range(50):
+                    store.add(
+                        FaultRule(
+                            service=f"svc-{i}",
+                            error_code="Err",
+                        )
+                    )
+            except Exception as e:
+                errors.append(e)
+
+        def find_rules():
+            try:
+                for _ in range(50):
+                    store.find_matching("svc-0", "Op", "us-east-1")
+            except Exception as e:
+                errors.append(e)
+
+        t1 = threading.Thread(target=add_rules)
+        t2 = threading.Thread(target=find_rules)
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+        assert not errors
+
+    def test_concurrent_add_and_remove(self):
+        store = FaultRuleStore()
+        errors = []
+        ids = []
+
+        def add_rules():
+            try:
+                for i in range(50):
+                    rid = store.add(
+                        FaultRule(
+                            rule_id=f"rule-{i}",
+                            service="s3",
+                            error_code="Err",
+                        )
+                    )
+                    ids.append(rid)
+            except Exception as e:
+                errors.append(e)
+
+        def remove_rules():
+            try:
+                for i in range(50):
+                    store.remove(f"rule-{i}")
+            except Exception as e:
+                errors.append(e)
+
+        t1 = threading.Thread(target=add_rules)
+        t2 = threading.Thread(target=remove_rules)
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+        assert not errors
+
+
+class TestFaultRuleStoreOperations:
+    def test_clear_returns_count(self):
+        store = FaultRuleStore()
+        store.add(FaultRule(service="s3", error_code="Err"))
+        store.add(FaultRule(service="sqs", error_code="Err"))
+        count = store.clear()
+        assert count == 2
+        assert store.list_rules() == []
+
+    def test_clear_empty_store(self):
+        store = FaultRuleStore()
+        assert store.clear() == 0
+
+    def test_remove_nonexistent(self):
+        store = FaultRuleStore()
+        assert store.remove("nonexistent") is False
+
+    def test_find_matching_returns_first(self):
+        """When multiple rules match, the first one wins."""
+        store = FaultRuleStore()
+        store.add(FaultRule(rule_id="first", service="s3", error_code="Err1"))
+        store.add(FaultRule(rule_id="second", service="s3", error_code="Err2"))
+        rule = store.find_matching("s3", "Put", "us-east-1")
+        assert rule is not None
+        assert rule.rule_id == "first"
+
+    def test_find_matching_no_match(self):
+        store = FaultRuleStore()
+        store.add(FaultRule(service="sqs", error_code="Err"))
+        result = store.find_matching("s3", "Put", "us-east-1")
+        assert result is None
+
+
+class TestFaultRuleStoreGlobalSingleton:
+    def test_get_fault_store_returns_same_instance(self):
+        s1 = get_fault_store()
+        s2 = get_fault_store()
+        assert s1 is s2

--- a/tests/unit/test_handler_chain_advanced.py
+++ b/tests/unit/test_handler_chain_advanced.py
@@ -1,0 +1,203 @@
+"""Advanced handler chain tests: exception handler failures,
+nested exceptions, context state mutations, chained stopping."""
+
+from unittest.mock import MagicMock
+
+from starlette.responses import Response
+
+from robotocore.gateway.handler_chain import HandlerChain, RequestContext
+
+
+def _make_context(**kwargs):
+    request = MagicMock()
+    return RequestContext(
+        request=request,
+        service_name=kwargs.get("service", "s3"),
+        operation=kwargs.get("operation"),
+        region=kwargs.get("region", "us-east-1"),
+    )
+
+
+class TestExceptionHandlerEdgeCases:
+    def test_exception_handler_itself_throws(self):
+        """If an exception handler throws, it should be caught and logged."""
+
+        def bad_handler(ctx):
+            raise ValueError("original error")
+
+        def crashing_exc_handler(ctx, exc):
+            raise RuntimeError("handler crashed too")
+
+        def good_exc_handler(ctx, exc):
+            ctx.response = Response(content="recovered")
+
+        chain = HandlerChain()
+        chain.request_handlers = [bad_handler]
+        chain.exception_handlers = [crashing_exc_handler, good_exc_handler]
+        ctx = _make_context()
+        chain.handle(ctx)
+        # Good handler should still have run despite crashing handler
+        assert ctx.response is not None
+        assert ctx.response.body == b"recovered"
+
+    def test_all_exception_handlers_crash_reraises_original(self):
+        """If all exception handlers fail and no response is set, original exc propagates."""
+
+        def bad_handler(ctx):
+            raise ValueError("original")
+
+        def crash1(ctx, exc):
+            raise RuntimeError("crash1")
+
+        def crash2(ctx, exc):
+            raise RuntimeError("crash2")
+
+        chain = HandlerChain()
+        chain.request_handlers = [bad_handler]
+        chain.exception_handlers = [crash1, crash2]
+        ctx = _make_context()
+        try:
+            chain.handle(ctx)
+            assert False, "Should have raised"
+        except ValueError as e:
+            assert str(e) == "original"
+
+    def test_exception_handler_sets_response_stops_reraise(self):
+        """If an exception handler sets response, the original exception is NOT re-raised."""
+
+        def bad_handler(ctx):
+            raise ValueError("error")
+
+        def exc_handler(ctx, exc):
+            ctx.response = Response(content=f"caught: {exc}")
+
+        chain = HandlerChain()
+        chain.request_handlers = [bad_handler]
+        chain.exception_handlers = [exc_handler]
+        ctx = _make_context()
+        chain.handle(ctx)
+        assert ctx.response is not None
+        assert b"caught: error" in ctx.response.body
+
+
+class TestHandlerChainContextMutation:
+    def test_handlers_can_modify_context_fields(self):
+        """Request handlers can modify context fields for downstream handlers."""
+
+        def set_operation(ctx):
+            ctx.operation = "PutObject"
+
+        def check_operation(ctx):
+            assert ctx.operation == "PutObject"
+            ctx.response = Response(content="ok")
+
+        chain = HandlerChain()
+        chain.request_handlers = [set_operation, check_operation]
+        ctx = _make_context()
+        chain.handle(ctx)
+        assert ctx.operation == "PutObject"
+
+    def test_parsed_request_dict_mutated(self):
+        """Handlers can populate parsed_request for downstream use."""
+
+        def parser(ctx):
+            ctx.parsed_request = {"Action": "CreateBucket", "Bucket": "test"}
+
+        def checker(ctx):
+            assert ctx.parsed_request["Action"] == "CreateBucket"
+            ctx.response = Response(content="ok")
+
+        chain = HandlerChain()
+        chain.request_handlers = [parser, checker]
+        ctx = _make_context()
+        chain.handle(ctx)
+        assert ctx.parsed_request["Bucket"] == "test"
+
+
+class TestHandlerChainStoppingBehavior:
+    def test_first_handler_sets_response_stops_all(self):
+        order = []
+
+        def h1(ctx):
+            order.append(1)
+            ctx.response = Response(content="h1")
+
+        def h2(ctx):
+            order.append(2)
+
+        def h3(ctx):
+            order.append(3)
+
+        chain = HandlerChain()
+        chain.request_handlers = [h1, h2, h3]
+        ctx = _make_context()
+        chain.handle(ctx)
+        assert order == [1]
+
+    def test_middle_handler_sets_response(self):
+        order = []
+
+        def h1(ctx):
+            order.append(1)
+
+        def h2(ctx):
+            order.append(2)
+            ctx.response = Response(content="h2")
+
+        def h3(ctx):
+            order.append(3)
+
+        chain = HandlerChain()
+        chain.request_handlers = [h1, h2, h3]
+        ctx = _make_context()
+        chain.handle(ctx)
+        assert order == [1, 2]
+
+    def test_exception_in_second_handler_stops_chain(self):
+        order = []
+
+        def h1(ctx):
+            order.append(1)
+
+        def h2(ctx):
+            order.append(2)
+            raise RuntimeError("boom")
+
+        def h3(ctx):
+            order.append(3)
+
+        def exc_handler(ctx, exc):
+            ctx.response = Response(content="error")
+
+        chain = HandlerChain()
+        chain.request_handlers = [h1, h2, h3]
+        chain.exception_handlers = [exc_handler]
+        ctx = _make_context()
+        chain.handle(ctx)
+        assert order == [1, 2]  # h3 never ran
+
+
+class TestRequestContextDefaults:
+    def test_custom_account_id(self):
+        ctx = RequestContext(
+            request=MagicMock(),
+            service_name="iam",
+            account_id="999999999999",
+        )
+        assert ctx.account_id == "999999999999"
+
+    def test_custom_region(self):
+        ctx = RequestContext(
+            request=MagicMock(),
+            service_name="s3",
+            region="eu-west-1",
+        )
+        assert ctx.region == "eu-west-1"
+
+    def test_custom_protocol(self):
+        ctx = RequestContext(
+            request=MagicMock(),
+            service_name="s3",
+            protocol="rest-xml",
+        )
+        assert ctx.protocol == "rest-xml"

--- a/tests/unit/test_resource_browser_advanced.py
+++ b/tests/unit/test_resource_browser_advanced.py
@@ -1,0 +1,160 @@
+"""Advanced tests for the resource browser: get_resource_counts, generic fallback,
+list-type collections, error handling in resource iteration."""
+
+from unittest.mock import MagicMock, patch
+
+from robotocore.resources.browser import (
+    RESOURCE_ATTRS,
+    _get_backend,
+    get_resource_counts,
+    get_service_resources,
+)
+
+
+class TestGetResourceCounts:
+    @patch("robotocore.resources.browser._get_backend")
+    def test_counts_resources_across_services(self, mock_backend_fn):
+        """Verify get_resource_counts aggregates counts from mapped services."""
+        bucket1 = MagicMock()
+        bucket2 = MagicMock()
+        s3_backend = MagicMock()
+        s3_backend.buckets = {"b1": bucket1, "b2": bucket2}
+
+        queue = MagicMock()
+        sqs_backend = MagicMock()
+        sqs_backend.queues = {"q1": queue}
+
+        def _backend(svc, account_id="123456789012"):
+            if svc == "s3":
+                return s3_backend
+            if svc == "sqs":
+                return sqs_backend
+            return None
+
+        mock_backend_fn.side_effect = _backend
+
+        counts = get_resource_counts()
+        assert counts.get("s3") == 2
+        assert counts.get("sqs") == 1
+
+    @patch("robotocore.resources.browser._get_backend")
+    def test_zero_count_services_excluded(self, mock_backend_fn):
+        """Services with zero resources should not appear in counts."""
+        backend = MagicMock()
+        backend.buckets = {}  # empty
+        mock_backend_fn.return_value = backend
+
+        counts = get_resource_counts()
+        assert "s3" not in counts
+
+    @patch("robotocore.resources.browser._get_backend")
+    def test_none_backend_skipped(self, mock_backend_fn):
+        mock_backend_fn.return_value = None
+        counts = get_resource_counts()
+        assert counts == {}
+
+    @patch("robotocore.resources.browser._get_backend")
+    def test_multiple_attrs_per_service_summed(self, mock_backend_fn):
+        """IAM has roles, users, policies — all should be summed."""
+        backend = MagicMock()
+        backend.roles = {"r1": MagicMock()}
+        backend.users = {"u1": MagicMock(), "u2": MagicMock()}
+        backend.policies = {"p1": MagicMock()}
+        mock_backend_fn.return_value = backend
+
+        counts = get_resource_counts()
+        assert counts.get("iam") == 4  # 1 role + 2 users + 1 policy
+
+    @patch("robotocore.resources.browser._get_backend")
+    def test_attr_with_no_len_skipped(self, mock_backend_fn):
+        """If an attribute doesn't support len(), it should be skipped gracefully."""
+        backend = MagicMock()
+        backend.buckets = MagicMock()
+        backend.buckets.__len__ = MagicMock(side_effect=TypeError("no len"))
+        mock_backend_fn.return_value = backend
+
+        # Should not raise
+        counts = get_resource_counts()
+        assert "s3" not in counts
+
+
+class TestGetServiceResourcesGenericFallback:
+    @patch("robotocore.resources.browser._get_backend")
+    def test_unmapped_service_uses_generic_heuristic(self, mock_backend_fn):
+        """Services not in RESOURCE_ATTRS should use the generic dict-scanning fallback."""
+
+        class FakeBackend:
+            widgets = {"w1": "widget1", "w2": "widget2"}
+            _private = {"hidden": True}
+
+        mock_backend_fn.return_value = FakeBackend()
+
+        # Use a service name not in RESOURCE_ATTRS
+        assert "acm" not in RESOURCE_ATTRS
+        resources = get_service_resources("acm")
+        # The generic fallback should find the "widgets" dict
+        assert any(r["type"] == "widgets" for r in resources)
+        widget_entry = [r for r in resources if r["type"] == "widgets"][0]
+        assert widget_entry["count"] == 2
+
+    @patch("robotocore.resources.browser._get_backend")
+    def test_list_type_collection(self, mock_backend_fn):
+        """Collections that are lists (not dicts) should also be iterable."""
+        item1 = MagicMock()
+        item1.name = "item-1"
+        item1.arn = "arn:aws:sqs:us-east-1:123:item-1"
+        item2 = MagicMock()
+        item2.name = "item-2"
+        item2.arn = "arn:aws:sqs:us-east-1:123:item-2"
+        backend = MagicMock()
+        backend.queues = [item1, item2]  # list, not dict
+        mock_backend_fn.return_value = backend
+
+        resources = get_service_resources("sqs")
+        assert len(resources) == 2
+        names = {r["name"] for r in resources}
+        assert "item-1" in names
+        assert "item-2" in names
+
+
+class TestGetBackend:
+    @patch("moto.backends.get_backend")
+    def test_returns_none_on_exception(self, mock_get_backend):
+        mock_get_backend.side_effect = Exception("backend error")
+        result = _get_backend("nonexistent")
+        assert result is None
+
+    @patch("moto.backends.get_backend")
+    def test_returns_none_for_unknown_account(self, mock_get_backend):
+        from moto.core.base_backend import BackendDict
+
+        bd = MagicMock(spec=BackendDict)
+        bd.__contains__ = MagicMock(return_value=False)
+        mock_get_backend.return_value = bd
+        result = _get_backend("s3", account_id="999999999999")
+        assert result is None
+
+
+class TestResourceAttrsCoverage:
+    def test_all_listed_services_have_string_attrs(self):
+        for service, attrs in RESOURCE_ATTRS.items():
+            assert isinstance(service, str)
+            for attr_name, type_name in attrs:
+                assert isinstance(attr_name, str)
+                assert isinstance(type_name, str)
+                assert len(type_name) > 0
+
+    def test_core_services_covered(self):
+        core = ["s3", "sqs", "dynamodb", "lambda", "iam", "ec2", "ecs", "kinesis"]
+        for svc in core:
+            assert svc in RESOURCE_ATTRS, f"Core service {svc} missing from RESOURCE_ATTRS"
+
+    def test_ec2_has_instances_and_vpcs(self):
+        attrs = dict(RESOURCE_ATTRS["ec2"])
+        assert "instances" in attrs
+        assert "vpcs" in attrs
+
+    def test_rds_has_databases_and_clusters(self):
+        attrs = dict(RESOURCE_ATTRS["rds"])
+        assert "databases" in attrs
+        assert "clusters" in attrs

--- a/tests/unit/test_state_manager_advanced.py
+++ b/tests/unit/test_state_manager_advanced.py
@@ -1,0 +1,210 @@
+"""Advanced tests for state manager: snapshots, compression, export/import bytes,
+path traversal protection, restore_on_startup, and find_latest_snapshot."""
+
+import os
+import tarfile
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from robotocore.state.manager import StateManager
+
+
+class TestCompressedSave:
+    def test_save_compressed_creates_archive(self, tmp_path):
+        mgr = StateManager(state_dir=str(tmp_path))
+        mgr.register_native_handler("svc", lambda: {"k": "v"}, lambda d: None)
+        result = mgr.save(name="compressed-snap", compress=True)
+        assert result.endswith(".tar.gz")
+        assert Path(result).exists()
+        # The uncompressed directory should have been cleaned up
+        assert not (tmp_path / "snapshots" / "compressed-snap").exists()
+
+    def test_compressed_archive_contains_files(self, tmp_path):
+        mgr = StateManager(state_dir=str(tmp_path))
+        mgr.register_native_handler("svc", lambda: {"data": 1}, lambda d: None)
+        result = mgr.save(name="check-contents", compress=True)
+        with tarfile.open(result, "r:gz") as tar:
+            names = tar.getnames()
+        assert "metadata.json" in names
+        assert "native_state.json" in names
+        assert "moto_state.pkl" in names
+
+    def test_load_compressed_snapshot(self, tmp_path):
+        loaded = {}
+        mgr = StateManager(state_dir=str(tmp_path))
+        mgr.register_native_handler("svc", lambda: {"val": 42}, lambda d: loaded.update(d))
+        mgr.save(name="load-compressed", compress=True)
+        # Clear and reload
+        loaded.clear()
+        success = mgr.load(name="load-compressed")
+        assert success is True
+        assert loaded.get("val") == 42
+
+    def test_list_snapshots_includes_compressed(self, tmp_path):
+        mgr = StateManager(state_dir=str(tmp_path))
+        mgr.save(name="dir-snap")
+        mgr.save(name="gz-snap", compress=True)
+        snaps = mgr.list_snapshots()
+        names = {s["name"] for s in snaps}
+        assert "dir-snap" in names
+        assert "gz-snap" in names
+        compressed_flags = {s["name"]: s["compressed"] for s in snaps}
+        assert compressed_flags["dir-snap"] is False
+        assert compressed_flags["gz-snap"] is True
+
+
+class TestExportImportSnapshotBytes:
+    def test_export_current_state_as_bytes(self, tmp_path):
+        mgr = StateManager(state_dir=str(tmp_path))
+        mgr.register_native_handler("svc", lambda: {"x": 1}, lambda d: None)
+        data = mgr.export_snapshot_bytes()
+        assert isinstance(data, bytes)
+        assert len(data) > 0
+        # Should be valid tar.gz
+        import io
+
+        with tarfile.open(fileobj=io.BytesIO(data), mode="r:gz") as tar:
+            assert "metadata.json" in tar.getnames()
+
+    def test_export_named_snapshot_directory(self, tmp_path):
+        mgr = StateManager(state_dir=str(tmp_path))
+        mgr.save(name="exportable")
+        data = mgr.export_snapshot_bytes(name="exportable")
+        assert isinstance(data, bytes)
+        assert len(data) > 0
+
+    def test_export_named_snapshot_compressed(self, tmp_path):
+        mgr = StateManager(state_dir=str(tmp_path))
+        mgr.save(name="exportable-gz", compress=True)
+        data = mgr.export_snapshot_bytes(name="exportable-gz")
+        assert isinstance(data, bytes)
+        assert len(data) > 0
+
+    def test_export_nonexistent_snapshot_raises(self, tmp_path):
+        mgr = StateManager(state_dir=str(tmp_path))
+        with pytest.raises(ValueError, match="not found"):
+            mgr.export_snapshot_bytes(name="nonexistent")
+
+    def test_import_bytes_creates_snapshot(self, tmp_path):
+        mgr = StateManager(state_dir=str(tmp_path))
+        mgr.register_native_handler("svc", lambda: {"a": 1}, lambda d: None)
+        data = mgr.export_snapshot_bytes()
+
+        mgr2 = StateManager(state_dir=str(tmp_path / "import-dest"))
+        mgr2.register_native_handler("svc", lambda: {}, lambda d: None)
+        name = mgr2.import_snapshot_bytes(data, name="imported", load_after_import=False)
+        assert name == "imported"
+        snaps = mgr2.list_snapshots()
+        assert any(s["name"] == "imported" for s in snaps)
+
+    def test_import_bytes_loads_by_default(self, tmp_path):
+        loaded = {}
+        mgr = StateManager(state_dir=str(tmp_path))
+        mgr.register_native_handler("svc", lambda: {"val": 99}, lambda d: None)
+        data = mgr.export_snapshot_bytes()
+
+        mgr2 = StateManager(state_dir=str(tmp_path / "dest"))
+        mgr2.register_native_handler("svc", lambda: {}, lambda d: loaded.update(d))
+        mgr2.import_snapshot_bytes(data, name="auto-load")
+        assert loaded.get("val") == 99
+
+    def test_import_bytes_no_state_dir_raises(self):
+        mgr = StateManager()
+        with pytest.raises(ValueError, match="No state directory"):
+            mgr.import_snapshot_bytes(b"data")
+
+    def test_import_uses_metadata_name(self, tmp_path):
+        mgr = StateManager(state_dir=str(tmp_path))
+        mgr.register_native_handler("svc", lambda: {}, lambda d: None)
+        mgr.save(name="meta-name")
+        data = mgr.export_snapshot_bytes(name="meta-name")
+
+        mgr2 = StateManager(state_dir=str(tmp_path / "dest"))
+        mgr2.register_native_handler("svc", lambda: {}, lambda d: None)
+        name = mgr2.import_snapshot_bytes(data, load_after_import=False)
+        assert name == "meta-name"
+
+
+class TestPathTraversal:
+    def test_save_path_traversal_rejected(self, tmp_path):
+        mgr = StateManager(state_dir=str(tmp_path))
+        with pytest.raises(ValueError, match="path traversal"):
+            mgr.save(name="../../etc/passwd")
+
+    def test_load_path_traversal_rejected(self, tmp_path):
+        mgr = StateManager(state_dir=str(tmp_path))
+        with pytest.raises(ValueError, match="path traversal"):
+            mgr.load(name="../../etc/passwd")
+
+
+class TestRestoreOnStartup:
+    def test_no_env_var_does_nothing(self, tmp_path):
+        mgr = StateManager(state_dir=str(tmp_path))
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("ROBOTOCORE_RESTORE_SNAPSHOT", None)
+            result = mgr.restore_on_startup()
+        assert result is False
+
+    def test_env_var_triggers_restore(self, tmp_path):
+        loaded = {}
+        mgr = StateManager(state_dir=str(tmp_path))
+        mgr.register_native_handler("svc", lambda: {"k": "v"}, lambda d: loaded.update(d))
+        mgr.save(name="auto-snap")
+
+        with patch.dict(os.environ, {"ROBOTOCORE_RESTORE_SNAPSHOT": "auto-snap"}):
+            result = mgr.restore_on_startup()
+        assert result is True
+        assert loaded.get("k") == "v"
+
+    def test_env_var_missing_snapshot(self, tmp_path):
+        mgr = StateManager(state_dir=str(tmp_path))
+        with patch.dict(os.environ, {"ROBOTOCORE_RESTORE_SNAPSHOT": "nonexistent"}):
+            result = mgr.restore_on_startup()
+        assert result is False
+
+
+class TestFindLatestSnapshot:
+    def test_latest_by_timestamp(self, tmp_path):
+        mgr = StateManager(state_dir=str(tmp_path))
+        mgr.save(name="first")
+        time.sleep(0.05)  # Ensure different saved_at
+        mgr.save(name="second")
+        name = mgr._find_latest_snapshot()
+        assert name == "second"
+
+    def test_latest_no_snapshots(self, tmp_path):
+        mgr = StateManager(state_dir=str(tmp_path))
+        assert mgr._find_latest_snapshot() is None
+
+    def test_load_latest_resolves(self, tmp_path):
+        loaded = {}
+        mgr = StateManager(state_dir=str(tmp_path))
+        mgr.register_native_handler("svc", lambda: {"v": 1}, lambda d: loaded.update(d))
+        mgr.save(name="old")
+        time.sleep(0.05)
+        mgr.register_native_handler("svc", lambda: {"v": 2}, lambda d: loaded.update(d))
+        mgr.save(name="new")
+
+        loaded.clear()
+        success = mgr.load(name="latest")
+        assert success is True
+        assert loaded.get("v") == 2
+
+
+class TestSelectiveLoad:
+    def test_load_specific_services_only(self, tmp_path):
+        loaded_svc1 = {}
+        loaded_svc2 = {}
+        mgr = StateManager(state_dir=str(tmp_path))
+        mgr.register_native_handler("svc1", lambda: {"a": 1}, lambda d: loaded_svc1.update(d))
+        mgr.register_native_handler("svc2", lambda: {"b": 2}, lambda d: loaded_svc2.update(d))
+        mgr.save()
+
+        loaded_svc1.clear()
+        loaded_svc2.clear()
+        mgr.load(services=["svc1"])
+        assert loaded_svc1.get("a") == 1
+        assert loaded_svc2 == {}  # svc2 not loaded


### PR DESCRIPTION
## Summary
- Adds **120 new unit tests** across 8 test files covering infrastructure features with thin test coverage
- Covers state manager (compressed snapshots, export/import bytes, path traversal, restore_on_startup), resource browser (get_resource_counts, generic fallback), audit log (thread safety), init hooks (script execution), tracing middleware, extensions (directory/env discovery, lifecycle error handling), handler chain (exception handler failures), and fault rules (regex, probability, thread safety, serialization)
- All tests pass, full suite green (5139 passed)

## Test plan
- [x] All 120 new tests pass individually
- [x] Full unit test suite passes (5139 passed, 0 failures)
- [x] Ruff lint and format clean
- [x] Every test asserts something meaningful (no mock-everything tests)
- [x] Thread safety tests use real threading with error collection


🤖 Generated with [Claude Code](https://claude.com/claude-code)