### PR TITLE
Improve Lambda DLQ retry: async, backoff, age check, iterative

### DIFF
--- a/prompts/20260312-070100-dlq-retry-improvements.md
+++ b/prompts/20260312-070100-dlq-retry-improvements.md
@@ -1,0 +1,35 @@
+---
+session: "aec88107"
+timestamp: "2026-03-12T07:01:00Z"
+model: claude-opus-4-6
+---
+
+## Human
+
+Fix four issues in the Lambda DLQ retry implementation in `src/robotocore/services/lambda_/provider.py`:
+1. Retries are synchronous and block the 202 response
+2. No exponential backoff between retries
+3. MaximumEventAgeInSeconds not checked
+4. Recursion should be replaced with iterative loop
+
+## Assistant
+
+## Key decisions
+
+**Issue 1 — async dispatch**: Changed `_invoke()` to spawn `_dispatch_async_result()` in a
+daemon `threading.Thread` instead of calling it synchronously. This matches AWS behavior where
+the 202 response returns immediately and retries happen in the background.
+
+**Issue 2 — exponential backoff**: Added `time.sleep(min(2 ** retry_attempt, 30))` before
+each retry. Cap at 30 seconds to prevent excessive waits. Uses 1s, 2s, 4s progression.
+
+**Issue 3 — MaximumEventAgeInSeconds**: Added `_invocation_time` parameter (defaults to
+`time.time()`) and checks elapsed time against `MaximumEventAgeInSeconds` (default 6 hours)
+before each retry. If exceeded, skips remaining retries and falls through to DLQ/OnFailure.
+
+**Issue 4 — iterative loop**: Replaced recursive `_dispatch_async_result` calls with a
+`while retry_attempt < max_retries` loop. This prevents stack overflow with large
+MaximumRetryAttempts values and makes the control flow clearer.
+
+All four fixes applied to a single rewrite of `_dispatch_async_result()` and its call site
+in `_invoke()`. The `threading` and `time` imports were already present at the top of the file.

--- a/src/robotocore/services/lambda_/provider.py
+++ b/src/robotocore/services/lambda_/provider.py
@@ -1234,14 +1234,12 @@ async def _invoke(
 
     # Handle async invocation with destinations and DLQ
     if invocation_type == "Event":
-        _dispatch_async_result(
-            func_name=func_name,
-            event=event,
-            result=result,
-            error_type=error_type,
-            region=region,
-            account_id=account_id,
-        )
+        # Dispatch async results in background — don't block the 202 response
+        threading.Thread(
+            target=_dispatch_async_result,
+            args=(func_name, event, result, error_type, region, account_id, time.time()),
+            daemon=True,
+        ).start()
 
     headers = {
         "x-amz-request-id": str(uuid.uuid4()),
@@ -1445,13 +1443,17 @@ def _dispatch_async_result(
     error_type: str | None,
     region: str,
     account_id: str,
-    _retry_attempt: int = 0,
+    _invocation_time: float | None = None,
 ) -> None:
     """After async invocation, dispatch to destinations and/or DLQ.
 
     AWS retries failed async invocations up to MaximumRetryAttempts (default 2)
-    before sending to the DLQ or OnFailure destination.
+    with exponential backoff before sending to the DLQ or OnFailure destination.
+    Uses an iterative loop instead of recursion to avoid stack overflow.
     """
+    if _invocation_time is None:
+        _invocation_time = time.time()
+
     func_arn = f"arn:aws:lambda:{region}:{account_id}:function:{func_name}"
 
     # Try to get event invoke config from Moto
@@ -1461,16 +1463,18 @@ def _dispatch_async_result(
     except Exception:
         invoke_config = None
 
-    is_success = error_type is None
-
-    # Get max retry attempts (AWS default is 2)
+    # Get max retry attempts and max event age (AWS defaults)
     max_retries = 2
+    max_age = 21600  # 6 hours
     if invoke_config:
         configured = invoke_config.get("MaximumRetryAttempts", -1)
         if configured >= 0:
             max_retries = configured
+        max_age = invoke_config.get("MaximumEventAgeInSeconds", 21600)
 
-    # On success: dispatch to OnSuccess destination
+    is_success = error_type is None
+
+    # On initial success: dispatch to OnSuccess destination
     if is_success:
         if invoke_config:
             dest_config = invoke_config.get("DestinationConfig", {})
@@ -1490,37 +1494,62 @@ def _dispatch_async_result(
                 )
         return
 
-    # On failure: retry if attempts remain
-    if _retry_attempt < max_retries:
+    # Retry loop for failures (iterative, not recursive)
+    retry_attempt = 0
+    while retry_attempt < max_retries:
+        # Check MaximumEventAgeInSeconds before retrying
+        if time.time() - _invocation_time > max_age:
+            logger.info(
+                "Event age exceeded MaximumEventAgeInSeconds, skipping retries for %s",
+                func_name,
+            )
+            break
+
+        # Exponential backoff: 1s, 2s, 4s, ... capped at 30s
+        backoff_seconds = min(2**retry_attempt, 30)
+        time.sleep(backoff_seconds)
+
         logger.info(
             "Retrying async invocation of %s (attempt %d/%d)",
             func_name,
-            _retry_attempt + 1,
+            retry_attempt + 1,
             max_retries,
         )
-        try:
-            retry_result, retry_error_type, _retry_logs = _execute_function(
-                func_name=func_name,
-                event=event,
-                region=region,
-                account_id=account_id,
-            )
-            # Recurse with incremented attempt
-            _dispatch_async_result(
-                func_name=func_name,
-                event=event,
-                result=retry_result,
-                error_type=retry_error_type,
-                region=region,
-                account_id=account_id,
-                _retry_attempt=_retry_attempt + 1,
-            )
-            return
-        except Exception:
-            logger.exception("Retry %d failed for %s", _retry_attempt + 1, func_name)
-            # Fall through to DLQ / OnFailure
 
-    # Retries exhausted — dispatch to OnFailure destination
+        try:
+            result, error_type, _ = _execute_function(
+                func_name=func_name,
+                event=event,
+                region=region,
+                account_id=account_id,
+            )
+            is_success = error_type is None
+        except Exception:
+            logger.exception("Retry %d failed for %s", retry_attempt + 1, func_name)
+
+        retry_attempt += 1
+
+        # If retry succeeded, dispatch to OnSuccess and return
+        if is_success:
+            if invoke_config:
+                dest_config = invoke_config.get("DestinationConfig", {})
+                if dest_config.get("OnSuccess", {}).get("Destination"):
+                    dest_arn = dest_config["OnSuccess"]["Destination"]
+                    from robotocore.services.lambda_.destinations import dispatch_destination
+
+                    dispatch_destination(
+                        destination_arn=dest_arn,
+                        function_arn=func_arn,
+                        payload=event,
+                        is_success=True,
+                        result=result,
+                        error=None,
+                        region=region,
+                        account_id=account_id,
+                    )
+            return
+
+    # Retries exhausted (or skipped due to event age) — dispatch to OnFailure destination
     if invoke_config:
         dest_config = invoke_config.get("DestinationConfig", {})
         if dest_config.get("OnFailure", {}).get("Destination"):


### PR DESCRIPTION
## Summary
- **Async dispatch**: Retries run in background thread — 202 response returns immediately (matches AWS)
- **Exponential backoff**: 1s, 2s, 4s... capped at 30s between retries
- **MaximumEventAgeInSeconds**: Skip retries if event age exceeds limit (default 6 hours)
- **Iterative loop**: Replace recursion with while loop to prevent stack overflow

## Test plan
- [x] Existing Lambda unit tests pass
- [x] Ruff lint/format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)