### PR TITLE
Fix ZIP path traversal: normalize backslashes before validation

### DIFF
--- a/prompts/20260312-070200-zip-backslash-fix.md
+++ b/prompts/20260312-070200-zip-backslash-fix.md
@@ -1,0 +1,18 @@
+---
+session: "find-every-problem"
+timestamp: "2026-03-12T07:02:00Z"
+model: claude-opus-4-6
+sequence: 8
+---
+
+## Human
+
+Review all pieces that need further review, then fix them thoroughly.
+
+## Assistant
+
+## Key decisions
+
+**ZIP backslash traversal**: The path validation split on `/` only, missing
+backslash-based traversal like `..\..\etc\passwd`. Fixed by normalizing
+backslashes to forward slashes before validation.

--- a/src/robotocore/services/lambda_/executor.py
+++ b/src/robotocore/services/lambda_/executor.py
@@ -292,14 +292,18 @@ class CodeCache:
                     try:
                         with zipfile.ZipFile(io.BytesIO(layer_zip)) as zf:
                             for name in zf.namelist():
-                                if name.startswith("/") or ".." in name.split("/"):
+                                # Normalize separators and check for traversal
+                                normalized = name.replace("\\", "/")
+                                if normalized.startswith("/") or ".." in normalized.split("/"):
                                     raise ValueError(f"Unsafe path in ZIP archive: {name}")
                             zf.extractall(tmpdir)
                     except (zipfile.BadZipFile, OSError):
                         logger.warning("CodeCache: failed to extract layer zip")
             with zipfile.ZipFile(io.BytesIO(code_zip)) as zf:
                 for name in zf.namelist():
-                    if name.startswith("/") or ".." in name.split("/"):
+                    # Normalize separators and check for traversal
+                    normalized = name.replace("\\", "/")
+                    if normalized.startswith("/") or ".." in normalized.split("/"):
                         raise ValueError(f"Unsafe path in ZIP archive: {name}")
                 zf.extractall(tmpdir)
         except (zipfile.BadZipFile, OSError) as exc:


### PR DESCRIPTION
## Summary
- Previous fix only split on forward slashes, missing backslash-based traversal like `..\..\etc\passwd`
- Now normalizes all path separators before checking for `..` components
- Applied to both layer zip and code zip extraction in Lambda executor

## Test plan
- [x] All 285 executor unit tests pass
- [x] Ruff lint/format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)