### PR TITLE
Fix lint false positives: regex, protocol, assertion helpers

### DIFF
--- a/prompts/20260312-172255-lint-false-positives.md
+++ b/prompts/20260312-172255-lint-false-positives.md
@@ -1,0 +1,30 @@
+---
+session: "agent-a2bb6cfb"
+timestamp: "2026-03-12T17:22:55Z"
+model: claude-opus-4-6
+---
+
+## Human
+
+Fix three lint false positives in one PR:
+1. Provider-import-sync regex fails on multi-line imports (rekognition false positive)
+2. CloudWatch registry protocol says "query" but should be "json"
+3. test-no-assertion check doesn't recognize _assert_ok() helper functions
+
+## Assistant
+
+## Key decisions
+
+**Regex fix**: The `[^.]+` pattern in the provider-import-sync check matched across
+newlines, so a multi-line import like `from robotocore.services.loader import (\n...)`
+consumed characters past the next `from robotocore.services.rekognition.` import,
+preventing it from matching. Fix: `[^.\n]+` to stop at newlines.
+
+**CloudWatch protocol**: Changed from "query" to "json". The registry protocol field
+is purely informational (lint check 7 compares it to botocore). Routing uses
+`get_service_protocol()` from botocore directly, not the registry. The native provider
+already handles both JSON and query dynamically.
+
+**Assertion helper detection**: Added AST check for function calls where the function
+name starts with `_assert` (e.g., `_assert_ok()`). This reduced test-no-assertion
+findings from 178 to 101 (~77 fewer false positives).

--- a/scripts/lint_project.py
+++ b/scripts/lint_project.py
@@ -93,6 +93,11 @@ def _check_single_test(fpath: Path, node: ast.FunctionDef, findings: list[Findin
             has_assert = True
         if isinstance(child, ast.Attribute) and child.attr == "raises":
             has_assert = True
+        # Recognize helper functions like _assert_ok() as valid assertions
+        if isinstance(child, ast.Call):
+            func = child.func
+            if isinstance(func, ast.Name) and func.id.startswith("_assert"):
+                has_assert = True
         if isinstance(child, ast.Call):
             has_any_call = True
         if isinstance(child, ast.Try):
@@ -420,7 +425,7 @@ def check_provider_import_sync(findings: list[Finding]):
 
     # Find what's imported in app.py
     imported_paths = set()
-    for match in re.finditer(r"from robotocore\.services\.([^.]+)\.", app_src):
+    for match in re.finditer(r"from robotocore\.services\.([^.\n]+)\.", app_src):
         imported_paths.add(match.group(1))
 
     unimported = provider_files - imported_paths

--- a/src/robotocore/services/registry.py
+++ b/src/robotocore/services/registry.py
@@ -40,7 +40,7 @@ SERVICE_REGISTRY: dict[str, ServiceInfo] = {
         "cloudformation", ServiceStatus.NATIVE, "query", "CloudFormation engine"
     ),
     "cloudwatch": ServiceInfo(
-        "cloudwatch", ServiceStatus.NATIVE, "query", "CloudWatch Metrics with alarm evaluation"
+        "cloudwatch", ServiceStatus.NATIVE, "json", "CloudWatch Metrics with alarm evaluation"
     ),
     "logs": ServiceInfo("logs", ServiceStatus.NATIVE, "json", "CloudWatch Logs"),
     "kms": ServiceInfo("kms", ServiceStatus.MOTO_BACKED, "json", "Key Management Service"),


### PR DESCRIPTION
## Summary
- **Provider-import-sync regex**: Fix `[^.]+` → `[^.\n]+` so multi-line imports don't cause false negatives (rekognition was falsely reported as not imported)
- **CloudWatch registry protocol**: Update `"query"` → `"json"` to match modern boto3 behavior (provider handles both dynamically)
- **Assertion helper detection**: Recognize `_assert_ok()` and similar helpers as valid assertions, reducing false positives from 178 → 101

## Test plan
- [x] `lint_project.py` runs cleanly with reduced warning count
- [x] ruff lint clean
- [ ] CI checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)