### PR TITLE
Add runtime config updates via POST /_robotocore/config

### DIFF
--- a/prompts/20260310-0800-runtime-config.md
+++ b/prompts/20260310-0800-runtime-config.md
@@ -1,0 +1,30 @@
+---
+session: "agent-a108699b"
+timestamp: "2026-03-10T08:00:00Z"
+model: claude-opus-4-6
+---
+
+## Human
+
+Implement runtime configuration updates for robotocore. Allow POST to
+`/_robotocore/config` to change settings live without restarting. Whitelist
+of mutable settings (LOG_LEVEL, DEBUG, ENFORCE_IAM, AUDIT_LOG_SIZE, etc.).
+Gate behind ENABLE_CONFIG_UPDATES=1. Include change history tracking,
+propagation to subsystems, and DELETE to reset overrides.
+
+## Assistant
+
+Created `src/robotocore/config/runtime.py` with a `RuntimeConfig` class
+that tracks mutable runtime overrides separately from env vars. Settings
+are whitelisted -- only 8 safe settings can be changed at runtime. Changes
+propagate to subsystems (e.g. LOG_LEVEL updates the root logger). Change
+history is recorded with timestamps and old/new values.
+
+Enhanced the existing GET `/_robotocore/config` endpoint to read from
+RuntimeConfig and return detailed settings with source info (env/runtime/default).
+Added POST method to the same route for updating settings, and a new
+DELETE `/_robotocore/config/{key}` route for resetting overrides.
+
+Tests written first: 20 unit tests for RuntimeConfig class behavior,
+7 semantic integration tests for HTTP endpoints via Starlette TestClient.
+All 27 tests pass.

--- a/src/robotocore/config/runtime.py
+++ b/src/robotocore/config/runtime.py
@@ -1,0 +1,173 @@
+"""Runtime configuration management.
+
+Allows updating a whitelisted set of configuration settings at runtime
+via the ``/_robotocore/config`` management endpoint, without restarting
+the server.
+
+Gated behind ``ENABLE_CONFIG_UPDATES=1`` for safety.
+"""
+
+import logging
+import os
+import time
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Whitelist of settings that can be changed at runtime.
+# Maps setting name -> description for documentation.
+# ---------------------------------------------------------------------------
+MUTABLE_SETTINGS: dict[str, str] = {
+    "LOG_LEVEL": "Root log verbosity (DEBUG, INFO, WARNING, ERROR)",
+    "DEBUG": "Enable/disable debug mode (0 or 1)",
+    "ENFORCE_IAM": "Toggle IAM policy enforcement (0 or 1)",
+    "AUDIT_LOG_SIZE": "Maximum entries in the audit ring buffer",
+    "SQS_DELAY_PURGE_RETRY": "Toggle SQS purge delay retry behavior (0 or 1)",
+    "SQS_DELAY_RECENTLY_DELETED": "Toggle SQS recently-deleted delay (0 or 1)",
+    "DYNAMODB_REMOVE_EXPIRED_ITEMS": "Toggle DynamoDB TTL item removal (0 or 1)",
+    "USAGE_ANALYTICS": "Toggle usage analytics (0 or 1)",
+}
+
+
+def _apply_setting(key: str, value: str) -> None:
+    """Propagate a setting change to the relevant subsystem."""
+    if key == "LOG_LEVEL":
+        level = getattr(logging, value.upper(), None)
+        if level is not None:
+            logging.getLogger().setLevel(level)
+    elif key == "DEBUG":
+        if value == "1":
+            logging.getLogger().setLevel(logging.DEBUG)
+    elif key == "AUDIT_LOG_SIZE":
+        try:
+            from robotocore.audit.log import get_audit_log
+
+            get_audit_log().resize(int(value))
+        except (ImportError, ValueError):
+            pass
+
+
+class RuntimeConfig:
+    """Manages runtime configuration overrides.
+
+    Overrides sit above environment variables and profile values.
+    Only settings listed in ``MUTABLE_SETTINGS`` can be changed.
+    """
+
+    def __init__(self) -> None:
+        self._overrides: dict[str, str] = {}
+        self._history: list[dict[str, Any]] = {}  # type: ignore[assignment]
+        self._history = []
+        self.updates_enabled: bool = os.environ.get("ENABLE_CONFIG_UPDATES", "0") == "1"
+
+    # ------------------------------------------------------------------
+    # Core API
+    # ------------------------------------------------------------------
+
+    def get(self, key: str, default: str | None = None) -> str | None:
+        """Return the effective value for *key*.
+
+        Priority: runtime override > env var > *default*.
+        """
+        if key in self._overrides:
+            return self._overrides[key]
+        return os.environ.get(key, default)
+
+    def set(self, key: str, value: str) -> str | None:
+        """Set a runtime override for *key*, returning the old value.
+
+        Raises ``PermissionError`` if updates are disabled.
+        Raises ``ValueError`` if *key* is not in the whitelist.
+        """
+        if not self.updates_enabled:
+            raise PermissionError("Runtime config updates are disabled")
+        if key not in MUTABLE_SETTINGS:
+            raise ValueError(f"Setting {key} cannot be changed at runtime")
+
+        old_value = self.get(key)
+        self._overrides[key] = value
+
+        # Record history
+        self._history.append(
+            {
+                "key": key,
+                "old_value": old_value,
+                "new_value": value,
+                "timestamp": time.time(),
+            }
+        )
+
+        # Propagate the change
+        _apply_setting(key, value)
+        logger.info("Config updated: %s = %s (was %s)", key, value, old_value)
+        return old_value
+
+    def delete(self, key: str) -> str | None:
+        """Remove a runtime override for *key*, returning the old override value.
+
+        Returns ``None`` if there was no override.
+        """
+        old = self._overrides.pop(key, None)
+        if old is not None:
+            # Re-apply the env/default value so subsystems revert
+            env_val = os.environ.get(key)
+            if env_val is not None:
+                _apply_setting(key, env_val)
+            self._history.append(
+                {
+                    "key": key,
+                    "old_value": old,
+                    "new_value": None,
+                    "timestamp": time.time(),
+                    "action": "reset",
+                }
+            )
+            logger.info("Config reset: %s (was %s)", key, old)
+        return old
+
+    # ------------------------------------------------------------------
+    # Inspection API
+    # ------------------------------------------------------------------
+
+    def get_history(self) -> list[dict[str, Any]]:
+        """Return the full change history."""
+        return list(self._history)
+
+    def list_all(self) -> list[dict[str, Any]]:
+        """Return all mutable settings with current value, source, and mutability."""
+        result: list[dict[str, Any]] = []
+        for key, description in MUTABLE_SETTINGS.items():
+            if key in self._overrides:
+                value = self._overrides[key]
+                source = "runtime"
+            elif key in os.environ:
+                value = os.environ[key]
+                source = "env"
+            else:
+                value = None
+                source = "default"
+            result.append(
+                {
+                    "key": key,
+                    "value": value,
+                    "source": source,
+                    "mutable": True,
+                    "description": description,
+                }
+            )
+        return result
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton
+# ---------------------------------------------------------------------------
+_runtime_config: RuntimeConfig | None = None
+
+
+def get_runtime_config() -> RuntimeConfig:
+    """Return the global RuntimeConfig singleton."""
+    global _runtime_config  # noqa: PLW0603
+    if _runtime_config is None:
+        _runtime_config = RuntimeConfig()
+    return _runtime_config

--- a/src/robotocore/gateway/app.py
+++ b/src/robotocore/gateway/app.py
@@ -236,19 +236,67 @@ async def services_endpoint(request: Request) -> JSONResponse:
 
 
 async def config_endpoint(request: Request) -> JSONResponse:
-    """Return current Robotocore configuration."""
+    """Return current Robotocore configuration (GET) or update it (POST)."""
+    from robotocore.config.runtime import get_runtime_config
+
+    rt = get_runtime_config()
+
+    if request.method == "POST":
+        if not rt.updates_enabled:
+            return JSONResponse(
+                {"error": "Runtime config updates are disabled. Set ENABLE_CONFIG_UPDATES=1."},
+                status_code=403,
+            )
+        body = await request.body()
+        if not body:
+            return JSONResponse({"error": "No settings provided"}, status_code=400)
+        try:
+            updates = json.loads(body)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            return JSONResponse({"error": "Invalid JSON"}, status_code=400)
+
+        if not isinstance(updates, dict):
+            return JSONResponse({"error": "Expected JSON object"}, status_code=400)
+
+        results: dict[str, str] = {}
+        for key, value in updates.items():
+            try:
+                rt.set(key, str(value))
+                results[key] = str(value)
+            except ValueError as e:
+                return JSONResponse({"error": str(e)}, status_code=400)
+
+        return JSONResponse({"status": "updated", "updated": results})
+
+    # GET — return config with detailed settings
     native_count = sum(1 for s in SERVICE_REGISTRY.values() if s.status == ServiceStatus.NATIVE)
+    log_level = rt.get("LOG_LEVEL", "INFO")
+    debug_val = rt.get("DEBUG", "0")
     return JSONResponse(
         {
-            "enforce_iam": False,
+            "enforce_iam": rt.get("ENFORCE_IAM", "0") == "1",
             "persistence": os.environ.get("PERSISTENCE", "0") == "1",
-            "log_level": os.environ.get("LOG_LEVEL", "INFO").upper(),
-            "debug": os.environ.get("DEBUG", "0") == "1",
+            "log_level": (log_level or "INFO").upper(),
+            "debug": debug_val == "1",
             "region": os.environ.get("DEFAULT_REGION", "us-east-1"),
             "services_count": len(SERVICE_REGISTRY),
             "native_providers": native_count,
+            "updates_enabled": rt.updates_enabled,
+            "settings": rt.list_all(),
         }
     )
+
+
+async def config_delete_endpoint(request: Request) -> JSONResponse:
+    """Reset a runtime config override back to its original value."""
+    from robotocore.config.runtime import get_runtime_config
+
+    rt = get_runtime_config()
+    key = request.path_params["key"]
+    old = rt.delete(key)
+    if old is None:
+        return JSONResponse({"error": f"No runtime override for {key}"}, status_code=404)
+    return JSONResponse({"status": "reset", "key": key, "previous_value": old})
 
 
 async def save_state(request: Request) -> JSONResponse:
@@ -740,7 +788,8 @@ async def handle_connections_api(
 management_routes = [
     Route("/_robotocore/health", health, methods=["GET"]),
     Route("/_robotocore/services", services_endpoint, methods=["GET"]),
-    Route("/_robotocore/config", config_endpoint, methods=["GET"]),
+    Route("/_robotocore/config", config_endpoint, methods=["GET", "POST"]),
+    Route("/_robotocore/config/{key}", config_delete_endpoint, methods=["DELETE"]),
     Route("/_robotocore/state/save", save_state, methods=["POST"]),
     Route("/_robotocore/state/load", load_state, methods=["POST"]),
     Route("/_robotocore/state/snapshots", list_snapshots, methods=["GET"]),

--- a/tests/unit/config/test_runtime.py
+++ b/tests/unit/config/test_runtime.py
@@ -1,0 +1,169 @@
+"""Unit tests for RuntimeConfig."""
+
+import logging
+import os
+import time
+from unittest.mock import patch
+
+import pytest
+
+from robotocore.config.runtime import (
+    MUTABLE_SETTINGS,
+    RuntimeConfig,
+    get_runtime_config,
+)
+
+
+@pytest.fixture
+def config():
+    """Create a fresh RuntimeConfig for each test."""
+    return RuntimeConfig()
+
+
+@pytest.fixture
+def enabled_config():
+    """Create a RuntimeConfig with updates enabled."""
+    with patch.dict(os.environ, {"ENABLE_CONFIG_UPDATES": "1"}):
+        cfg = RuntimeConfig()
+        yield cfg
+
+
+class TestRuntimeConfigStorage:
+    def test_stores_overrides(self, config):
+        config._overrides["LOG_LEVEL"] = "DEBUG"
+        assert config._overrides["LOG_LEVEL"] == "DEBUG"
+
+    def test_get_returns_override_when_set(self, enabled_config):
+        enabled_config.set("LOG_LEVEL", "DEBUG")
+        assert enabled_config.get("LOG_LEVEL") == "DEBUG"
+
+    def test_get_returns_env_var_when_no_override(self, config):
+        with patch.dict(os.environ, {"LOG_LEVEL": "WARNING"}):
+            assert config.get("LOG_LEVEL") == "WARNING"
+
+    def test_get_returns_default_when_no_override_or_env(self, config):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("LOG_LEVEL", None)
+            result = config.get("LOG_LEVEL", "INFO")
+            assert result == "INFO"
+
+    def test_delete_removes_override(self, enabled_config):
+        enabled_config.set("LOG_LEVEL", "DEBUG")
+        assert enabled_config.get("LOG_LEVEL") == "DEBUG"
+        old = enabled_config.delete("LOG_LEVEL")
+        assert old == "DEBUG"
+        # After delete, should fall back to env or default
+        with patch.dict(os.environ, {"LOG_LEVEL": "WARNING"}):
+            assert enabled_config.get("LOG_LEVEL") == "WARNING"
+
+    def test_delete_nonexistent_returns_none(self, config):
+        result = config.delete("LOG_LEVEL")
+        assert result is None
+
+
+class TestWhitelist:
+    def test_whitelisted_setting_accepted(self, enabled_config):
+        enabled_config.set("LOG_LEVEL", "DEBUG")
+        assert enabled_config.get("LOG_LEVEL") == "DEBUG"
+
+    def test_non_whitelisted_setting_rejected(self, enabled_config):
+        with pytest.raises(ValueError, match="cannot be changed at runtime"):
+            enabled_config.set("PORT", "5000")
+
+    def test_all_mutable_settings_in_whitelist(self):
+        expected = {
+            "LOG_LEVEL",
+            "DEBUG",
+            "ENFORCE_IAM",
+            "AUDIT_LOG_SIZE",
+            "SQS_DELAY_PURGE_RETRY",
+            "SQS_DELAY_RECENTLY_DELETED",
+            "DYNAMODB_REMOVE_EXPIRED_ITEMS",
+            "USAGE_ANALYTICS",
+        }
+        assert set(MUTABLE_SETTINGS.keys()) == expected
+
+
+class TestChangeHistory:
+    def test_change_history_recorded(self, enabled_config):
+        enabled_config.set("LOG_LEVEL", "DEBUG")
+        history = enabled_config.get_history()
+        assert len(history) == 1
+        assert history[0]["key"] == "LOG_LEVEL"
+
+    def test_change_history_includes_old_and_new_values(self, enabled_config):
+        with patch.dict(os.environ, {"LOG_LEVEL": "INFO"}):
+            enabled_config.set("LOG_LEVEL", "DEBUG")
+            history = enabled_config.get_history()
+            assert history[0]["old_value"] == "INFO"
+            assert history[0]["new_value"] == "DEBUG"
+
+    def test_change_history_has_timestamp(self, enabled_config):
+        before = time.time()
+        enabled_config.set("LOG_LEVEL", "DEBUG")
+        after = time.time()
+        history = enabled_config.get_history()
+        assert before <= history[0]["timestamp"] <= after
+
+    def test_multiple_changes_tracked(self, enabled_config):
+        enabled_config.set("LOG_LEVEL", "DEBUG")
+        enabled_config.set("ENFORCE_IAM", "1")
+        history = enabled_config.get_history()
+        assert len(history) == 2
+
+
+class TestChangePropagation:
+    def test_log_level_change_propagates_to_logger(self, enabled_config):
+        enabled_config.set("LOG_LEVEL", "DEBUG")
+        root_logger = logging.getLogger()
+        assert root_logger.level == logging.DEBUG
+
+    def test_reset_returns_to_original_value(self, enabled_config):
+        with patch.dict(os.environ, {"LOG_LEVEL": "INFO"}):
+            enabled_config.set("LOG_LEVEL", "DEBUG")
+            assert enabled_config.get("LOG_LEVEL") == "DEBUG"
+            enabled_config.delete("LOG_LEVEL")
+            assert enabled_config.get("LOG_LEVEL") == "INFO"
+
+
+class TestListConfig:
+    def test_list_all_current_config_with_sources(self, enabled_config):
+        with patch.dict(os.environ, {"LOG_LEVEL": "INFO", "DEBUG": "0"}):
+            enabled_config.set("LOG_LEVEL", "DEBUG")
+            all_config = enabled_config.list_all()
+            # LOG_LEVEL should show as runtime override
+            log_entry = next(e for e in all_config if e["key"] == "LOG_LEVEL")
+            assert log_entry["value"] == "DEBUG"
+            assert log_entry["source"] == "runtime"
+            assert log_entry["mutable"] is True
+
+            # DEBUG should show as env
+            debug_entry = next(e for e in all_config if e["key"] == "DEBUG")
+            assert debug_entry["value"] == "0"
+            assert debug_entry["source"] == "env"
+
+
+class TestEnableGate:
+    def test_config_updates_disabled_by_default(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("ENABLE_CONFIG_UPDATES", None)
+            cfg = RuntimeConfig()
+            assert cfg.updates_enabled is False
+
+    def test_config_updates_enabled_when_env_set(self):
+        with patch.dict(os.environ, {"ENABLE_CONFIG_UPDATES": "1"}):
+            cfg = RuntimeConfig()
+            assert cfg.updates_enabled is True
+
+    def test_set_raises_when_updates_disabled(self, config):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("ENABLE_CONFIG_UPDATES", None)
+            with pytest.raises(PermissionError, match="disabled"):
+                config.set("LOG_LEVEL", "DEBUG")
+
+
+class TestSingleton:
+    def test_get_runtime_config_returns_same_instance(self):
+        a = get_runtime_config()
+        b = get_runtime_config()
+        assert a is b

--- a/tests/unit/config/test_runtime_integration.py
+++ b/tests/unit/config/test_runtime_integration.py
@@ -1,0 +1,128 @@
+"""Semantic integration tests for runtime config endpoints.
+
+These test the HTTP endpoints via Starlette's test client, verifying
+the full request/response cycle for config management.
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+from starlette.testclient import TestClient
+
+
+@pytest.fixture
+def client_enabled():
+    """Create a test client with config updates enabled."""
+    with patch.dict(os.environ, {"ENABLE_CONFIG_UPDATES": "1"}):
+        # Reset the singleton so it picks up the env var
+        import robotocore.config.runtime as rt_mod
+
+        old = rt_mod._runtime_config
+        rt_mod._runtime_config = None
+        try:
+            from robotocore.gateway.app import app
+
+            with TestClient(app, raise_server_exceptions=False) as client:
+                yield client
+        finally:
+            rt_mod._runtime_config = old
+
+
+@pytest.fixture
+def client_disabled():
+    """Create a test client with config updates disabled."""
+    with patch.dict(os.environ, {}, clear=False):
+        os.environ.pop("ENABLE_CONFIG_UPDATES", None)
+        import robotocore.config.runtime as rt_mod
+
+        old = rt_mod._runtime_config
+        rt_mod._runtime_config = None
+        try:
+            from robotocore.gateway.app import app
+
+            with TestClient(app, raise_server_exceptions=False) as client:
+                yield client
+        finally:
+            rt_mod._runtime_config = old
+
+
+class TestPostConfig:
+    def test_post_updates_setting_and_get_shows_new_value(self, client_enabled):
+        # Update LOG_LEVEL
+        resp = client_enabled.post(
+            "/_robotocore/config",
+            json={"LOG_LEVEL": "DEBUG"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["updated"]["LOG_LEVEL"] == "DEBUG"
+
+        # GET should show the new value
+        resp = client_enabled.get("/_robotocore/config")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["log_level"] == "DEBUG"
+
+    def test_post_without_enable_returns_403(self, client_disabled):
+        resp = client_disabled.post(
+            "/_robotocore/config",
+            json={"LOG_LEVEL": "DEBUG"},
+        )
+        assert resp.status_code == 403
+        assert "disabled" in resp.json()["error"].lower()
+
+    def test_post_non_whitelisted_setting_returns_400(self, client_enabled):
+        resp = client_enabled.post(
+            "/_robotocore/config",
+            json={"PORT": "5000"},
+        )
+        assert resp.status_code == 400
+        assert "cannot be changed at runtime" in resp.json()["error"]
+
+    def test_multiple_settings_updated_in_one_post(self, client_enabled):
+        resp = client_enabled.post(
+            "/_robotocore/config",
+            json={"LOG_LEVEL": "DEBUG", "ENFORCE_IAM": "1"},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["updated"]["LOG_LEVEL"] == "DEBUG"
+        assert data["updated"]["ENFORCE_IAM"] == "1"
+
+
+class TestDeleteConfig:
+    def test_delete_resets_to_original(self, client_enabled):
+        # Set override
+        client_enabled.post(
+            "/_robotocore/config",
+            json={"LOG_LEVEL": "DEBUG"},
+        )
+        # Delete it
+        resp = client_enabled.delete("/_robotocore/config/LOG_LEVEL")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "reset"
+
+    def test_delete_nonexistent_returns_404(self, client_enabled):
+        resp = client_enabled.delete("/_robotocore/config/LOG_LEVEL")
+        assert resp.status_code == 404
+
+
+class TestGetConfig:
+    def test_config_shows_source_env_vs_runtime(self, client_enabled):
+        with patch.dict(os.environ, {"DEBUG": "0"}):
+            # Set runtime override for LOG_LEVEL
+            client_enabled.post(
+                "/_robotocore/config",
+                json={"LOG_LEVEL": "DEBUG"},
+            )
+            resp = client_enabled.get("/_robotocore/config")
+            data = resp.json()
+            # Should still have standard config fields
+            assert "log_level" in data
+            assert "debug" in data
+            # Should also have detailed settings with sources
+            assert "settings" in data
+            log_setting = next((s for s in data["settings"] if s["key"] == "LOG_LEVEL"), None)
+            assert log_setting is not None
+            assert log_setting["source"] == "runtime"


### PR DESCRIPTION
## Summary
- Add `RuntimeConfig` class in `src/robotocore/config/runtime.py` for managing mutable runtime settings
- `POST /_robotocore/config` updates whitelisted settings (LOG_LEVEL, DEBUG, ENFORCE_IAM, AUDIT_LOG_SIZE, SQS_DELAY_PURGE_RETRY, SQS_DELAY_RECENTLY_DELETED, DYNAMODB_REMOVE_EXPIRED_ITEMS, USAGE_ANALYTICS)
- `DELETE /_robotocore/config/{key}` resets a runtime override back to its original value
- Enhanced `GET /_robotocore/config` to show current values with source (env/runtime/default) and mutability info
- Gated behind `ENABLE_CONFIG_UPDATES=1` env var (returns 403 when disabled)
- Change propagation: LOG_LEVEL updates root logger, AUDIT_LOG_SIZE resizes ring buffer
- Full change history with timestamps, old/new values

## Test plan
- [x] 20 unit tests for RuntimeConfig class (storage, whitelist, history, propagation, enable gate)
- [x] 7 integration tests for HTTP endpoints (POST/GET/DELETE lifecycle, 403/400 error cases)
- [x] All 27 tests passing
- [x] Lint clean (ruff check + format)

🤖 Generated with [Claude Code](https://claude.com/claude-code)