### PR TITLE
Implement Lambda recursion detection enforcement (18 tests)

### DIFF
--- a/prompts/20260312-100000-lambda-recursion-detection.md
+++ b/prompts/20260312-100000-lambda-recursion-detection.md
@@ -1,0 +1,25 @@
+---
+session: "agent-aa06a690"
+timestamp: "2026-03-12T10:00:00Z"
+model: claude-opus-4-6
+---
+
+## Human
+
+Implement Lambda recursion detection enforcement. The recursion config is stored via PutFunctionRecursionConfig / GetFunctionRecursionConfig but never enforced during invocations. When RecursiveLoop is "Terminate" (default), detect recursive invocations and terminate after threshold (16).
+
+## Assistant
+
+## Key decisions
+
+**Separate module for recursion tracking**: Created `src/robotocore/services/lambda_/recursion.py` as a standalone module rather than inlining into provider.py. This keeps the recursion logic testable in isolation and avoids bloating the already-large provider module.
+
+**Thread-safe depth counters**: Used a dict keyed by (account_id, region, func_name) with a threading lock, matching the pattern used elsewhere in the provider (e.g., _recursion_configs, _provisioned_concurrency). Each invocation increments on entry and decrements in a finally block.
+
+**Two enforcement points**: Recursion detection is checked in both `_invoke()` (direct API invocations) and `_invoke_lambda_sync()` in invoke.py (cross-service invocations via SNS/SQS/EventBridge). Both paths needed coverage because a recursive loop can go through either path.
+
+**Threshold of 16**: Matches AWS's documented behavior for recursive loop detection.
+
+**check-then-increment pattern**: The check happens before increment so that depth 16 is the trigger point (0-15 are allowed, 16 triggers termination). The increment happens before execution so that nested calls during execution see the correct depth.
+
+**N818 lint suppression**: The exception class is named `RecursiveInvocationException` (not `Error` suffix) to match the AWS API error code exactly. Added noqa comment explaining why.

--- a/src/robotocore/services/lambda_/invoke.py
+++ b/src/robotocore/services/lambda_/invoke.py
@@ -58,6 +58,13 @@ def _invoke_lambda_sync(
 ) -> tuple[dict | str | None, str | None, str]:
     """Internal: execute a Lambda function synchronously (runs in thread pool)."""
     from robotocore.services.lambda_.executor import get_layer_zips
+    from robotocore.services.lambda_.recursion import (
+        RecursiveInvocationException,
+        check_recursion,
+        decrement_depth,
+        get_recursion_config,
+        increment_depth,
+    )
 
     # Parse function name from ARN
     arn_parts = function_arn.split(":")
@@ -70,81 +77,95 @@ def _invoke_lambda_sync(
     if len(arn_parts) >= 5:
         account_id = arn_parts[4]
 
+    # Check recursion detection
+    recursive_loop = get_recursion_config(account_id, region, function_name)
     try:
-        from moto.backends import get_backend
-        from moto.core import DEFAULT_ACCOUNT_ID
+        check_recursion(account_id, region, function_name, recursive_loop)
+    except RecursiveInvocationException as exc:
+        logger.warning("Recursive invocation blocked for %s: %s", function_name, exc)
+        return None, "RecursiveInvocationException", str(exc)
 
-        acct = account_id if account_id != "123456789012" else DEFAULT_ACCOUNT_ID
-        backend = get_backend("lambda")[acct][region]
-        fn = backend.get_function(function_name)
-    except Exception as e:
-        logger.error("Lambda invoke: function not found: %s (%s)", function_name, e)
-        return None, "ResourceNotFoundException", f"Function not found: {function_name}"
+    # Track recursion depth
+    increment_depth(account_id, region, function_name)
 
-    runtime = getattr(fn, "run_time", "") or ""
-
-    # Get code zip
-    code_zip = getattr(fn, "code_bytes", None)
-    if not code_zip:
-        raw = (fn.code or {}).get("ZipFile") if hasattr(fn, "code") else None
-        if raw:
-            code_zip = base64.b64decode(raw) if isinstance(raw, str) else raw
-
-    if not code_zip:
-        logger.error("Lambda invoke: no code for %s", function_name)
-        return None, "InvalidCodeException", f"No code found for {function_name}"
-
-    handler = getattr(fn, "handler", "lambda_function.handler")
-    timeout = int(getattr(fn, "timeout", 3) or 3)
-    memory_size = int(getattr(fn, "memory_size", 128) or 128)
-    env_vars = getattr(fn, "environment_vars", {}) or {}
-    layer_zips = get_layer_zips(fn, account_id, region)
-
-    from robotocore.services.lambda_.docker_executor import get_executor_mode
-
-    if get_executor_mode() == "docker":
-        from robotocore.services.lambda_.docker_executor import get_docker_executor
-
-        docker_exec = get_docker_executor()
-        result, error_type, logs = docker_exec.execute(
-            code_zip=code_zip,
-            handler=handler,
-            event=payload,
-            function_name=function_name,
-            runtime=runtime,
-            timeout=timeout,
-            memory_size=memory_size,
-            env_vars=env_vars,
-            region=region,
-            account_id=account_id,
-            layer_zips=layer_zips if layer_zips else None,
-        )
-    else:
-        from robotocore.services.lambda_.runtimes import get_executor_for_runtime
-
-        executor = get_executor_for_runtime(runtime)
-        result, error_type, logs = executor.execute(
-            code_zip=code_zip,
-            handler=handler,
-            event=payload,
-            function_name=function_name,
-            timeout=timeout,
-            memory_size=memory_size,
-            env_vars=env_vars,
-            region=region,
-            account_id=account_id,
-            layer_zips=layer_zips if layer_zips else None,
-        )
-
-    if callback:
+    try:
         try:
-            callback(result, error_type, logs)
-        except Exception:
-            logger.exception("Lambda invoke callback failed for %s", function_name)
+            from moto.backends import get_backend
+            from moto.core import DEFAULT_ACCOUNT_ID
 
-    if error_type:
-        logger.warning("Lambda %s returned error %s", function_name, error_type)
-    else:
-        logger.debug("Lambda %s invoked successfully", function_name)
+            acct = account_id if account_id != "123456789012" else DEFAULT_ACCOUNT_ID
+            backend = get_backend("lambda")[acct][region]
+            fn = backend.get_function(function_name)
+        except Exception as e:
+            logger.error("Lambda invoke: function not found: %s (%s)", function_name, e)
+            return None, "ResourceNotFoundException", f"Function not found: {function_name}"
 
-    return result, error_type, logs
+        runtime = getattr(fn, "run_time", "") or ""
+
+        # Get code zip
+        code_zip = getattr(fn, "code_bytes", None)
+        if not code_zip:
+            raw = (fn.code or {}).get("ZipFile") if hasattr(fn, "code") else None
+            if raw:
+                code_zip = base64.b64decode(raw) if isinstance(raw, str) else raw
+
+        if not code_zip:
+            logger.error("Lambda invoke: no code for %s", function_name)
+            return None, "InvalidCodeException", f"No code found for {function_name}"
+
+        handler = getattr(fn, "handler", "lambda_function.handler")
+        timeout = int(getattr(fn, "timeout", 3) or 3)
+        memory_size = int(getattr(fn, "memory_size", 128) or 128)
+        env_vars = getattr(fn, "environment_vars", {}) or {}
+        layer_zips = get_layer_zips(fn, account_id, region)
+
+        from robotocore.services.lambda_.docker_executor import get_executor_mode
+
+        if get_executor_mode() == "docker":
+            from robotocore.services.lambda_.docker_executor import get_docker_executor
+
+            docker_exec = get_docker_executor()
+            result, error_type, logs = docker_exec.execute(
+                code_zip=code_zip,
+                handler=handler,
+                event=payload,
+                function_name=function_name,
+                runtime=runtime,
+                timeout=timeout,
+                memory_size=memory_size,
+                env_vars=env_vars,
+                region=region,
+                account_id=account_id,
+                layer_zips=layer_zips if layer_zips else None,
+            )
+        else:
+            from robotocore.services.lambda_.runtimes import get_executor_for_runtime
+
+            executor = get_executor_for_runtime(runtime)
+            result, error_type, logs = executor.execute(
+                code_zip=code_zip,
+                handler=handler,
+                event=payload,
+                function_name=function_name,
+                timeout=timeout,
+                memory_size=memory_size,
+                env_vars=env_vars,
+                region=region,
+                account_id=account_id,
+                layer_zips=layer_zips if layer_zips else None,
+            )
+
+        if callback:
+            try:
+                callback(result, error_type, logs)
+            except Exception:
+                logger.exception("Lambda invoke callback failed for %s", function_name)
+
+        if error_type:
+            logger.warning("Lambda %s returned error %s", function_name, error_type)
+        else:
+            logger.debug("Lambda %s invoked successfully", function_name)
+
+        return result, error_type, logs
+    finally:
+        decrement_depth(account_id, region, function_name)

--- a/src/robotocore/services/lambda_/provider.py
+++ b/src/robotocore/services/lambda_/provider.py
@@ -1127,8 +1127,23 @@ async def _invoke(
     func_name: str, body: bytes, request: Request, region: str, account_id: str
 ) -> Response:
     """Invoke a Lambda function — uses in-process execution for Python runtimes."""
+    from robotocore.services.lambda_.recursion import (
+        RecursiveInvocationException,
+        check_recursion,
+        decrement_depth,
+        get_recursion_config,
+        increment_depth,
+    )
+
     backend = _get_moto_backend(account_id, region)
     fn = backend.get_function(func_name)
+
+    # Check recursion detection before executing
+    recursive_loop = get_recursion_config(account_id, region, func_name)
+    try:
+        check_recursion(account_id, region, func_name, recursive_loop)
+    except RecursiveInvocationException as exc:
+        return _error("RecursiveInvocationException", str(exc), 400)
 
     invocation_type = request.headers.get("x-amz-invocation-type", "RequestResponse")
     log_type = request.headers.get("x-amz-log-type", "None")
@@ -1171,6 +1186,9 @@ async def _invoke(
                 get_code_cache().invalidate(func_name)
 
     result, error_type, logs = None, None, ""
+
+    # Track recursion depth for this invocation
+    increment_depth(account_id, region, func_name)
 
     # Acquire concurrency slot
     function_key = f"{account_id}:{region}:{func_name}"
@@ -1231,6 +1249,7 @@ async def _invoke(
             result, error_type, logs = "Simple Lambda happy path OK", None, ""
     finally:
         tracker.release(function_key)
+        decrement_depth(account_id, region, func_name)
 
     # Handle async invocation with destinations and DLQ
     if invocation_type == "Event":

--- a/src/robotocore/services/lambda_/recursion.py
+++ b/src/robotocore/services/lambda_/recursion.py
@@ -1,0 +1,107 @@
+"""Lambda recursion detection — prevents infinite invocation loops.
+
+AWS Lambda recursion detection tracks when a function invokes itself (directly
+or via a chain through SQS/SNS/etc). When RecursiveLoop is set to "Terminate"
+(the default), invocations are terminated after a threshold (~16 recursive calls).
+
+The recursion depth is tracked per-function using a threading-aware counter.
+Each invocation increments the counter on entry and decrements on exit.
+Cross-service invocations (via invoke.py) also participate in tracking.
+"""
+
+import logging
+import threading
+
+logger = logging.getLogger(__name__)
+
+# Maximum recursive invocation depth before termination (matches AWS behavior)
+MAX_RECURSION_DEPTH = 16
+
+# Per-thread recursion depth counters: key = (account_id, region, func_name)
+_recursion_depths: dict[tuple[str, str, str], int] = {}
+_depth_lock = threading.Lock()
+
+
+class RecursiveInvocationException(Exception):  # noqa: N818 — matches AWS error code
+    """Raised when a Lambda function exceeds the recursive invocation limit."""
+
+    def __init__(self, function_name: str, depth: int):
+        self.function_name = function_name
+        self.depth = depth
+        super().__init__(
+            f"RecursiveInvocationException: Lambda function {function_name} "
+            f"exceeded recursive invocation limit ({depth} >= {MAX_RECURSION_DEPTH})"
+        )
+
+
+def get_recursion_depth(account_id: str, region: str, func_name: str) -> int:
+    """Return the current recursion depth for a function."""
+    key = (account_id, region, func_name)
+    with _depth_lock:
+        return _recursion_depths.get(key, 0)
+
+
+def increment_depth(account_id: str, region: str, func_name: str) -> int:
+    """Increment recursion depth and return the new value."""
+    key = (account_id, region, func_name)
+    with _depth_lock:
+        current = _recursion_depths.get(key, 0)
+        _recursion_depths[key] = current + 1
+        return current + 1
+
+
+def decrement_depth(account_id: str, region: str, func_name: str) -> None:
+    """Decrement recursion depth after invocation completes."""
+    key = (account_id, region, func_name)
+    with _depth_lock:
+        current = _recursion_depths.get(key, 0)
+        if current > 0:
+            _recursion_depths[key] = current - 1
+        if _recursion_depths.get(key, 0) == 0:
+            _recursion_depths.pop(key, None)
+
+
+def check_recursion(
+    account_id: str, region: str, func_name: str, recursive_loop: str = "Terminate"
+) -> None:
+    """Check recursion depth and raise if limit exceeded.
+
+    Args:
+        account_id: AWS account ID
+        region: AWS region
+        func_name: Lambda function name
+        recursive_loop: "Terminate" (default) or "Allow"
+
+    Raises:
+        RecursiveInvocationException: If depth >= MAX_RECURSION_DEPTH and mode is "Terminate"
+    """
+    if recursive_loop == "Allow":
+        return
+
+    depth = get_recursion_depth(account_id, region, func_name)
+    if depth >= MAX_RECURSION_DEPTH:
+        logger.warning(
+            "Recursive invocation detected for %s (depth=%d, limit=%d)",
+            func_name,
+            depth,
+            MAX_RECURSION_DEPTH,
+        )
+        raise RecursiveInvocationException(func_name, depth)
+
+
+def get_recursion_config(account_id: str, region: str, func_name: str) -> str:
+    """Get the recursion config for a function from the provider store.
+
+    Returns "Terminate" (default) or "Allow".
+    """
+    from robotocore.services.lambda_.provider import _recursion_configs, _recursion_lock
+
+    key = (account_id, region, func_name)
+    with _recursion_lock:
+        return _recursion_configs.get(key, "Terminate")
+
+
+def reset_all_depths() -> None:
+    """Reset all recursion depth counters (for testing)."""
+    with _depth_lock:
+        _recursion_depths.clear()

--- a/tests/unit/services/lambda_/test_recursion_detection.py
+++ b/tests/unit/services/lambda_/test_recursion_detection.py
@@ -1,0 +1,153 @@
+"""Unit tests for Lambda recursion detection enforcement."""
+
+import pytest
+
+from robotocore.services.lambda_.recursion import (
+    MAX_RECURSION_DEPTH,
+    RecursiveInvocationException,
+    check_recursion,
+    decrement_depth,
+    get_recursion_depth,
+    increment_depth,
+    reset_all_depths,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_depths():
+    """Reset recursion depth counters before and after each test."""
+    reset_all_depths()
+    yield
+    reset_all_depths()
+
+
+ACCOUNT = "123456789012"
+REGION = "us-east-1"
+FUNC = "my-function"
+
+
+class TestRecursionDepthTracking:
+    """Test the basic depth increment/decrement/get operations."""
+
+    def test_initial_depth_is_zero(self):
+        assert get_recursion_depth(ACCOUNT, REGION, FUNC) == 0
+
+    def test_increment_returns_new_depth(self):
+        assert increment_depth(ACCOUNT, REGION, FUNC) == 1
+        assert increment_depth(ACCOUNT, REGION, FUNC) == 2
+        assert increment_depth(ACCOUNT, REGION, FUNC) == 3
+
+    def test_decrement_reduces_depth(self):
+        increment_depth(ACCOUNT, REGION, FUNC)
+        increment_depth(ACCOUNT, REGION, FUNC)
+        assert get_recursion_depth(ACCOUNT, REGION, FUNC) == 2
+
+        decrement_depth(ACCOUNT, REGION, FUNC)
+        assert get_recursion_depth(ACCOUNT, REGION, FUNC) == 1
+
+    def test_decrement_below_zero_stays_at_zero(self):
+        decrement_depth(ACCOUNT, REGION, FUNC)
+        assert get_recursion_depth(ACCOUNT, REGION, FUNC) == 0
+
+    def test_decrement_to_zero_cleans_up_key(self):
+        increment_depth(ACCOUNT, REGION, FUNC)
+        decrement_depth(ACCOUNT, REGION, FUNC)
+        assert get_recursion_depth(ACCOUNT, REGION, FUNC) == 0
+
+    def test_different_functions_tracked_independently(self):
+        increment_depth(ACCOUNT, REGION, "func-a")
+        increment_depth(ACCOUNT, REGION, "func-a")
+        increment_depth(ACCOUNT, REGION, "func-b")
+
+        assert get_recursion_depth(ACCOUNT, REGION, "func-a") == 2
+        assert get_recursion_depth(ACCOUNT, REGION, "func-b") == 1
+
+    def test_different_regions_tracked_independently(self):
+        increment_depth(ACCOUNT, "us-east-1", FUNC)
+        increment_depth(ACCOUNT, "us-west-2", FUNC)
+        increment_depth(ACCOUNT, "us-west-2", FUNC)
+
+        assert get_recursion_depth(ACCOUNT, "us-east-1", FUNC) == 1
+        assert get_recursion_depth(ACCOUNT, "us-west-2", FUNC) == 2
+
+    def test_different_accounts_tracked_independently(self):
+        increment_depth("111111111111", REGION, FUNC)
+        increment_depth("222222222222", REGION, FUNC)
+        increment_depth("222222222222", REGION, FUNC)
+
+        assert get_recursion_depth("111111111111", REGION, FUNC) == 1
+        assert get_recursion_depth("222222222222", REGION, FUNC) == 2
+
+    def test_reset_all_depths(self):
+        increment_depth(ACCOUNT, REGION, "func-a")
+        increment_depth(ACCOUNT, REGION, "func-b")
+        reset_all_depths()
+
+        assert get_recursion_depth(ACCOUNT, REGION, "func-a") == 0
+        assert get_recursion_depth(ACCOUNT, REGION, "func-b") == 0
+
+
+class TestCheckRecursion:
+    """Test the check_recursion enforcement logic."""
+
+    def test_no_error_below_threshold(self):
+        """No exception when depth is below MAX_RECURSION_DEPTH."""
+        for _ in range(MAX_RECURSION_DEPTH - 1):
+            increment_depth(ACCOUNT, REGION, FUNC)
+        # Should not raise — we're at depth 15, threshold is 16
+        check_recursion(ACCOUNT, REGION, FUNC, "Terminate")
+
+    def test_error_at_threshold(self):
+        """RecursiveInvocationException at exactly MAX_RECURSION_DEPTH."""
+        for _ in range(MAX_RECURSION_DEPTH):
+            increment_depth(ACCOUNT, REGION, FUNC)
+        with pytest.raises(RecursiveInvocationException) as exc_info:
+            check_recursion(ACCOUNT, REGION, FUNC, "Terminate")
+        assert FUNC in str(exc_info.value)
+        assert exc_info.value.depth == MAX_RECURSION_DEPTH
+
+    def test_error_above_threshold(self):
+        """RecursiveInvocationException above MAX_RECURSION_DEPTH."""
+        for _ in range(MAX_RECURSION_DEPTH + 5):
+            increment_depth(ACCOUNT, REGION, FUNC)
+        with pytest.raises(RecursiveInvocationException):
+            check_recursion(ACCOUNT, REGION, FUNC, "Terminate")
+
+    def test_allow_mode_skips_check(self):
+        """No exception when mode is 'Allow', even above threshold."""
+        for _ in range(MAX_RECURSION_DEPTH + 10):
+            increment_depth(ACCOUNT, REGION, FUNC)
+        # Should not raise
+        check_recursion(ACCOUNT, REGION, FUNC, "Allow")
+
+    def test_terminate_is_default(self):
+        """Default behavior is 'Terminate'."""
+        for _ in range(MAX_RECURSION_DEPTH):
+            increment_depth(ACCOUNT, REGION, FUNC)
+        with pytest.raises(RecursiveInvocationException):
+            check_recursion(ACCOUNT, REGION, FUNC)
+
+    def test_zero_depth_always_passes(self):
+        """Fresh function with no invocations always passes."""
+        check_recursion(ACCOUNT, REGION, FUNC, "Terminate")
+
+
+class TestRecursiveInvocationException:
+    """Test the exception itself."""
+
+    def test_attributes(self):
+        exc = RecursiveInvocationException("my-func", 16)
+        assert exc.function_name == "my-func"
+        assert exc.depth == 16
+        assert "my-func" in str(exc)
+        assert "16" in str(exc)
+
+    def test_is_exception(self):
+        assert issubclass(RecursiveInvocationException, Exception)
+
+
+class TestMaxRecursionDepthConstant:
+    """Verify the threshold matches AWS behavior."""
+
+    def test_max_depth_is_16(self):
+        assert MAX_RECURSION_DEPTH == 16


### PR DESCRIPTION
## Summary
- Implement runtime enforcement of Lambda recursion detection (previously stored but never checked)
- New `recursion.py` module: thread-safe depth tracking per function, threshold of 16 (matching AWS)
- Enforced in both `_invoke()` (direct) and `_invoke_lambda_sync()` (cross-service) paths
- Returns `RecursiveInvocationException` (400) when recursion limit exceeded with mode "Terminate"
- "Allow" mode permits unlimited recursion depth

## Test plan
- [x] 18 new tests covering depth tracking, enforcement, isolation, mode switching
- [x] All 360 Lambda unit tests pass (4 skipped)
- [x] ruff lint clean
- [ ] CI checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)