### PR TITLE
Expand CLI to cover all management API endpoints

### DIFF
--- a/prompts/20260312-120000-cli-expansion.md
+++ b/prompts/20260312-120000-cli-expansion.md
@@ -1,0 +1,53 @@
+---
+session: "find-every-problem"
+timestamp: "2026-03-12T12:00:00Z"
+model: claude-opus-4-6
+tools: [subagent, git-worktree]
+sequence: 3
+---
+
+## Human
+
+Flesh out the cli to be really good. iterate with your own reviews until done.
+
+## Assistant
+
+### Phase 1: CLI Expansion (worktree agent)
+
+Expanded the CLI from ~428 lines (7 commands) to ~1285 lines covering all 47
+management API endpoints:
+
+- **Container lifecycle**: start (--wait), stop, status (with health info), logs (--tail, --no-follow), restart, health, wait, version
+- **State management**: save, load, list, reset
+- **Services**: list with --status filter and --format json/table
+- **Config**: get, set (with JSON value parsing), reset
+- **Chaos**: list, add (--service, --error, --status-code, --operation, --rate, --latency), remove, clear
+- **Resources**: overview table or per-service detail
+- **Audit**: recent API calls with --limit
+- **Usage**: summary, per-service breakdown, error breakdown
+- **Pods**: list, save, load, info, delete
+- **SES**: messages (with --limit), clear
+- **IAM**: policy stream (--limit, --decision), suggest policy
+- **Diagnose**: diagnostic bundle
+
+Added helpers: `_print_table()`, `_api_cmd()`, `_get_format()`, `_add_format_flag()`
+
+### Phase 2: Self-review and field name fixes
+
+Discovered critical field name mismatches between CLI and actual management API:
+
+- **Chaos**: CLI sent `error`/`rate` but API expects `error_code`/`probability`;
+  CLI read `id`/`error`/`rate` but API returns `rule_id`/`error_code`/`probability`
+- **Pods**: CLI read `created`/`size`/`services` but API returns `created_at`/`size_bytes`/`version_count`
+- **Usage services**: CLI read `calls`/`errors` but API returns `request_count`/`error_count`
+- **Resources**: API wraps response in `{"resources": {...}}` — CLI didn't unwrap
+
+Also consolidated state commands to use `_api_cmd` helper for consistent error
+handling, and fixed type annotations.
+
+### Key decisions
+
+- Used Explore agents to verify actual API field names against source code
+- Kept CLI flag names user-friendly (`--error`, `--rate`) while mapping to API
+  field names (`error_code`, `probability`) in the request body
+- Table output is the default, `--format json` available for scripting

--- a/src/robotocore/cli.py
+++ b/src/robotocore/cli.py
@@ -59,7 +59,7 @@ def _api_request(
     *,
     method: str = "GET",
     data: dict | None = None,
-) -> dict:
+) -> dict | list:
     """Make an HTTP request to the robotocore management API."""
     body = None
     if data is not None:
@@ -323,61 +323,50 @@ def cmd_version(args: argparse.Namespace) -> int:
 
 def cmd_state_save(args: argparse.Namespace) -> int:
     """Save a state snapshot."""
-    base_url = _get_base_url(args)
-    try:
-        data = _api_request(
-            f"{base_url}/_robotocore/state/save",
-            method="POST",
-            data={"name": args.snapshot_name},
-        )
-        _print_json(data)
-        return 0
-    except (urllib.error.URLError, TimeoutError, OSError) as e:
-        print(f"State save failed: {e}", file=sys.stderr)
+    resp = _api_cmd(
+        args,
+        "/_robotocore/state/save",
+        method="POST",
+        data={"name": args.snapshot_name},
+        label="State save",
+    )
+    if resp is None:
         return 1
+    _print_json(resp)
+    return 0
 
 
 def cmd_state_load(args: argparse.Namespace) -> int:
     """Load a state snapshot."""
-    base_url = _get_base_url(args)
-    try:
-        data = _api_request(
-            f"{base_url}/_robotocore/state/load",
-            method="POST",
-            data={"name": args.snapshot_name},
-        )
-        _print_json(data)
-        return 0
-    except (urllib.error.URLError, TimeoutError, OSError) as e:
-        print(f"State load failed: {e}", file=sys.stderr)
+    resp = _api_cmd(
+        args,
+        "/_robotocore/state/load",
+        method="POST",
+        data={"name": args.snapshot_name},
+        label="State load",
+    )
+    if resp is None:
         return 1
+    _print_json(resp)
+    return 0
 
 
 def cmd_state_list(args: argparse.Namespace) -> int:
     """List state snapshots."""
-    base_url = _get_base_url(args)
-    try:
-        data = _api_request(f"{base_url}/_robotocore/state/snapshots")
-        _print_json(data)
-        return 0
-    except (urllib.error.URLError, TimeoutError, OSError) as e:
-        print(f"State list failed: {e}", file=sys.stderr)
+    resp = _api_cmd(args, "/_robotocore/state/snapshots", label="State list")
+    if resp is None:
         return 1
+    _print_json(resp)
+    return 0
 
 
 def cmd_state_reset(args: argparse.Namespace) -> int:
     """Reset all state."""
-    base_url = _get_base_url(args)
-    try:
-        data = _api_request(
-            f"{base_url}/_robotocore/state/reset",
-            method="POST",
-        )
-        _print_json(data)
-        return 0
-    except (urllib.error.URLError, TimeoutError, OSError) as e:
-        print(f"State reset failed: {e}", file=sys.stderr)
+    resp = _api_cmd(args, "/_robotocore/state/reset", method="POST", label="State reset")
+    if resp is None:
         return 1
+    _print_json(resp)
+    return 0
 
 
 # ---------------------------------------------------------------------------
@@ -511,17 +500,17 @@ def _cmd_chaos_list(args: argparse.Namespace) -> int:
         if not rules:
             print("No chaos rules configured.")
             return 0
-        headers = ["ID", "SERVICE", "ERROR", "STATUS", "OPERATION", "RATE", "LATENCY"]
+        headers = ["ID", "SERVICE", "ERROR", "STATUS", "OPERATION", "PROB", "LATENCY"]
         rows = []
         for r in rules:
             rows.append(
                 [
-                    str(r.get("id", "?")),
+                    str(r.get("rule_id", "?")),
                     r.get("service", "*"),
-                    r.get("error", "?"),
+                    r.get("error_code", "?"),
                     str(r.get("status_code", "?")),
                     r.get("operation", "*"),
-                    str(r.get("rate", 1.0)),
+                    str(r.get("probability", 1.0)),
                     str(r.get("latency_ms", 0)),
                 ]
             )
@@ -532,7 +521,7 @@ def _cmd_chaos_list(args: argparse.Namespace) -> int:
 def _cmd_chaos_add(args: argparse.Namespace) -> int:
     rule: dict = {
         "service": args.service,
-        "error": args.error,
+        "error_code": args.error,
         "status_code": args.status_code,
     }
     if getattr(args, "operation", None):
@@ -540,7 +529,7 @@ def _cmd_chaos_add(args: argparse.Namespace) -> int:
     if getattr(args, "latency", None) is not None:
         rule["latency_ms"] = args.latency
     if getattr(args, "rate", None) is not None:
-        rule["rate"] = args.rate
+        rule["probability"] = args.rate
     resp = _api_cmd(
         args,
         "/_robotocore/chaos/rules",
@@ -601,7 +590,7 @@ def cmd_resources(args: argparse.Namespace) -> int:
         _print_json(resp)
     else:
         # Summary mode: show counts per service
-        resources = resp if isinstance(resp, dict) else {}
+        resources = resp.get("resources", resp) if isinstance(resp, dict) else {}
         headers = ["SERVICE", "COUNT"]
         rows = []
         for svc_name, svc_data in sorted(resources.items()):
@@ -682,14 +671,14 @@ def _cmd_usage_services(args: argparse.Namespace) -> int:
     if fmt == "json":
         _print_json(services)
     else:
-        headers = ["SERVICE", "CALLS", "ERRORS"]
+        headers = ["SERVICE", "REQUESTS", "ERRORS"]
         rows = []
         for s in services:
             rows.append(
                 [
                     s.get("service", "?"),
-                    str(s.get("calls", 0)),
-                    str(s.get("errors", 0)),
+                    str(s.get("request_count", 0)),
+                    str(s.get("error_count", 0)),
                 ]
             )
         rows.sort(key=lambda r: int(r[1]) if r[1].isdigit() else 0, reverse=True)
@@ -756,15 +745,15 @@ def _cmd_pods_list(args: argparse.Namespace) -> int:
         if not pods:
             print("No pods found.")
             return 0
-        headers = ["NAME", "CREATED", "SIZE", "SERVICES"]
+        headers = ["NAME", "CREATED", "SIZE", "VERSIONS"]
         rows = []
         for p in pods:
             rows.append(
                 [
                     p.get("name", "?"),
-                    p.get("created", "?"),
-                    str(p.get("size", "?")),
-                    str(p.get("services", "?")),
+                    p.get("created_at", "?"),
+                    str(p.get("size_bytes", "?")),
+                    str(p.get("version_count", "?")),
                 ]
             )
         _print_table(headers, rows)
@@ -1221,7 +1210,7 @@ def build_parser() -> argparse.ArgumentParser:
 # Dispatch
 # ---------------------------------------------------------------------------
 
-_STATE_DISPATCH: dict[str | None, type[...] | None] = {
+_STATE_DISPATCH = {
     "save": cmd_state_save,
     "load": cmd_state_load,
     "list": cmd_state_list,
@@ -1238,7 +1227,7 @@ def _run(argv: list[str] | None = None) -> int:
         parser.print_help()
         return 1
 
-    dispatch: dict[str, ...] = {
+    dispatch = {
         "start": cmd_start,
         "stop": cmd_stop,
         "status": cmd_status,

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -678,7 +678,9 @@ class TestCmdStateList:
         rc = _run(["state", "list"])
         assert rc == 0
         mock_api.assert_called_once_with(
-            f"http://localhost:{DEFAULT_PORT}/_robotocore/state/snapshots"
+            f"http://localhost:{DEFAULT_PORT}/_robotocore/state/snapshots",
+            method="GET",
+            data=None,
         )
 
 
@@ -691,6 +693,7 @@ class TestCmdStateReset:
         mock_api.assert_called_once_with(
             f"http://localhost:{DEFAULT_PORT}/_robotocore/state/reset",
             method="POST",
+            data=None,
         )
 
 
@@ -796,12 +799,12 @@ class TestCmdChaos:
         mock_api.return_value = {
             "rules": [
                 {
-                    "id": "r1",
+                    "rule_id": "r1",
                     "service": "s3",
-                    "error": "ThrottlingException",
+                    "error_code": "ThrottlingException",
                     "status_code": 429,
                     "operation": "*",
-                    "rate": 1.0,
+                    "probability": 1.0,
                     "latency_ms": 0,
                 }
             ]
@@ -822,7 +825,7 @@ class TestCmdChaos:
 
     @mock.patch("robotocore.cli._api_request")
     def test_chaos_add(self, mock_api):
-        mock_api.return_value = {"id": "r1"}
+        mock_api.return_value = {"rule_id": "r1"}
         rc = _run(
             [
                 "chaos",
@@ -839,12 +842,12 @@ class TestCmdChaos:
         mock_api.assert_called_once_with(
             f"http://localhost:{DEFAULT_PORT}/_robotocore/chaos/rules",
             method="POST",
-            data={"service": "s3", "error": "ThrottlingException", "status_code": 429},
+            data={"service": "s3", "error_code": "ThrottlingException", "status_code": 429},
         )
 
     @mock.patch("robotocore.cli._api_request")
     def test_chaos_add_with_options(self, mock_api):
-        mock_api.return_value = {"id": "r2"}
+        mock_api.return_value = {"rule_id": "r2"}
         rc = _run(
             [
                 "chaos",
@@ -866,12 +869,12 @@ class TestCmdChaos:
         assert rc == 0
         call_data = mock_api.call_args[1]["data"]
         assert call_data["operation"] == "SendMessage"
-        assert call_data["rate"] == 0.3
+        assert call_data["probability"] == 0.3
         assert call_data["latency_ms"] == 200
 
     @mock.patch("robotocore.cli._api_request")
     def test_chaos_remove(self, mock_api):
-        mock_api.return_value = {"status": "removed"}
+        mock_api.return_value = {"status": "deleted", "rule_id": "r1"}
         rc = _run(["chaos", "remove", "r1"])
         assert rc == 0
         mock_api.assert_called_once_with(
@@ -958,7 +961,9 @@ class TestCmdUsage:
 
     @mock.patch("robotocore.cli._api_request")
     def test_usage_services(self, mock_api, capsys):
-        mock_api.return_value = {"services": [{"service": "s3", "calls": 50, "errors": 2}]}
+        mock_api.return_value = {
+            "services": [{"service": "s3", "request_count": 50, "error_count": 2}]
+        }
         rc = _run(["usage", "services"])
         assert rc == 0
         out = capsys.readouterr().out
@@ -979,7 +984,14 @@ class TestCmdPods:
     @mock.patch("robotocore.cli._api_request")
     def test_pods_list(self, mock_api, capsys):
         mock_api.return_value = {
-            "pods": [{"name": "my-pod", "created": "2026-03-12", "size": 1024, "services": 5}]
+            "pods": [
+                {
+                    "name": "my-pod",
+                    "created_at": "2026-03-12",
+                    "size_bytes": 1024,
+                    "version_count": 5,
+                }
+            ]
         }
         rc = _run(["pods", "list"])
         assert rc == 0


### PR DESCRIPTION
## Summary
- Expand CLI from 7 commands to 20 command groups covering all 47 management API endpoints
- Add table formatting with `--format json` option for scripting
- Add `_api_cmd()` helper for consistent error handling across all commands
- Fix field name mismatches between CLI and actual API (chaos, pods, usage, resources)

New command groups: `services`, `config`, `chaos`, `resources`, `audit`, `usage`, `pods`, `ses`, `iam`, `diagnose`, `version`

## Test plan
- [x] 131 unit tests pass (argument parsing, dispatch, mocked API calls, table formatting)
- [x] ruff lint clean
- [ ] CI checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)