### PR TITLE
Add Lambda Function URL routing in the gateway

### DIFF
--- a/prompts/20260312-070000-lambda-function-url-routing.md
+++ b/prompts/20260312-070000-lambda-function-url-routing.md
@@ -1,0 +1,30 @@
+---
+session: "a168fa9f"
+timestamp: "2026-03-12T07:00:00Z"
+model: claude-opus-4-6
+---
+
+## Human
+
+Implement Lambda Function URL routing in the gateway. Function URLs are created via the Lambda API but the gateway never actually routes HTTP requests to them.
+
+Research the existing function URL CRUD in provider.py and urls.py, then add routing in the gateway middleware to detect function URL requests and invoke the target Lambda with the API Gateway v2 payload format.
+
+## Assistant
+
+## Key decisions
+
+**Routing approach**: Added path-based routing (`/lambda-url/{url-id}/...`) in `AWSRoutingMiddleware`, placed after the S3 website check and before the S3 vhost rewrite. Also supports Host header matching (`{url-id}.lambda-url.{region}.on.aws`). Path-based is the primary mechanism for local testing since Host header manipulation is harder without DNS.
+
+**Event format**: Builds the API Gateway v2 payload format with `version: "2.0"`, `requestContext.http.method`, `rawPath`, `rawQueryString`, `queryStringParameters`, `headers`, `body`, and `isBase64Encoded`. This matches what AWS sends to Lambda functions invoked via function URLs.
+
+**Response handling**: Supports both structured responses (with `statusCode`, `body`, `headers`) and simple return values. Structured responses map directly to HTTP responses; simple values are JSON-serialized with 200 status.
+
+**CORS**: Reads the CORS config from the function URL config and applies the appropriate `access-control-*` headers. Supports wildcard and specific origin matching.
+
+**Architecture**: Created `src/robotocore/gateway/lambda_url.py` as a self-contained module (like `s3_routing.py` and the API Gateway execution handlers). Reads directly from the `_url_configs` store in `services/lambda_/urls.py` to find configs by URL ID.
+
+**Files changed**:
+- `src/robotocore/gateway/lambda_url.py` (new) — function URL detection, event building, invocation
+- `src/robotocore/gateway/app.py` — import + routing in AWSRoutingMiddleware
+- `tests/compatibility/test_lambda_function_urls_compat.py` (new) — 9 compat tests, 100% effective

--- a/src/robotocore/gateway/app.py
+++ b/src/robotocore/gateway/app.py
@@ -23,6 +23,12 @@ from robotocore.gateway.handlers import (
     logging_response_handler,
     populate_context_handler,
 )
+from robotocore.gateway.lambda_url import (
+    _extract_url_id_from_path,
+    _parse_function_url_host,
+    handle_function_url_request,
+    is_function_url_request,
+)
 from robotocore.gateway.router import route_to_service
 from robotocore.gateway.s3_routing import (
     get_s3_routing_config,
@@ -1325,6 +1331,26 @@ class AWSRoutingMiddleware:
                     request,
                     bucket_name=parsed["bucket"],
                     region=parsed.get("region", "us-east-1"),
+                )
+                await response(scope, receive, send)
+                return
+
+        # --- Lambda Function URLs: /lambda-url/{url-id}/... or Host header ---
+        if is_function_url_request(scope):
+            request = Request(scope, receive)
+            # Try path-based routing first
+            if path.startswith("/lambda-url/"):
+                url_id, remaining_path = _extract_url_id_from_path(path)
+            else:
+                # Host-header based routing
+                host = request.headers.get("host", "")
+                url_id = _parse_function_url_host(host)
+                remaining_path = path or "/"
+            if url_id:
+                response = await handle_function_url_request(
+                    request,
+                    url_id=url_id,
+                    path=remaining_path,
                 )
                 await response(scope, receive, send)
                 return

--- a/src/robotocore/gateway/lambda_url.py
+++ b/src/robotocore/gateway/lambda_url.py
@@ -1,0 +1,275 @@
+"""Lambda Function URL routing — invokes Lambda functions via their Function URLs.
+
+When a function URL config is created, the function becomes invocable at a URL like:
+  https://{url-id}.lambda-url.{region}.on.aws/
+
+In the emulator, we route requests matching the path pattern:
+  /lambda-url/{url-id}/{path}
+or Host header matching:
+  {url-id}.lambda-url.{region}.on.aws
+
+The request is converted to the API Gateway v2 payload format and the Lambda
+function is invoked. The function's return value becomes the HTTP response.
+"""
+
+import base64
+import json
+import logging
+import time
+
+from starlette.requests import Request
+from starlette.responses import Response
+
+from robotocore.services.lambda_.invoke import invoke_lambda_sync
+from robotocore.services.lambda_.urls import _url_configs, _url_lock
+
+logger = logging.getLogger(__name__)
+
+
+def find_config_by_url_id(url_id: str) -> dict | None:
+    """Find a function URL config by its URL ID prefix."""
+    with _url_lock:
+        for config in _url_configs.values():
+            func_url = config.get("FunctionUrl", "")
+            # FunctionUrl looks like https://{url_id}.lambda-url.{region}.on.aws/
+            if f"https://{url_id}." in func_url:
+                return dict(config)
+    return None
+
+
+def _parse_function_url_host(host: str) -> str | None:
+    """Extract the url-id from a lambda-url Host header.
+
+    Pattern: {url-id}.lambda-url.{region}.on.aws
+    Returns the url-id or None if the host doesn't match.
+    """
+    if ".lambda-url." not in host:
+        return None
+    # Strip port if present
+    hostname = host.split(":")[0]
+    parts = hostname.split(".")
+    # Expect: url-id.lambda-url.region.on.aws (5 parts)
+    if len(parts) >= 5 and parts[1] == "lambda-url" and parts[3] == "on" and parts[4] == "aws":
+        return parts[0]
+    return None
+
+
+def is_function_url_request(scope: dict) -> bool:
+    """Check if an ASGI scope represents a Lambda function URL request."""
+    # Check path pattern: /lambda-url/{url-id}/...
+    path = scope.get("path", "")
+    if path.startswith("/lambda-url/"):
+        return True
+
+    # Check Host header pattern
+    for key, val in scope.get("headers", []):
+        if key == b"host":
+            host = val.decode("latin-1")
+            if ".lambda-url." in host:
+                return True
+            break
+
+    return False
+
+
+def _extract_url_id_from_path(path: str) -> tuple[str, str]:
+    """Extract url-id and remaining path from /lambda-url/{url-id}/{path}.
+
+    Returns (url_id, remaining_path).
+    """
+    # /lambda-url/{url-id}/...
+    parts = path.split("/", 3)  # ['', 'lambda-url', 'url-id', 'rest...']
+    url_id = parts[2] if len(parts) > 2 else ""
+    remaining = "/" + parts[3] if len(parts) > 3 else "/"
+    return url_id, remaining
+
+
+def _build_function_url_event(
+    request: Request,
+    body: bytes,
+    path: str,
+    url_id: str,
+    func_arn: str,
+) -> dict:
+    """Build the API Gateway v2 payload format event for a function URL invocation."""
+    headers = dict(request.headers)
+    query_params = dict(request.query_params)
+    method = request.method
+
+    # Determine if body is base64 encoded
+    is_base64 = False
+    body_str = ""
+    if body:
+        try:
+            body_str = body.decode("utf-8")
+        except UnicodeDecodeError:
+            body_str = base64.b64encode(body).decode("ascii")
+            is_base64 = True
+
+    # Build queryStringParameters (single values, last wins — matches AWS behavior)
+    query_string_params = None
+    if query_params:
+        query_string_params = dict(query_params)
+
+    # Build the raw query string
+    raw_query = request.url.query or ""
+
+    # Request context
+    now = time.time()
+    time_str = time.strftime("%d/%b/%Y:%H:%M:%S +0000", time.gmtime(now))
+    epoch_ms = int(now * 1000)
+
+    request_context = {
+        "accountId": "123456789012",
+        "apiId": url_id,
+        "domainName": f"{url_id}.lambda-url.us-east-1.on.aws",
+        "domainPrefix": url_id,
+        "http": {
+            "method": method,
+            "path": path,
+            "protocol": "HTTP/1.1",
+            "sourceIp": request.client.host if request.client else "127.0.0.1",
+            "userAgent": headers.get("user-agent", ""),
+        },
+        "requestId": f"req-{url_id}-{epoch_ms}",
+        "routeKey": "$default",
+        "stage": "$default",
+        "time": time_str,
+        "timeEpoch": epoch_ms,
+    }
+
+    event = {
+        "version": "2.0",
+        "routeKey": "$default",
+        "rawPath": path,
+        "rawQueryString": raw_query,
+        "headers": headers,
+        "requestContext": request_context,
+        "isBase64Encoded": is_base64,
+    }
+
+    if body_str:
+        event["body"] = body_str
+
+    if query_string_params:
+        event["queryStringParameters"] = query_string_params
+
+    return event
+
+
+async def handle_function_url_request(
+    request: Request,
+    url_id: str,
+    path: str,
+) -> Response:
+    """Handle a Lambda function URL invocation.
+
+    Builds the v2 event format, invokes the function, and returns the response.
+    """
+    config = find_config_by_url_id(url_id)
+    if not config:
+        return Response(
+            content=json.dumps({"message": "Function URL not found"}),
+            status_code=404,
+            media_type="application/json",
+        )
+
+    func_arn = config.get("FunctionArn", "")
+    cors_config = config.get("Cors", {})
+
+    body = await request.body()
+    event = _build_function_url_event(request, body, path, url_id, func_arn)
+
+    # Parse region and account from the ARN
+    arn_parts = func_arn.split(":")
+    region = arn_parts[3] if len(arn_parts) > 3 else "us-east-1"
+    account_id = arn_parts[4] if len(arn_parts) > 4 else "123456789012"
+
+    result, error_type, logs = invoke_lambda_sync(
+        function_arn=func_arn,
+        payload=event,
+        region=region,
+        account_id=account_id,
+    )
+
+    # Build response from Lambda result
+    resp_headers: dict[str, str] = {}
+
+    # Apply CORS headers if configured
+    if cors_config:
+        if cors_config.get("AllowOrigins"):
+            origins = cors_config["AllowOrigins"]
+            request_origin = request.headers.get("origin", "")
+            if "*" in origins:
+                resp_headers["access-control-allow-origin"] = "*"
+            elif request_origin in origins:
+                resp_headers["access-control-allow-origin"] = request_origin
+        if cors_config.get("AllowMethods"):
+            resp_headers["access-control-allow-methods"] = ", ".join(cors_config["AllowMethods"])
+        if cors_config.get("AllowHeaders"):
+            resp_headers["access-control-allow-headers"] = ", ".join(cors_config["AllowHeaders"])
+        if cors_config.get("ExposeHeaders"):
+            resp_headers["access-control-expose-headers"] = ", ".join(cors_config["ExposeHeaders"])
+        if cors_config.get("MaxAge") is not None:
+            resp_headers["access-control-max-age"] = str(cors_config["MaxAge"])
+        if cors_config.get("AllowCredentials"):
+            resp_headers["access-control-allow-credentials"] = "true"
+
+    if error_type:
+        error_body = json.dumps(
+            {
+                "errorMessage": str(result) if result else error_type,
+                "errorType": error_type,
+            }
+        )
+        resp_headers["x-amzn-errortype"] = error_type
+        return Response(
+            content=error_body,
+            status_code=502,
+            headers=resp_headers,
+            media_type="application/json",
+        )
+
+    # Lambda can return a structured response (like API Gateway v2 format)
+    # or a simple value
+    if isinstance(result, dict):
+        # Check if it's a structured response with statusCode
+        if "statusCode" in result:
+            status_code = int(result["statusCode"])
+            resp_body = result.get("body", "")
+            if result.get("headers"):
+                resp_headers.update(result["headers"])
+            if result.get("isBase64Encoded") and resp_body:
+                resp_body = base64.b64decode(resp_body)
+                return Response(
+                    content=resp_body,
+                    status_code=status_code,
+                    headers=resp_headers,
+                )
+            return Response(
+                content=resp_body if isinstance(resp_body, str) else json.dumps(resp_body),
+                status_code=status_code,
+                headers=resp_headers,
+                media_type="application/json",
+            )
+        # Simple dict response
+        return Response(
+            content=json.dumps(result),
+            status_code=200,
+            headers=resp_headers,
+            media_type="application/json",
+        )
+    elif isinstance(result, str):
+        return Response(
+            content=result,
+            status_code=200,
+            headers=resp_headers,
+            media_type="application/json",
+        )
+    else:
+        return Response(
+            content=json.dumps(result) if result is not None else "null",
+            status_code=200,
+            headers=resp_headers,
+            media_type="application/json",
+        )

--- a/tests/compatibility/test_lambda_function_urls_compat.py
+++ b/tests/compatibility/test_lambda_function_urls_compat.py
@@ -1,0 +1,259 @@
+"""Lambda Function URL compatibility tests — create, invoke via HTTP, verify response."""
+
+import io
+import json
+import zipfile
+
+import pytest
+import requests
+
+from tests.compatibility.conftest import ENDPOINT_URL, make_client
+
+
+def _make_zip(code: str) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("lambda_function.py", code)
+    return buf.getvalue()
+
+
+@pytest.fixture
+def lam():
+    return make_client("lambda")
+
+
+@pytest.fixture
+def iam():
+    return make_client("iam")
+
+
+@pytest.fixture
+def role(iam):
+    trust = json.dumps(
+        {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Principal": {"Service": "lambda.amazonaws.com"},
+                    "Action": "sts:AssumeRole",
+                }
+            ],
+        }
+    )
+    role_name = "lambda-furl-test-role"
+    iam.create_role(RoleName=role_name, AssumeRolePolicyDocument=trust)
+    yield f"arn:aws:iam::123456789012:role/{role_name}"
+    iam.delete_role(RoleName=role_name)
+
+
+def _create_echo_function(lam, role, func_name: str) -> None:
+    """Create a Lambda that echoes event details back as a structured response."""
+    code = _make_zip(
+        """import json
+
+def handler(event, ctx):
+    body = {
+        "method": event.get("requestContext", {}).get("http", {}).get("method", ""),
+        "path": event.get("rawPath", ""),
+        "queryStringParameters": event.get("queryStringParameters"),
+        "headers": event.get("headers", {}),
+        "body": event.get("body"),
+        "isBase64Encoded": event.get("isBase64Encoded", False),
+        "rawQueryString": event.get("rawQueryString", ""),
+        "version": event.get("version", ""),
+    }
+    return {
+        "statusCode": 200,
+        "headers": {"content-type": "application/json", "x-custom-echo": "true"},
+        "body": json.dumps(body),
+    }
+"""
+    )
+    lam.create_function(
+        FunctionName=func_name,
+        Runtime="python3.12",
+        Role=role,
+        Handler="lambda_function.handler",
+        Code={"ZipFile": code},
+    )
+
+
+def _get_url_id(lam, func_name: str) -> str:
+    """Create a function URL config and return the url-id."""
+    resp = lam.create_function_url_config(
+        FunctionName=func_name,
+        AuthType="NONE",
+    )
+    # FunctionUrl looks like https://{url-id}.lambda-url.{region}.on.aws/
+    return resp["FunctionUrl"].split("//")[1].split(".")[0]
+
+
+class TestFunctionUrlInvocation:
+    """Test invoking Lambda functions via function URLs."""
+
+    def test_get_request_returns_response(self, lam, role):
+        """Create function URL, invoke via HTTP GET, verify response."""
+        func_name = "furl-get-test"
+        _create_echo_function(lam, role, func_name)
+        try:
+            url_id = _get_url_id(lam, func_name)
+            resp = requests.get(f"{ENDPOINT_URL}/lambda-url/{url_id}/")
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["method"] == "GET"
+            assert body["path"] == "/"
+            assert body["version"] == "2.0"
+            # Cleanup URL config
+            lam.delete_function_url_config(FunctionName=func_name)
+        finally:
+            lam.delete_function(FunctionName=func_name)
+
+    def test_post_with_json_body(self, lam, role):
+        """POST with JSON body, verify event.body contains it."""
+        func_name = "furl-post-test"
+        _create_echo_function(lam, role, func_name)
+        try:
+            url_id = _get_url_id(lam, func_name)
+            payload = {"key": "value", "number": 42}
+            resp = requests.post(
+                f"{ENDPOINT_URL}/lambda-url/{url_id}/",
+                json=payload,
+            )
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["method"] == "POST"
+            # The body should be the JSON-encoded payload string
+            received_body = json.loads(body["body"])
+            assert received_body["key"] == "value"
+            assert received_body["number"] == 42
+            lam.delete_function_url_config(FunctionName=func_name)
+        finally:
+            lam.delete_function(FunctionName=func_name)
+
+    def test_get_with_query_params(self, lam, role):
+        """GET with query params, verify event.queryStringParameters."""
+        func_name = "furl-query-test"
+        _create_echo_function(lam, role, func_name)
+        try:
+            url_id = _get_url_id(lam, func_name)
+            resp = requests.get(
+                f"{ENDPOINT_URL}/lambda-url/{url_id}/",
+                params={"foo": "bar", "baz": "123"},
+            )
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["queryStringParameters"]["foo"] == "bar"
+            assert body["queryStringParameters"]["baz"] == "123"
+            assert "foo=" in body["rawQueryString"]
+            lam.delete_function_url_config(FunctionName=func_name)
+        finally:
+            lam.delete_function(FunctionName=func_name)
+
+    def test_custom_headers_forwarded(self, lam, role):
+        """Custom headers are forwarded in the event."""
+        func_name = "furl-headers-test"
+        _create_echo_function(lam, role, func_name)
+        try:
+            url_id = _get_url_id(lam, func_name)
+            resp = requests.get(
+                f"{ENDPOINT_URL}/lambda-url/{url_id}/",
+                headers={"X-Custom-Header": "test-value", "X-Another": "abc"},
+            )
+            assert resp.status_code == 200
+            body = resp.json()
+            # Headers are lowercased in the event
+            assert body["headers"]["x-custom-header"] == "test-value"
+            assert body["headers"]["x-another"] == "abc"
+            lam.delete_function_url_config(FunctionName=func_name)
+        finally:
+            lam.delete_function(FunctionName=func_name)
+
+    def test_response_headers_from_lambda(self, lam, role):
+        """Lambda's response headers are returned in the HTTP response."""
+        func_name = "furl-resp-headers-test"
+        _create_echo_function(lam, role, func_name)
+        try:
+            url_id = _get_url_id(lam, func_name)
+            resp = requests.get(f"{ENDPOINT_URL}/lambda-url/{url_id}/")
+            assert resp.status_code == 200
+            assert resp.headers.get("x-custom-echo") == "true"
+            lam.delete_function_url_config(FunctionName=func_name)
+        finally:
+            lam.delete_function(FunctionName=func_name)
+
+    def test_path_forwarded(self, lam, role):
+        """Sub-paths after the url-id are forwarded."""
+        func_name = "furl-path-test"
+        _create_echo_function(lam, role, func_name)
+        try:
+            url_id = _get_url_id(lam, func_name)
+            resp = requests.get(f"{ENDPOINT_URL}/lambda-url/{url_id}/api/items/123")
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["path"] == "/api/items/123"
+            lam.delete_function_url_config(FunctionName=func_name)
+        finally:
+            lam.delete_function(FunctionName=func_name)
+
+    def test_nonexistent_url_returns_404(self):
+        """Request to a non-existent function URL returns 404."""
+        resp = requests.get(f"{ENDPOINT_URL}/lambda-url/nonexistent123/")
+        assert resp.status_code == 404
+
+
+class TestFunctionUrlCORS:
+    """Test CORS header handling on function URLs."""
+
+    def test_cors_headers_returned(self, lam, role):
+        """CORS config on the function URL is reflected in response headers."""
+        func_name = "furl-cors-test"
+        _create_echo_function(lam, role, func_name)
+        try:
+            # Create function URL with CORS config
+            resp = lam.create_function_url_config(
+                FunctionName=func_name,
+                AuthType="NONE",
+                Cors={
+                    "AllowOrigins": ["https://example.com"],
+                    "AllowMethods": ["GET", "POST"],
+                    "AllowHeaders": ["X-Custom-Header"],
+                    "MaxAge": 3600,
+                },
+            )
+            url_id = resp["FunctionUrl"].split("//")[1].split(".")[0]
+
+            resp = requests.get(
+                f"{ENDPOINT_URL}/lambda-url/{url_id}/",
+                headers={"Origin": "https://example.com"},
+            )
+            assert resp.status_code == 200
+            assert resp.headers.get("access-control-allow-origin") == "https://example.com"
+            assert "GET" in resp.headers.get("access-control-allow-methods", "")
+            assert "POST" in resp.headers.get("access-control-allow-methods", "")
+            assert resp.headers.get("access-control-max-age") == "3600"
+            lam.delete_function_url_config(FunctionName=func_name)
+        finally:
+            lam.delete_function(FunctionName=func_name)
+
+    def test_cors_wildcard_origin(self, lam, role):
+        """Wildcard origin returns * in Access-Control-Allow-Origin."""
+        func_name = "furl-cors-wildcard"
+        _create_echo_function(lam, role, func_name)
+        try:
+            resp = lam.create_function_url_config(
+                FunctionName=func_name,
+                AuthType="NONE",
+                Cors={"AllowOrigins": ["*"]},
+            )
+            url_id = resp["FunctionUrl"].split("//")[1].split(".")[0]
+
+            resp = requests.get(
+                f"{ENDPOINT_URL}/lambda-url/{url_id}/",
+                headers={"Origin": "https://anything.com"},
+            )
+            assert resp.status_code == 200
+            assert resp.headers.get("access-control-allow-origin") == "*"
+            lam.delete_function_url_config(FunctionName=func_name)
+        finally:
+            lam.delete_function(FunctionName=func_name)


### PR DESCRIPTION
## Summary
- Lambda Function URLs can now be invoked via HTTP at `/lambda-url/{url-id}/...`
- Requests are converted to the API Gateway v2 payload format and the Lambda function is invoked
- Supports CORS headers from the function URL config, query params, custom headers, sub-paths, and structured responses
- Also supports Host header routing (`{url-id}.lambda-url.{region}.on.aws`)

## Test plan
- [x] 9 new compat tests in `test_lambda_function_urls_compat.py`, all passing
- [x] 100% effective test rate (validate_test_quality.py)
- [x] All existing gateway unit tests still pass (593 passed)
- [x] Tests cover: GET, POST with JSON body, query params, custom headers, response headers, sub-paths, 404 for nonexistent, CORS with specific origin, CORS with wildcard

🤖 Generated with [Claude Code](https://claude.com/claude-code)