### PR TITLE
Add built-in DNS server resolving *.amazonaws.com locally

### DIFF
--- a/prompts/20260311-120000-dns-unit-tests.md
+++ b/prompts/20260311-120000-dns-unit-tests.md
@@ -1,0 +1,35 @@
+---
+session: "dns-unit-tests"
+timestamp: "2026-03-11T12:00:00Z"
+model: claude-opus-4-6
+---
+
+## Human
+
+Add comprehensive unit tests for PR #76 — Built-in DNS server resolving
+*.amazonaws.com locally. Cover DNS resolution, wildcard matching, upstream
+fallback, config, error cases. Mock network calls.
+
+## Assistant
+
+Read all source files in `src/robotocore/dns/` (resolver.py and server.py)
+and existing tests in `tests/unit/dns/`. Identified coverage gaps:
+
+- `_get_system_dns()` parsing /etc/resolv.conf with mocked file I/O
+- `_get_upstream_server()` with/without configured upstream
+- `_forward_upstream()` with mocked sockets (timeout, OSError, success)
+- `_build_response()` for all query types (A, AAAA, CNAME, MX, TXT)
+- `_handle_query()` end-to-end: local resolution, upstream forwarding, SERVFAIL
+- Malformed packets: empty data, single byte, extractable query ID
+- Case-insensitive hostname matching
+- Config env var parsing: comma separation, trailing commas, empty strings
+- IPv4-to-IPv6 mapping with specific hex group verification
+- Module-level start/stop singleton helpers
+- DNSServer init and stop-when-not-started
+
+Created two new test files:
+- `tests/unit/dns/test_resolver.py` — 49 tests for resolver logic
+- `tests/unit/dns/test_server_unit.py` — 42 tests for server with mocked I/O
+
+All 129 DNS unit tests pass (91 new + 38 existing). Zero network calls in
+new tests — all socket/file I/O is mocked.

--- a/tests/unit/dns/test_resolver.py
+++ b/tests/unit/dns/test_resolver.py
@@ -1,0 +1,346 @@
+"""Comprehensive unit tests for robotocore.dns.resolver.
+
+Tests cover: hostname matching, config parsing, A/AAAA/CNAME resolution,
+edge cases, case sensitivity, and environment variable handling.
+"""
+
+import os
+from unittest.mock import patch
+
+from robotocore.dns.resolver import (
+    _DEFAULT_LOCAL_PATTERNS,
+    DEFAULT_TTL,
+    get_config,
+    resolve_a_record,
+    resolve_aaaa_record,
+    resolve_cname_record,
+    should_resolve_locally,
+)
+
+# ---------------------------------------------------------------------------
+# should_resolve_locally — pattern matching
+# ---------------------------------------------------------------------------
+
+
+class TestShouldResolveLocally:
+    """Hostname-to-local resolution decisions."""
+
+    def test_s3_subdomain(self) -> None:
+        config = get_config()
+        assert should_resolve_locally("s3.us-east-1.amazonaws.com", config) is True
+
+    def test_deep_subdomain(self) -> None:
+        config = get_config()
+        assert should_resolve_locally("vpce-abc.s3.us-east-1.amazonaws.com", config) is True
+
+    def test_case_insensitive_matching(self) -> None:
+        config = get_config()
+        assert should_resolve_locally("S3.US-EAST-1.AMAZONAWS.COM", config) is True
+
+    def test_mixed_case_matching(self) -> None:
+        config = get_config()
+        assert should_resolve_locally("DynamoDB.Us-West-2.Amazonaws.Com", config) is True
+
+    def test_trailing_dot_stripped(self) -> None:
+        config = get_config()
+        assert should_resolve_locally("s3.amazonaws.com.", config) is True
+
+    def test_multiple_trailing_dots_stripped(self) -> None:
+        config = get_config()
+        # rstrip(".") removes all trailing dots
+        assert should_resolve_locally("s3.amazonaws.com...", config) is True
+
+    def test_non_aws_domain_returns_false(self) -> None:
+        config = get_config()
+        assert should_resolve_locally("google.com", config) is False
+
+    def test_partial_amazonaws_not_matched(self) -> None:
+        """A domain like 'fakeamazonaws.com' should NOT match."""
+        config = get_config()
+        # The pattern is .*\.amazonaws\.com$ — requires a dot before amazonaws
+        assert should_resolve_locally("fakeamazonaws.com", config) is False
+
+    def test_amazonaws_in_subdomain_not_matched(self) -> None:
+        config = get_config()
+        assert should_resolve_locally("amazonaws.com.evil.com", config) is False
+
+    def test_empty_hostname(self) -> None:
+        config = get_config()
+        assert should_resolve_locally("", config) is False
+
+    def test_bare_amazonaws_com(self) -> None:
+        config = get_config()
+        assert should_resolve_locally("amazonaws.com", config) is True
+
+    def test_bare_aws_amazon_com(self) -> None:
+        config = get_config()
+        assert should_resolve_locally("aws.amazon.com", config) is True
+
+    def test_subdomain_of_aws_amazon_com(self) -> None:
+        config = get_config()
+        assert should_resolve_locally("console.aws.amazon.com", config) is True
+
+    def test_upstream_pattern_takes_priority(self) -> None:
+        """Upstream bypass patterns are checked before local patterns."""
+        config = get_config()
+        config["upstream_patterns"] = [r".*\.amazonaws\.com"]
+        assert should_resolve_locally("s3.amazonaws.com", config) is False
+
+    def test_upstream_pattern_partial_match(self) -> None:
+        """Upstream patterns use re.search, so partial matches work."""
+        config = get_config()
+        config["upstream_patterns"] = [r"us-gov"]
+        assert should_resolve_locally("s3.us-gov-west-1.amazonaws.com", config) is False
+        assert should_resolve_locally("s3.us-east-1.amazonaws.com", config) is True
+
+    def test_empty_local_patterns_resolves_nothing(self) -> None:
+        config = get_config()
+        config["local_patterns"] = []
+        config["upstream_patterns"] = []
+        assert should_resolve_locally("s3.amazonaws.com", config) is False
+
+    def test_uses_default_config_when_none(self) -> None:
+        """When config=None, should_resolve_locally calls get_config()."""
+        result = should_resolve_locally("s3.amazonaws.com")
+        assert result is True
+
+    def test_custom_local_pattern_only(self) -> None:
+        config = {
+            "local_patterns": [r".*\.mytest\.local$"],
+            "upstream_patterns": [],
+        }
+        assert should_resolve_locally("api.mytest.local", config) is True
+        assert should_resolve_locally("s3.amazonaws.com", config) is False
+
+
+# ---------------------------------------------------------------------------
+# get_config — environment variable parsing
+# ---------------------------------------------------------------------------
+
+
+class TestGetConfig:
+    """Config from environment variables."""
+
+    def _clean_env(self) -> dict[str, str]:
+        """Return env dict with all DNS_ vars removed."""
+        return {k: v for k, v in os.environ.items() if not k.startswith("DNS_")}
+
+    def test_defaults_with_no_env(self) -> None:
+        with patch.dict(os.environ, self._clean_env(), clear=True):
+            config = get_config()
+            assert config["resolve_ip"] == "127.0.0.1"
+            assert config["port"] == 53
+            assert config["address"] == "0.0.0.0"
+            assert config["disabled"] is False
+            assert config["upstream_server"] == ""
+            assert config["upstream_patterns"] == []
+            assert config["ttl"] == 300
+            assert len(config["local_patterns"]) == len(_DEFAULT_LOCAL_PATTERNS)
+
+    def test_dns_resolve_ip(self) -> None:
+        with patch.dict(os.environ, {"DNS_RESOLVE_IP": "192.168.1.100"}):
+            config = get_config()
+            assert config["resolve_ip"] == "192.168.1.100"
+
+    def test_dns_port_parsed_as_int(self) -> None:
+        with patch.dict(os.environ, {"DNS_PORT": "5353"}):
+            config = get_config()
+            assert config["port"] == 5353
+            assert isinstance(config["port"], int)
+
+    def test_dns_disabled_only_when_1(self) -> None:
+        with patch.dict(os.environ, {"DNS_DISABLED": "0"}):
+            assert get_config()["disabled"] is False
+        with patch.dict(os.environ, {"DNS_DISABLED": "true"}):
+            assert get_config()["disabled"] is False  # Only "1" disables
+        with patch.dict(os.environ, {"DNS_DISABLED": "1"}):
+            assert get_config()["disabled"] is True
+
+    def test_upstream_patterns_comma_separated(self) -> None:
+        env = {"DNS_NAME_PATTERNS_TO_RESOLVE_UPSTREAM": r"foo\.com , bar\.net"}
+        with patch.dict(os.environ, env):
+            config = get_config()
+            assert config["upstream_patterns"] == [r"foo\.com", r"bar\.net"]
+
+    def test_upstream_patterns_empty_string(self) -> None:
+        env = {"DNS_NAME_PATTERNS_TO_RESOLVE_UPSTREAM": ""}
+        with patch.dict(os.environ, env):
+            config = get_config()
+            assert config["upstream_patterns"] == []
+
+    def test_upstream_patterns_trailing_comma(self) -> None:
+        env = {"DNS_NAME_PATTERNS_TO_RESOLVE_UPSTREAM": r"foo\.com,"}
+        with patch.dict(os.environ, env):
+            config = get_config()
+            assert config["upstream_patterns"] == [r"foo\.com"]
+
+    def test_local_patterns_appended_to_defaults(self) -> None:
+        env = {"DNS_LOCAL_NAME_PATTERNS": r".*\.custom\.dev"}
+        with patch.dict(os.environ, env):
+            config = get_config()
+            assert len(config["local_patterns"]) == len(_DEFAULT_LOCAL_PATTERNS) + 1
+            assert config["local_patterns"][-1] == r".*\.custom\.dev"
+
+    def test_local_patterns_multiple(self) -> None:
+        env = {"DNS_LOCAL_NAME_PATTERNS": r".*\.a,.*\.b,.*\.c"}
+        with patch.dict(os.environ, env):
+            config = get_config()
+            assert len(config["local_patterns"]) == len(_DEFAULT_LOCAL_PATTERNS) + 3
+
+
+# ---------------------------------------------------------------------------
+# resolve_a_record
+# ---------------------------------------------------------------------------
+
+
+class TestResolveARecord:
+    """A record resolution."""
+
+    def test_aws_hostname_returns_configured_ip(self) -> None:
+        config = get_config()
+        config["resolve_ip"] = "10.0.0.42"
+        assert resolve_a_record("sqs.amazonaws.com", config) == "10.0.0.42"
+
+    def test_non_aws_returns_none(self) -> None:
+        config = get_config()
+        assert resolve_a_record("example.org", config) is None
+
+    def test_uses_default_config_when_none(self) -> None:
+        result = resolve_a_record("s3.amazonaws.com")
+        assert result == "127.0.0.1"
+
+    def test_returns_string_type(self) -> None:
+        config = get_config()
+        result = resolve_a_record("s3.amazonaws.com", config)
+        assert isinstance(result, str)
+
+    def test_ipv6_resolve_ip_still_returned_for_a_record(self) -> None:
+        """If resolve_ip is IPv6, A record still returns it as-is."""
+        config = get_config()
+        config["resolve_ip"] = "::1"
+        result = resolve_a_record("s3.amazonaws.com", config)
+        assert result == "::1"
+
+
+# ---------------------------------------------------------------------------
+# resolve_aaaa_record
+# ---------------------------------------------------------------------------
+
+
+class TestResolveAAAARecord:
+    """AAAA (IPv6) record resolution."""
+
+    def test_ipv4_mapped_to_ipv6_format(self) -> None:
+        config = get_config()
+        config["resolve_ip"] = "127.0.0.1"
+        result = resolve_aaaa_record("s3.amazonaws.com", config)
+        assert result is not None
+        # IPv4-mapped IPv6: ::ffff:127.0.0.1 -> 0000:0000:0000:0000:0000:ffff:7f00:0001
+        assert "ffff" in result.lower()
+        # Verify it's colon-separated hex groups (no dotted quad)
+        parts = result.split(":")
+        assert len(parts) == 8
+        for part in parts:
+            assert len(part) == 4, f"Expected 4-char hex group, got '{part}'"
+            int(part, 16)  # Must be valid hex
+
+    def test_ipv4_mapped_specific_value(self) -> None:
+        """Verify the exact mapped address for 127.0.0.1."""
+        config = get_config()
+        config["resolve_ip"] = "127.0.0.1"
+        result = resolve_aaaa_record("s3.amazonaws.com", config)
+        assert result is not None
+        # ::ffff:127.0.0.1 = ::ffff:7f00:0001
+        assert result.endswith("ffff:7f00:0001")
+
+    def test_ipv4_mapped_10_0_0_1(self) -> None:
+        config = get_config()
+        config["resolve_ip"] = "10.0.0.1"
+        result = resolve_aaaa_record("s3.amazonaws.com", config)
+        assert result is not None
+        # 10.0.0.1 -> 0a00:0001
+        assert result.endswith("ffff:0a00:0001")
+
+    def test_native_ipv6_returned_directly(self) -> None:
+        config = get_config()
+        config["resolve_ip"] = "::1"
+        result = resolve_aaaa_record("s3.amazonaws.com", config)
+        assert result == "::1"
+
+    def test_native_ipv6_full_address(self) -> None:
+        config = get_config()
+        config["resolve_ip"] = "fe80::1"
+        result = resolve_aaaa_record("s3.amazonaws.com", config)
+        assert result == "fe80::1"
+
+    def test_invalid_ip_returns_none(self) -> None:
+        config = get_config()
+        config["resolve_ip"] = "not-a-valid-ip"
+        result = resolve_aaaa_record("s3.amazonaws.com", config)
+        assert result is None
+
+    def test_non_aws_hostname_returns_none(self) -> None:
+        config = get_config()
+        result = resolve_aaaa_record("google.com", config)
+        assert result is None
+
+    def test_uses_default_config_when_none(self) -> None:
+        result = resolve_aaaa_record("s3.amazonaws.com")
+        assert result is not None
+        assert "ffff" in result.lower()
+
+
+# ---------------------------------------------------------------------------
+# resolve_cname_record
+# ---------------------------------------------------------------------------
+
+
+class TestResolveCNAMERecord:
+    """CNAME record resolution."""
+
+    def test_aws_hostname_returns_with_trailing_dot(self) -> None:
+        config = get_config()
+        result = resolve_cname_record("s3.amazonaws.com", config)
+        assert result == "s3.amazonaws.com."
+
+    def test_trailing_dot_input_normalized(self) -> None:
+        config = get_config()
+        result = resolve_cname_record("s3.amazonaws.com.", config)
+        # rstrip(".") removes trailing dot, then "." is appended
+        assert result == "s3.amazonaws.com."
+
+    def test_non_aws_returns_none(self) -> None:
+        config = get_config()
+        result = resolve_cname_record("github.com", config)
+        assert result is None
+
+    def test_uses_default_config_when_none(self) -> None:
+        result = resolve_cname_record("s3.amazonaws.com")
+        assert result is not None
+        assert result.endswith(".")
+
+    def test_subdomain_preserved(self) -> None:
+        config = get_config()
+        result = resolve_cname_record("sqs.us-east-1.amazonaws.com", config)
+        assert result == "sqs.us-east-1.amazonaws.com."
+
+
+# ---------------------------------------------------------------------------
+# DEFAULT_TTL constant
+# ---------------------------------------------------------------------------
+
+
+class TestDefaults:
+    """Verify module-level defaults."""
+
+    def test_default_ttl_is_300(self) -> None:
+        assert DEFAULT_TTL == 300
+
+    def test_default_local_patterns_count(self) -> None:
+        assert len(_DEFAULT_LOCAL_PATTERNS) == 4
+
+    def test_default_local_patterns_contain_amazonaws(self) -> None:
+        assert any("amazonaws" in p for p in _DEFAULT_LOCAL_PATTERNS)
+
+    def test_default_local_patterns_contain_aws_amazon(self) -> None:
+        assert any("aws" in p and "amazon" in p for p in _DEFAULT_LOCAL_PATTERNS)

--- a/tests/unit/dns/test_server_unit.py
+++ b/tests/unit/dns/test_server_unit.py
@@ -1,0 +1,392 @@
+"""Comprehensive unit tests for robotocore.dns.server.
+
+Tests cover: _get_system_dns, _get_upstream_server, _forward_upstream,
+_build_response, _handle_query, DNSServer lifecycle, and module-level
+start/stop helpers. Network calls are mocked.
+"""
+
+import os
+import struct
+from unittest.mock import MagicMock, mock_open, patch
+
+from dnslib import DNSHeader, DNSRecord
+
+from robotocore.dns.resolver import DEFAULT_TTL, get_config
+from robotocore.dns.server import (
+    DNSServer,
+    _build_response,
+    _forward_upstream,
+    _get_system_dns,
+    _get_upstream_server,
+    _handle_query,
+    start_dns_server,
+    stop_dns_server,
+)
+
+# ---------------------------------------------------------------------------
+# _get_system_dns — parsing /etc/resolv.conf
+# ---------------------------------------------------------------------------
+
+
+class TestGetSystemDNS:
+    """Test detection of system DNS from /etc/resolv.conf."""
+
+    def test_parses_first_nameserver(self) -> None:
+        content = "nameserver 1.1.1.1\nnameserver 8.8.8.8\n"
+        with patch("builtins.open", mock_open(read_data=content)):
+            assert _get_system_dns() == "1.1.1.1"
+
+    def test_skips_comments(self) -> None:
+        content = "# nameserver 9.9.9.9\nnameserver 1.0.0.1\n"
+        with patch("builtins.open", mock_open(read_data=content)):
+            assert _get_system_dns() == "1.0.0.1"
+
+    def test_skips_non_nameserver_lines(self) -> None:
+        content = "search example.com\nnameserver 4.4.4.4\n"
+        with patch("builtins.open", mock_open(read_data=content)):
+            assert _get_system_dns() == "4.4.4.4"
+
+    def test_handles_extra_whitespace(self) -> None:
+        content = "  nameserver   8.8.4.4  \n"
+        with patch("builtins.open", mock_open(read_data=content)):
+            assert _get_system_dns() == "8.8.4.4"
+
+    def test_fallback_on_oserror(self) -> None:
+        with patch("builtins.open", side_effect=OSError("no such file")):
+            assert _get_system_dns() == "8.8.8.8"
+
+    def test_fallback_on_empty_file(self) -> None:
+        with patch("builtins.open", mock_open(read_data="")):
+            assert _get_system_dns() == "8.8.8.8"
+
+    def test_nameserver_without_value_skipped(self) -> None:
+        content = "nameserver\nnameserver 2.2.2.2\n"
+        with patch("builtins.open", mock_open(read_data=content)):
+            # "nameserver" alone has only 1 part, so skip it
+            assert _get_system_dns() == "2.2.2.2"
+
+
+# ---------------------------------------------------------------------------
+# _get_upstream_server
+# ---------------------------------------------------------------------------
+
+
+class TestGetUpstreamServer:
+    """Test upstream server selection."""
+
+    def test_uses_config_when_provided(self) -> None:
+        config = {"upstream_server": "1.2.3.4"}
+        assert _get_upstream_server(config) == "1.2.3.4"
+
+    def test_falls_back_to_system_dns(self) -> None:
+        config = {"upstream_server": ""}
+        with patch("robotocore.dns.server._get_system_dns", return_value="9.9.9.9"):
+            assert _get_upstream_server(config) == "9.9.9.9"
+
+    def test_empty_string_triggers_fallback(self) -> None:
+        config = {"upstream_server": ""}
+        with patch("robotocore.dns.server._get_system_dns", return_value="8.8.8.8"):
+            assert _get_upstream_server(config) == "8.8.8.8"
+
+    def test_missing_key_triggers_fallback(self) -> None:
+        config = {}
+        with patch("robotocore.dns.server._get_system_dns", return_value="1.1.1.1"):
+            assert _get_upstream_server(config) == "1.1.1.1"
+
+
+# ---------------------------------------------------------------------------
+# _forward_upstream — mocked socket
+# ---------------------------------------------------------------------------
+
+
+class TestForwardUpstream:
+    """Test upstream DNS forwarding with mocked sockets."""
+
+    def test_returns_response_bytes(self) -> None:
+        fake_response = b"\x00\x01response"
+        mock_sock = MagicMock()
+        mock_sock.recvfrom.return_value = (fake_response, ("8.8.8.8", 53))
+
+        with patch("socket.socket", return_value=mock_sock):
+            result = _forward_upstream(b"\x00\x01query", "8.8.8.8")
+            assert result == fake_response
+
+    def test_sends_to_correct_upstream(self) -> None:
+        mock_sock = MagicMock()
+        mock_sock.recvfrom.return_value = (b"resp", ("1.2.3.4", 53))
+
+        with patch("socket.socket", return_value=mock_sock):
+            _forward_upstream(b"q", "1.2.3.4", upstream_port=5353)
+            mock_sock.sendto.assert_called_once_with(b"q", ("1.2.3.4", 5353))
+
+    def test_returns_none_on_timeout(self) -> None:
+        mock_sock = MagicMock()
+        mock_sock.recvfrom.side_effect = TimeoutError()
+
+        with patch("socket.socket", return_value=mock_sock):
+            result = _forward_upstream(b"q", "8.8.8.8")
+            assert result is None
+
+    def test_returns_none_on_oserror(self) -> None:
+        mock_sock = MagicMock()
+        mock_sock.recvfrom.side_effect = OSError("Network unreachable")
+
+        with patch("socket.socket", return_value=mock_sock):
+            result = _forward_upstream(b"q", "8.8.8.8")
+            assert result is None
+
+    def test_socket_always_closed(self) -> None:
+        mock_sock = MagicMock()
+        mock_sock.recvfrom.side_effect = TimeoutError()
+
+        with patch("socket.socket", return_value=mock_sock):
+            _forward_upstream(b"q", "8.8.8.8")
+            mock_sock.close.assert_called_once()
+
+    def test_socket_closed_on_success(self) -> None:
+        mock_sock = MagicMock()
+        mock_sock.recvfrom.return_value = (b"resp", ("8.8.8.8", 53))
+
+        with patch("socket.socket", return_value=mock_sock):
+            _forward_upstream(b"q", "8.8.8.8")
+            mock_sock.close.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _build_response — local DNS response construction
+# ---------------------------------------------------------------------------
+
+
+class TestBuildResponse:
+    """Test local DNS response building for different query types."""
+
+    def _make_config(self, resolve_ip: str = "127.0.0.1") -> dict:
+        config = get_config()
+        config["resolve_ip"] = resolve_ip
+        return config
+
+    def test_a_query_for_aws_hostname(self) -> None:
+        request = DNSRecord.question("s3.amazonaws.com", "A")
+        config = self._make_config()
+        response = _build_response(request, config)
+        assert response is not None
+        assert len(response.rr) == 1
+        assert str(response.rr[0].rdata) == "127.0.0.1"
+        assert response.rr[0].ttl == DEFAULT_TTL
+
+    def test_a_query_with_custom_ip(self) -> None:
+        request = DNSRecord.question("s3.amazonaws.com", "A")
+        config = self._make_config("10.0.0.42")
+        response = _build_response(request, config)
+        assert response is not None
+        assert str(response.rr[0].rdata) == "10.0.0.42"
+
+    def test_a_query_for_non_aws_returns_none(self) -> None:
+        request = DNSRecord.question("google.com", "A")
+        config = self._make_config()
+        response = _build_response(request, config)
+        assert response is None
+
+    def test_aaaa_query_for_aws_hostname(self) -> None:
+        request = DNSRecord.question("sqs.amazonaws.com", "AAAA")
+        config = self._make_config()
+        response = _build_response(request, config)
+        assert response is not None
+        assert len(response.rr) == 1
+        assert response.rr[0].ttl == DEFAULT_TTL
+
+    def test_aaaa_query_for_non_aws_returns_none(self) -> None:
+        request = DNSRecord.question("google.com", "AAAA")
+        config = self._make_config()
+        response = _build_response(request, config)
+        assert response is None
+
+    def test_cname_query_for_aws_hostname(self) -> None:
+        request = DNSRecord.question("sqs.amazonaws.com", "CNAME")
+        config = self._make_config()
+        response = _build_response(request, config)
+        assert response is not None
+        assert len(response.rr) == 1
+        assert "sqs.amazonaws.com" in str(response.rr[0].rdata)
+
+    def test_cname_query_for_non_aws_returns_none(self) -> None:
+        request = DNSRecord.question("github.com", "CNAME")
+        config = self._make_config()
+        response = _build_response(request, config)
+        assert response is None
+
+    def test_mx_query_returns_none(self) -> None:
+        """MX queries are not handled locally."""
+        request = DNSRecord.question("s3.amazonaws.com", "MX")
+        config = self._make_config()
+        response = _build_response(request, config)
+        assert response is None
+
+    def test_txt_query_returns_none(self) -> None:
+        """TXT queries are not handled locally."""
+        request = DNSRecord.question("s3.amazonaws.com", "TXT")
+        config = self._make_config()
+        response = _build_response(request, config)
+        assert response is None
+
+    def test_custom_ttl(self) -> None:
+        request = DNSRecord.question("s3.amazonaws.com", "A")
+        config = self._make_config()
+        config["ttl"] = 600
+        response = _build_response(request, config)
+        assert response is not None
+        assert response.rr[0].ttl == 600
+
+
+# ---------------------------------------------------------------------------
+# _handle_query — full query handling pipeline
+# ---------------------------------------------------------------------------
+
+
+class TestHandleQuery:
+    """Test the full query handling pipeline."""
+
+    def _make_config(self) -> dict:
+        config = get_config()
+        config["resolve_ip"] = "127.0.0.1"
+        return config
+
+    def test_local_resolution_returns_packed_response(self) -> None:
+        request = DNSRecord.question("s3.amazonaws.com", "A")
+        config = self._make_config()
+        result = _handle_query(request.pack(), config, "8.8.8.8")
+        response = DNSRecord.parse(result)
+        assert len(response.rr) == 1
+        assert str(response.rr[0].rdata) == "127.0.0.1"
+
+    def test_non_aws_forwards_upstream(self) -> None:
+        request = DNSRecord.question("example.com", "A")
+        config = self._make_config()
+        fake_upstream = DNSRecord(DNSHeader(id=request.header.id, qr=1, ra=1))
+        with patch("robotocore.dns.server._forward_upstream", return_value=fake_upstream.pack()):
+            result = _handle_query(request.pack(), config, "8.8.8.8")
+            response = DNSRecord.parse(result)
+            assert response.header.qr == 1  # It's a response
+
+    def test_upstream_failure_returns_servfail(self) -> None:
+        request = DNSRecord.question("example.com", "A")
+        config = self._make_config()
+        with patch("robotocore.dns.server._forward_upstream", return_value=None):
+            result = _handle_query(request.pack(), config, "8.8.8.8")
+            response = DNSRecord.parse(result)
+            assert response.header.rcode == 2  # SERVFAIL
+
+    def test_malformed_data_with_extractable_id(self) -> None:
+        """Malformed packet with a valid 2-byte ID prefix -> SERVFAIL with same ID."""
+        query_id = 0x1234
+        bad_data = struct.pack("!H", query_id) + b"\xff\xff\xff garbage"
+        config = self._make_config()
+        result = _handle_query(bad_data, config, "8.8.8.8")
+        if result:
+            response = DNSRecord.parse(result)
+            assert response.header.id == query_id
+            assert response.header.rcode == 2  # SERVFAIL
+
+    def test_completely_empty_data(self) -> None:
+        config = self._make_config()
+        result = _handle_query(b"", config, "8.8.8.8")
+        # Empty data -> can't extract ID -> empty bytes
+        assert result == b""
+
+    def test_single_byte_data(self) -> None:
+        config = self._make_config()
+        result = _handle_query(b"\x01", config, "8.8.8.8")
+        # Less than 2 bytes -> can't extract ID
+        # Might return b"" or a SERVFAIL — either is acceptable
+        assert isinstance(result, bytes)
+
+
+# ---------------------------------------------------------------------------
+# DNSServer — lifecycle without actual binding
+# ---------------------------------------------------------------------------
+
+
+class TestDNSServerInit:
+    """Test DNSServer initialization and properties."""
+
+    def test_default_config(self) -> None:
+        server = DNSServer(address="127.0.0.1", port=15400)
+        assert server.address == "127.0.0.1"
+        assert server.port == 15400
+        assert server.is_running is False
+
+    def test_custom_config(self) -> None:
+        config = {"resolve_ip": "10.0.0.1", "ttl": 60}
+        server = DNSServer(address="0.0.0.0", port=53, config=config)
+        assert server.config["resolve_ip"] == "10.0.0.1"
+        assert server.config["ttl"] == 60
+
+    def test_not_running_initially(self) -> None:
+        server = DNSServer()
+        assert server.is_running is False
+        assert server._socket is None
+        assert server._thread is None
+
+    def test_stop_when_not_started(self) -> None:
+        """Stopping a server that was never started should not raise."""
+        server = DNSServer()
+        server.stop()  # Should not raise
+        assert server.is_running is False
+
+
+# ---------------------------------------------------------------------------
+# Module-level start/stop helpers
+# ---------------------------------------------------------------------------
+
+
+class TestModuleLevelHelpers:
+    """Test start_dns_server and stop_dns_server module-level functions."""
+
+    def test_start_dns_server_disabled(self) -> None:
+        with patch.dict(os.environ, {"DNS_DISABLED": "1"}):
+            result = start_dns_server()
+            assert result is None
+
+    def test_start_dns_server_bind_failure(self) -> None:
+        """If the port can't be bound, returns None without raising."""
+        with patch.dict(os.environ, {"DNS_PORT": "15401", "DNS_ADDRESS": "127.0.0.1"}):
+            with patch.object(DNSServer, "start", side_effect=OSError("Address in use")):
+                result = start_dns_server()
+                assert result is None
+
+    def test_stop_dns_server_when_none(self) -> None:
+        """stop_dns_server should handle None _server gracefully."""
+        import robotocore.dns.server as mod
+
+        original = mod._server
+        mod._server = None
+        try:
+            stop_dns_server()  # Should not raise
+        finally:
+            mod._server = original
+
+    def test_stop_dns_server_calls_stop(self) -> None:
+        import robotocore.dns.server as mod
+
+        mock_server = MagicMock()
+        original = mod._server
+        mod._server = mock_server
+        try:
+            stop_dns_server()
+            mock_server.stop.assert_called_once()
+            assert mod._server is None
+        finally:
+            mod._server = original
+
+    def test_start_returns_server_on_success(self) -> None:
+        with patch.dict(
+            os.environ, {"DNS_PORT": "15402", "DNS_ADDRESS": "127.0.0.1", "DNS_DISABLED": "0"}
+        ):
+            with patch.object(DNSServer, "start"):
+                result = start_dns_server()
+                assert result is not None
+                assert isinstance(result, DNSServer)
+                # Clean up
+                import robotocore.dns.server as mod
+
+                mod._server = None


### PR DESCRIPTION
## Summary
- dnslib-based UDP DNS server on port 53
- Resolves *.amazonaws.com to localhost
- Enables transparent SDK usage without endpoint_url

🤖 Generated with [Claude Code](https://claude.com/claude-code)