### PR TITLE
Fix code quality bot findings from PRs #108 and #111

### DIFF
--- a/prompts/20260312-050000-code-quality-fixes.md
+++ b/prompts/20260312-050000-code-quality-fixes.md
@@ -1,0 +1,30 @@
+---
+session: "migration-parity"
+timestamp: "2026-03-12T05:00:00Z"
+model: claude-opus-4-6
+sequence: 8
+---
+
+## Human
+
+Launch an agent for every PR — including merged ones — and look for
+github-code-quality comments. For each one, review the file in question
+and potentially make a new PR with fixes.
+
+## Assistant
+
+## Key decisions
+
+**Found code quality bot comments on 3 PRs**: #95 (open), #108 (merged), #111
+(merged). All were "empty except" warnings plus one "unused variable" warning.
+
+**Fixes are comment-only for the empty excepts**: Each bare `except: pass` is
+intentional (keyboard interrupt handling, polling loops, best-effort cleanup).
+Added explanatory comments rather than restructuring the code, since the logic
+is correct.
+
+**Removed unused variables in test**: The test unpacked `result, error_type, logs`
+but only asserted on the mock call. Changed to not capture the return value.
+
+**PR #95 is still open**: Its code quality issue lives on a feature branch, not
+main. Fixed separately on that branch.

--- a/src/robotocore/cli.py
+++ b/src/robotocore/cli.py
@@ -179,7 +179,7 @@ def cmd_logs(args: argparse.Namespace) -> int:
         print(f"Failed to get logs for container '{name}'.", file=sys.stderr)
         return 1
     except KeyboardInterrupt:
-        pass
+        pass  # User pressed Ctrl+C to stop following logs
     return 0
 
 
@@ -219,7 +219,7 @@ def cmd_wait(args: argparse.Namespace) -> int:
                 print("Robotocore is ready.")
                 return 0
         except (urllib.error.URLError, TimeoutError, OSError, json.JSONDecodeError):
-            pass
+            pass  # Server not ready yet, retry after sleep
         time.sleep(1)
 
     print(f"Timed out after {timeout}s waiting for robotocore to become healthy.", file=sys.stderr)

--- a/src/robotocore/services/lambda_/docker_executor.py
+++ b/src/robotocore/services/lambda_/docker_executor.py
@@ -355,7 +355,7 @@ class DockerLambdaExecutor:
                     if isinstance(error_obj, dict) and "errorMessage" in error_obj:
                         return error_obj, "Handled", logs
                 except json.JSONDecodeError:
-                    pass
+                    pass  # stdout isn't JSON; fall through to generic error
             return (
                 {
                     "errorMessage": stdout or "Function execution failed",
@@ -385,7 +385,7 @@ class DockerLambdaExecutor:
                 timeout=10,
             )
         except Exception:
-            pass
+            pass  # Best-effort cleanup; container may already be gone
 
     def _execute_local_fallback(
         self,

--- a/tests/unit/services/test_lambda_docker_executor.py
+++ b/tests/unit/services/test_lambda_docker_executor.py
@@ -484,7 +484,7 @@ class TestDockerLambdaExecutor:
 
             with patch.object(executor, "_execute_local_fallback") as mock_fallback:
                 mock_fallback.return_value = ({"fallback": True}, None, "")
-                result, error_type, logs = executor.execute(
+                executor.execute(
                     code_zip=b"fake-zip",
                     handler="handler.main",
                     event={},


### PR DESCRIPTION
## Summary
- Add explanatory comments to bare `except: pass` clauses in `cli.py` and `docker_executor.py`
- Remove unused variable unpacking in `test_lambda_docker_executor.py`

Addresses `github-code-quality[bot]` comments from merged PRs #108 and #111.

## Test plan
- [x] `uv run pytest tests/unit/test_cli.py tests/unit/services/test_lambda_docker_executor.py` — 90 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)