### PR TITLE
Fix path traversal in archive extraction (cloud pods + Lambda ZIP)

### DIFF
--- a/prompts/20260312-051000-archive-path-traversal.md
+++ b/prompts/20260312-051000-archive-path-traversal.md
@@ -1,0 +1,22 @@
+---
+session: "find-every-problem"
+timestamp: "2026-03-12T05:10:00Z"
+model: claude-opus-4-6
+sequence: 5
+---
+
+## Human
+
+Find every problem with robotocore and fix it.
+
+## Assistant
+
+## Key decisions
+
+**Cloud Pods tar extraction**: Added `filter='data'` to `tar.extractall()` in
+cloud_pods.py. This Python 3.12+ feature blocks path traversal attacks via
+`../` entries in tarballs. Previously only mitigated by using a temp directory.
+
+**Lambda ZIP extraction**: Added member name validation before `zf.extractall()`
+in executor.py. Rejects any zip entry starting with `/` or containing `..` path
+components. Protects against Zip Slip attacks from malicious Lambda code packages.

--- a/src/robotocore/services/lambda_/executor.py
+++ b/src/robotocore/services/lambda_/executor.py
@@ -291,10 +291,16 @@ class CodeCache:
                 for layer_zip in layer_zips:
                     try:
                         with zipfile.ZipFile(io.BytesIO(layer_zip)) as zf:
+                            for name in zf.namelist():
+                                if name.startswith("/") or ".." in name.split("/"):
+                                    raise ValueError(f"Unsafe path in ZIP archive: {name}")
                             zf.extractall(tmpdir)
                     except (zipfile.BadZipFile, OSError):
                         logger.warning("CodeCache: failed to extract layer zip")
             with zipfile.ZipFile(io.BytesIO(code_zip)) as zf:
+                for name in zf.namelist():
+                    if name.startswith("/") or ".." in name.split("/"):
+                        raise ValueError(f"Unsafe path in ZIP archive: {name}")
                 zf.extractall(tmpdir)
         except (zipfile.BadZipFile, OSError) as exc:
             # Clean up on extraction failure

--- a/src/robotocore/state/cloud_pods.py
+++ b/src/robotocore/state/cloud_pods.py
@@ -185,7 +185,7 @@ class CloudPodsManager:
         # Extract and load
         with tempfile.TemporaryDirectory() as tmpdir:
             with tarfile.open(fileobj=io.BytesIO(archive_bytes), mode="r:gz") as tar:
-                tar.extractall(tmpdir)  # noqa: S202
+                tar.extractall(tmpdir, filter="data")
 
             tmp_path = Path(tmpdir)
             moto_path = tmp_path / "moto_state.pkl"


### PR DESCRIPTION
## Summary
- **Cloud Pods**: Add `filter='data'` to `tar.extractall()` — blocks path traversal via `../` entries in tarballs
- **Lambda executor**: Validate zip member names before `extractall()` — rejects entries with `/` prefix or `..` components (Zip Slip protection)

## Test plan
- [x] All relevant unit tests pass
- [x] Ruff lint/format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)