### PR TITLE
Fix asyncio test in test_moto_bridge.py

### DIFF
--- a/prompts/20260311-fix-moto-bridge-asyncio.md
+++ b/prompts/20260311-fix-moto-bridge-asyncio.md
@@ -1,0 +1,17 @@
+---
+role: assistant
+timestamp: "2026-03-11T21:15:00Z"
+session: fix-moto-bridge-asyncio
+sequence: 1
+---
+
+# Fix asyncio test in test_moto_bridge.py
+
+## Problem
+`TestHeadRequestInForwardWithBody::test_forward_to_moto_with_body_preserves_content_length_for_head`
+uses `@pytest.mark.asyncio` with `async def`, but pytest-asyncio is not configured. In Python 3.12+
+with pytest-xdist workers, `asyncio.get_event_loop()` raises RuntimeError.
+
+## Fix
+Replace `@pytest.mark.asyncio async def` with plain `def` using `asyncio.run()` to call the async
+function. This matches the pattern used in all other async tests in the codebase.

--- a/tests/unit/providers/test_moto_bridge.py
+++ b/tests/unit/providers/test_moto_bridge.py
@@ -324,9 +324,9 @@ class TestHeadRequestInForwardWithBody:
     the content-length header that HEAD responses must include.
     """
 
-    @pytest.mark.asyncio
-    async def test_forward_to_moto_with_body_preserves_content_length_for_head(self):
+    def test_forward_to_moto_with_body_preserves_content_length_for_head(self):
         """HEAD responses must keep content-length and have empty body."""
+        import asyncio
         from unittest.mock import MagicMock, patch
 
         from robotocore.providers.moto_bridge import forward_to_moto_with_body
@@ -359,7 +359,7 @@ class TestHeadRequestInForwardWithBody:
                 return_value=MagicMock(),
             ),
         ):
-            response = await forward_to_moto_with_body(mock_request, "s3", b"")
+            response = asyncio.run(forward_to_moto_with_body(mock_request, "s3", b""))
 
         # HEAD response MUST have empty body
         assert response.body == b"", f"HEAD response body should be empty but got {response.body!r}"


### PR DESCRIPTION
## Summary
- Replace `@pytest.mark.asyncio async def` with plain `def` + `asyncio.run()` in `TestHeadRequestInForwardWithBody`
- Fixes RuntimeError in Python 3.12+ when pytest-asyncio is not configured

## Test plan
- [x] `uv run pytest tests/unit/providers/test_moto_bridge.py -q` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)