### PR TITLE
Add unified chaos + observability feedback loop

### DIFF
--- a/prompts/20260311-chaos-observability-loop.md
+++ b/prompts/20260311-chaos-observability-loop.md
@@ -1,0 +1,23 @@
+---
+role: assistant
+timestamp: "2026-03-11T21:30:00Z"
+session: chaos-observability-loop
+sequence: 1
+---
+
+# Chaos + Observability Feedback Loop
+
+## Human prompt
+Implement unified chaos + observability feedback loop: per-request context that flows through all middleware, chaos-audit bridge that records fault injections in the audit log, and a unified timeline API endpoint.
+
+## Implementation decisions
+
+1. **RequestContext as dataclass with contextvars**: Used `contextvars.ContextVar` for async-safe per-request state. The context carries `chaos_applied` list that accumulates events as middleware runs.
+
+2. **Audit log integration via `record()` kwargs**: The existing `AuditLog.record()` uses keyword-only args (service, operation, etc.), not a dict. The bridge calls it with `operation="chaos:{fault_type}"` and `error="chaos_injection:{rule_name}"` to distinguish chaos entries from normal API calls.
+
+3. **Timeline categorization**: Instead of separate storage, chaos events are identified by their `error` field prefix (`chaos_injection:`). This avoids schema changes to the ring buffer.
+
+4. **Minimal middleware changes**: Only added 2 `record_chaos_event()` calls in `chaos/middleware.py` — one for latency injection, one for error injection. Import is inside the function to avoid circular imports.
+
+5. **Route at `/_robotocore/timeline`**: Added between audit and usage routes in management_routes list.

--- a/src/robotocore/chaos/middleware.py
+++ b/src/robotocore/chaos/middleware.py
@@ -26,9 +26,12 @@ def chaos_handler(context: RequestContext) -> None:
     if rule is None:
         return
 
+    from robotocore.observability.chaos_audit_bridge import record_chaos_event
+
     # Use asyncio.sleep via asyncio.to_thread-compatible approach to avoid
     # blocking the event loop.
     if rule.latency_ms > 0:
+        record_chaos_event(rule.rule_id, "latency", {"latency_ms": rule.latency_ms})
         try:
             loop = asyncio.get_running_loop()
             # We're in an async context; schedule a non-blocking sleep
@@ -47,6 +50,11 @@ def chaos_handler(context: RequestContext) -> None:
                 "Message": rule.error_message,
                 "RequestId": request_id,
             }
+        )
+        record_chaos_event(
+            rule.rule_id,
+            "error",
+            {"status_code": rule.status_code, "error_code": rule.error_code},
         )
         context.response = Response(
             content=error_body,

--- a/src/robotocore/gateway/app.py
+++ b/src/robotocore/gateway/app.py
@@ -32,6 +32,13 @@ from robotocore.gateway.s3_routing import (
 from robotocore.gateway.tls import TLSConfig, get_cert_info
 from robotocore.observability.hooks import run_init_hooks
 from robotocore.observability.metrics import request_counter
+from robotocore.observability.request_context import (
+    RequestContext as ObsRequestContext,
+)
+from robotocore.observability.request_context import (
+    set_current_context,
+)
+from robotocore.observability.timeline import handle_timeline
 from robotocore.observability.tracing import TracingMiddleware
 from robotocore.providers.moto_bridge import forward_to_moto
 from robotocore.services.acm.provider import handle_acm_request
@@ -993,6 +1000,10 @@ async def handle_aws_request(request: Request) -> Response:
         account_id=account_id,
     )
 
+    # Set up per-request observability context for chaos/audit correlation
+    obs_ctx = ObsRequestContext(service=service_name)
+    set_current_context(obs_ctx)
+
     # Pre-read the body so synchronous handlers (populate_context_handler) can
     # access it via request._body for form-encoded Action parsing.
     await request.body()
@@ -1174,6 +1185,8 @@ management_routes = [
     Route("/_robotocore/resources/{service}", resources_for_service, methods=["GET"]),
     # Audit log
     Route("/_robotocore/audit", audit_log, methods=["GET"]),
+    # Unified timeline (chaos + audit)
+    Route("/_robotocore/timeline", handle_timeline, methods=["GET"]),
     # Usage analytics
     Route("/_robotocore/usage", usage_summary, methods=["GET"]),
     Route("/_robotocore/usage/services", usage_services, methods=["GET"]),

--- a/src/robotocore/observability/chaos_audit_bridge.py
+++ b/src/robotocore/observability/chaos_audit_bridge.py
@@ -1,0 +1,34 @@
+"""Bridge between chaos middleware and audit log for unified observability."""
+
+import logging
+
+from robotocore.observability.request_context import get_current_context
+
+logger = logging.getLogger(__name__)
+
+
+def record_chaos_event(rule_name: str, fault_type: str, details: dict) -> None:
+    """Record a chaos fault injection in both the request context and audit log."""
+    ctx = get_current_context()
+    if ctx:
+        ctx.chaos_applied.append(
+            {
+                "rule": rule_name,
+                "type": fault_type,
+                **details,
+            }
+        )
+
+    # Also record in audit log
+    try:
+        from robotocore.audit.log import get_audit_log
+
+        audit = get_audit_log()
+        audit.record(
+            service=ctx.service if ctx else "unknown",
+            operation=f"chaos:{fault_type}",
+            status_code=details.get("status_code", 0),
+            error=f"chaos_injection:{rule_name}",
+        )
+    except Exception:
+        logger.debug("Could not record chaos event in audit log", exc_info=True)

--- a/src/robotocore/observability/request_context.py
+++ b/src/robotocore/observability/request_context.py
@@ -1,0 +1,36 @@
+"""Per-request context for correlating chaos, audit, and observability events."""
+
+import contextvars
+import time
+import uuid
+from dataclasses import dataclass, field
+
+_current_request: contextvars.ContextVar["RequestContext | None"] = contextvars.ContextVar(
+    "request_context", default=None
+)
+
+
+@dataclass
+class RequestContext:
+    """Tracks observability state for a single request across middleware layers."""
+
+    request_id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    service: str = ""
+    operation: str = ""
+    start_time: float = field(default_factory=time.monotonic)
+    chaos_applied: list[dict] = field(default_factory=list)
+
+    @property
+    def elapsed_ms(self) -> float:
+        """Milliseconds since request started."""
+        return (time.monotonic() - self.start_time) * 1000
+
+
+def get_current_context() -> "RequestContext | None":
+    """Return the current request's observability context, or None."""
+    return _current_request.get()
+
+
+def set_current_context(ctx: "RequestContext") -> None:
+    """Set the observability context for the current request."""
+    _current_request.set(ctx)

--- a/src/robotocore/observability/timeline.py
+++ b/src/robotocore/observability/timeline.py
@@ -1,0 +1,35 @@
+"""Unified timeline combining audit log and chaos events."""
+
+import time
+
+from starlette.requests import Request
+from starlette.responses import JSONResponse
+
+
+async def handle_timeline(request: Request) -> JSONResponse:
+    """GET /_robotocore/timeline -- unified view of recent API calls + chaos events."""
+    from robotocore.audit.log import get_audit_log
+
+    limit = int(request.query_params.get("limit", "50"))
+    service_filter = request.query_params.get("service")
+
+    audit = get_audit_log()
+    entries = audit.recent(limit=limit * 2, service=service_filter)
+
+    # Annotate with category
+    for entry in entries:
+        error = entry.get("error") or ""
+        if error.startswith("chaos_injection:"):
+            entry["_category"] = "chaos"
+        else:
+            entry["_category"] = "api_call"
+
+    entries = entries[:limit]
+
+    return JSONResponse(
+        {
+            "entries": entries,
+            "count": len(entries),
+            "server_time": time.time(),
+        }
+    )

--- a/tests/unit/observability/test_chaos_audit_bridge.py
+++ b/tests/unit/observability/test_chaos_audit_bridge.py
@@ -1,0 +1,175 @@
+"""Tests for chaos-audit bridge and unified timeline."""
+
+from starlette.testclient import TestClient
+
+from robotocore.audit.log import AuditLog, get_audit_log
+from robotocore.observability.chaos_audit_bridge import record_chaos_event
+from robotocore.observability.request_context import (
+    RequestContext,
+    get_current_context,
+    set_current_context,
+)
+
+
+class TestRequestContext:
+    """Test per-request observability context."""
+
+    def test_create_context_with_defaults(self):
+        ctx = RequestContext()
+        assert ctx.request_id  # non-empty UUID
+        assert ctx.service == ""
+        assert ctx.operation == ""
+        assert ctx.chaos_applied == []
+
+    def test_create_context_with_service(self):
+        ctx = RequestContext(service="sqs", operation="SendMessage")
+        assert ctx.service == "sqs"
+        assert ctx.operation == "SendMessage"
+
+    def test_elapsed_ms(self):
+        ctx = RequestContext()
+        # elapsed_ms should be non-negative and small (just created)
+        assert ctx.elapsed_ms >= 0
+        assert ctx.elapsed_ms < 1000  # less than 1 second
+
+    def test_set_and_get_context(self):
+        ctx = RequestContext(service="dynamodb")
+        set_current_context(ctx)
+        retrieved = get_current_context()
+        assert retrieved is ctx
+        assert retrieved.service == "dynamodb"
+
+
+class TestRecordChaosEvent:
+    """Test chaos event recording in request context and audit log."""
+
+    def test_records_in_request_context(self):
+        ctx = RequestContext(service="s3", operation="GetObject")
+        set_current_context(ctx)
+
+        record_chaos_event("rule-1", "error", {"status_code": 503})
+
+        assert len(ctx.chaos_applied) == 1
+        assert ctx.chaos_applied[0]["rule"] == "rule-1"
+        assert ctx.chaos_applied[0]["type"] == "error"
+        assert ctx.chaos_applied[0]["status_code"] == 503
+
+    def test_records_in_audit_log(self, monkeypatch):
+        audit = AuditLog(max_size=100)
+        monkeypatch.setattr("robotocore.audit.log.get_audit_log", lambda: audit)
+
+        ctx = RequestContext(service="sqs", operation="SendMessage")
+        set_current_context(ctx)
+
+        # Call the function which imports get_audit_log internally
+        record_chaos_event("throttle-rule", "error", {"status_code": 429})
+
+        entries = audit.recent(limit=10)
+        assert len(entries) >= 1
+        chaos_entries = [e for e in entries if "chaos_injection" in (e.get("error") or "")]
+        assert len(chaos_entries) == 1
+        assert chaos_entries[0]["service"] == "sqs"
+        assert chaos_entries[0]["operation"] == "chaos:error"
+
+    def test_multiple_chaos_events_accumulate(self):
+        ctx = RequestContext(service="lambda")
+        set_current_context(ctx)
+
+        record_chaos_event("rule-a", "latency", {"latency_ms": 500})
+        record_chaos_event("rule-b", "error", {"status_code": 500})
+
+        assert len(ctx.chaos_applied) == 2
+        assert ctx.chaos_applied[0]["type"] == "latency"
+        assert ctx.chaos_applied[1]["type"] == "error"
+
+
+class TestTimeline:
+    """Test the unified timeline endpoint."""
+
+    def test_timeline_returns_entries(self):
+        from starlette.applications import Starlette
+        from starlette.routing import Route
+
+        from robotocore.observability.timeline import handle_timeline
+
+        app = Starlette(routes=[Route("/timeline", handle_timeline, methods=["GET"])])
+        client = TestClient(app)
+
+        # Record some audit entries first
+        audit = get_audit_log()
+        audit.record(service="s3", operation="PutObject", status_code=200)
+        audit.record(
+            service="sqs",
+            operation="chaos:error",
+            status_code=429,
+            error="chaos_injection:throttle-rule",
+        )
+
+        response = client.get("/timeline")
+        assert response.status_code == 200
+        data = response.json()
+        assert "entries" in data
+        assert "count" in data
+        assert "server_time" in data
+        assert data["count"] >= 2
+
+    def test_timeline_categories(self):
+        from starlette.applications import Starlette
+        from starlette.routing import Route
+
+        from robotocore.observability.timeline import handle_timeline
+
+        app = Starlette(routes=[Route("/timeline", handle_timeline, methods=["GET"])])
+        client = TestClient(app)
+
+        audit = get_audit_log()
+        audit.clear()
+        audit.record(service="s3", operation="PutObject", status_code=200)
+        audit.record(
+            service="sqs",
+            operation="chaos:error",
+            status_code=429,
+            error="chaos_injection:throttle-rule",
+        )
+
+        response = client.get("/timeline")
+        data = response.json()
+        categories = {e["_category"] for e in data["entries"]}
+        assert "api_call" in categories
+        assert "chaos" in categories
+
+    def test_timeline_service_filter(self):
+        from starlette.applications import Starlette
+        from starlette.routing import Route
+
+        from robotocore.observability.timeline import handle_timeline
+
+        app = Starlette(routes=[Route("/timeline", handle_timeline, methods=["GET"])])
+        client = TestClient(app)
+
+        audit = get_audit_log()
+        audit.clear()
+        audit.record(service="s3", operation="PutObject", status_code=200)
+        audit.record(service="sqs", operation="SendMessage", status_code=200)
+
+        response = client.get("/timeline?service=s3")
+        data = response.json()
+        assert all(e["service"] == "s3" for e in data["entries"])
+
+    def test_timeline_limit(self):
+        from starlette.applications import Starlette
+        from starlette.routing import Route
+
+        from robotocore.observability.timeline import handle_timeline
+
+        app = Starlette(routes=[Route("/timeline", handle_timeline, methods=["GET"])])
+        client = TestClient(app)
+
+        audit = get_audit_log()
+        audit.clear()
+        for i in range(10):
+            audit.record(service="s3", operation=f"Op{i}", status_code=200)
+
+        response = client.get("/timeline?limit=3")
+        data = response.json()
+        assert data["count"] == 3


### PR DESCRIPTION
## Summary
- Add per-request observability context (`contextvars`-based) that flows through all middleware layers, correlating chaos events with audit log entries
- Bridge chaos middleware to audit log: fault injections (latency, errors) now appear as audit entries with `chaos_injection:` prefix
- New `GET /_robotocore/timeline` endpoint returns a unified view of API calls and chaos events with category annotations and service filtering

## Test plan
- [x] 11 unit tests covering RequestContext creation/retrieval, chaos event recording in both context and audit log, timeline endpoint response shape/filtering/limits
- [x] All tests pass (`uv run pytest tests/unit/observability/test_chaos_audit_bridge.py`)
- [x] ruff lint + format clean
- [ ] Verify timeline endpoint manually with a running server

🤖 Generated with [Claude Code](https://claude.com/claude-code)