### PR TITLE
Add prompt log for lambda testing session

### DIFF
--- a/prompts/20260312-040000-lambda-testing-and-bugfixes.md
+++ b/prompts/20260312-040000-lambda-testing-and-bugfixes.md
@@ -1,0 +1,90 @@
+---
+session: "find-every-problem"
+timestamp: "2026-03-12T04:00:00Z"
+model: claude-opus-4-6
+tools: [subagent, git-worktree]
+sequence: 1
+---
+
+## Human
+
+Everything needs robust testing. Spawn agents with this goal: Our CI must
+find every possible problem with our system before a user does.
+
+[Later]: I'm going to bed. You're in charge. Find every problem with robotocore
+and fix it. Do whatever it takes.
+
+## Assistant
+
+## Key decisions
+
+### Phase 1: Lambda Runtime Testing (#118-#124)
+
+**Discovery**: Only Python Lambda had real e2e tests. Node.js had 1 test
+(create only, no invoke). Ruby, Java, .NET, and custom runtimes had zero.
+
+**Approach**: 6 parallel worktree agents, one per runtime family. Each agent
+wrote actual code in the target language, zipped it, created Lambda functions,
+invoked them, and asserted on results.
+
+**Bugs found**:
+- **Async deadlock** (critical): `executor.execute()` called synchronously in
+  async handler. Any Lambda calling back to robotocore (S3, DynamoDB) would hang
+  forever. Fixed with `asyncio.to_thread()`.
+- **Bool/int/float serialization**: `True` → `"True"` (invalid JSON) instead of
+  `"true"`. Fixed `json.dumps` path for scalar types.
+- **Layers never extracted**: `get_layer_zips()` existed but was never called
+  during sync invocations. Fixed call chain.
+- **Handler-not-found returned null body**: `Runtime.HandlerNotFound` returned
+  `None` result → `null` JSON. Fixed to return structured error dict.
+- **Subprocess timeout returned None**: `run_subprocess()` returned
+  `(None, "Task.TimedOut", ...)`. Fixed to return structured error dict.
+- **.NET executor fundamentally broken**: Bootstrap.cs template had Python
+  `{{` escaping but was never format-interpolated (57 compilation errors).
+  Rewrote the entire dotnet executor.
+
+### Phase 2: Systematic Audit (#125-#135)
+
+**Async deadlock audit**: Found same pattern in Step Functions provider and
+state manager endpoints. Fixed both with `asyncio.to_thread()`.
+
+**State save/load audit**: Found `pickle.dump()` crashes when Moto backends
+contain `threading.Lock` (SQS, ECR, StepFunctions). Built custom
+`_ThreadSafePickler` that intercepts threading primitives and replaces with
+picklable sentinels. Also found `_RestrictedUnpickler` was too restrictive
+(blocked `builtins.getattr`, missing `ipaddress` module for EC2/VPC).
+
+**Lambda API surface audit**: Found DLQ dispatch was broken (3 bugs in
+`dispatch_to_dlq`), Function URLs weren't routable via gateway, destinations
+existed but had zero test coverage. Fixed all and wrote tests.
+
+**What I chose NOT to fix**: SnapStart, Lambda@Edge, container image support,
+response streaming wire format — these are substantial features that need
+design decisions, not quick fixes. Documented as known gaps.
+
+### Phase 3: Broader Service Testing
+
+**S3 notifications**: Already implemented, just untested. Wrote 11 tests
+covering S3→SQS, S3→SNS, prefix/suffix filters, delete events.
+
+**Error wire format**: 34 tests across all 5 AWS protocols (rest-xml, json,
+rest-json, query, ec2) verifying error response structure matches AWS.
+
+**CloudFormation**: 12 tests verifying CFN actually provisions resources in
+target services (not just that CFN API calls succeed).
+
+**Concurrent requests**: 10 stress tests with ThreadPoolExecutor verifying
+no race conditions under load.
+
+**IAM enforcement**: 15 tests covering policy evaluation. Found and fixed
+middleware reading `os.environ` instead of `RuntimeConfig`.
+
+**Chaos engineering**: 17 tests covering fault injection. Found latency
+injection is fire-and-forget (doesn't actually delay responses).
+
+### What I skipped
+
+- Moto source changes (risky, need upstream strategy)
+- Provisioned concurrency enforcement (stored but not enforced — by design?)
+- Recursion detection (stored but never checked — unclear if worth implementing)
+- Code signing validation (stored but never validated — AWS-specific crypto)


### PR DESCRIPTION
## Summary
- Documents the find-every-problem session (PRs #116-#135)
- Covers Lambda runtime testing, async deadlock fixes, state serialization hardening

## Test plan
- [x] No code changes, documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)