### PR TITLE
Implement Lambda provisioned concurrency enforcement (18 tests)

### DIFF
--- a/prompts/20260312-120000-lambda-provisioned-concurrency.md
+++ b/prompts/20260312-120000-lambda-provisioned-concurrency.md
@@ -1,0 +1,41 @@
+---
+session: "prov-concurrency-enforce"
+timestamp: "2026-03-12T12:00:00Z"
+model: claude-opus-4-6
+---
+
+## Human
+
+Implement Lambda provisioned concurrency enforcement. Currently it's stored via CRUD
+operations but NEVER used during invocations. Track provisioned vs on-demand invocations,
+return ProvisionedConcurrencyInvocation header when provisioned capacity is used, enforce
+pool routing, and add x-amz-executed-version header based on qualifier.
+
+## Assistant
+
+## Key decisions
+
+**Provisioned pool routing in ConcurrencyTracker**: Extended `acquire()` to accept a
+`qualifier` parameter and return a bool indicating whether provisioned concurrency was
+used. The tracker now maintains `_provisioned_in_use` dict alongside `_provisioned`
+capacity. When provisioned capacity has room, the invocation uses a provisioned slot;
+when full, it falls through to on-demand. This keeps the enforcement in the tracker
+(single lock, thread-safe) rather than scattering it across provider code.
+
+**Qualifier-based keying**: Provisioned concurrency keys in the tracker use
+`{account}:{region}:{func}:{qualifier}` to match AWS behavior where provisioned
+concurrency is per-version/alias, not per-function. Different versions have independent
+pools.
+
+**x-amz-executed-version**: Now reflects the actual qualifier — numeric version strings
+are passed through, while aliases and $LATEST resolve to "$LATEST". This matches AWS
+behavior where the header shows the concrete version number.
+
+**Utilization metrics**: `_get_provisioned_concurrency` now enriches the stored config
+with live utilization data from the tracker, returning `ProvisionedConcurrencyUtilization`
+(0.0-1.0) and updating `AvailableProvisionedConcurrentExecutions` based on actual in-use
+count.
+
+**What I preserved**: The `acquire()` API is backward-compatible — qualifier defaults to
+`$LATEST`, and the bool return value is new but won't break callers that ignore it. All
+existing tests pass unchanged.

--- a/src/robotocore/services/lambda_/limits.py
+++ b/src/robotocore/services/lambda_/limits.py
@@ -84,17 +84,24 @@ class ConcurrencyTracker:
         # function_key -> reserved concurrency (set via PutFunctionConcurrency)
         self._reserved: dict[str, int] = {}
 
-        # function_key -> provisioned concurrency
+        # function_key -> provisioned concurrency capacity
         self._provisioned: dict[str, int] = {}
+
+        # function_key -> current provisioned concurrency in use
+        self._provisioned_in_use: dict[str, int] = {}
 
         # account-level total code size tracking
         self._total_code_size: int = 0
 
     # -- concurrent execution tracking --
 
-    def acquire(self, function_key: str) -> None:
-        """Increment concurrent execution count. Raises TooManyRequestsException
-        if the account-level limit or function reserved limit is reached."""
+    def acquire(self, function_key: str, qualifier: str = "$LATEST") -> bool:
+        """Increment concurrent execution count. Returns True if the invocation
+        was routed through provisioned concurrency, False if on-demand.
+
+        Raises TooManyRequestsException if the account-level limit or function
+        reserved limit is reached.
+        """
         with self._lock:
             account_limit = get_concurrent_executions_limit()
 
@@ -104,11 +111,30 @@ class ConcurrencyTracker:
                     f"Rate Exceeded. Account concurrent execution limit {account_limit} reached."
                 )
 
+            # Check if provisioned concurrency is available for this function+qualifier
+            prov_key = f"{function_key}:{qualifier}"
+            provisioned_capacity = self._provisioned.get(prov_key)
+            used_provisioned = False
+
+            if provisioned_capacity is not None and provisioned_capacity > 0:
+                prov_in_use = self._provisioned_in_use.get(prov_key, 0)
+                if prov_in_use < provisioned_capacity:
+                    # Route through provisioned pool
+                    self._provisioned_in_use[prov_key] = prov_in_use + 1
+                    used_provisioned = True
+                # If provisioned is full, fall through to on-demand pool
+
             # Check per-function reserved concurrency
             reserved = self._reserved.get(function_key)
             if reserved is not None:
                 current = self._function_counts.get(function_key, 0)
                 if current >= reserved:
+                    # If we already allocated provisioned, undo it
+                    if used_provisioned:
+                        self._provisioned_in_use[prov_key] = (
+                            self._provisioned_in_use.get(prov_key, 1) - 1
+                        )
+                        used_provisioned = False
                     raise TooManyRequestsException(
                         f"Rate Exceeded. Function {function_key} reserved concurrency "
                         f"limit {reserved} reached."
@@ -123,20 +149,33 @@ class ConcurrencyTracker:
                     if key not in self._reserved
                 )
                 if unreserved_in_use >= unreserved_limit:
+                    # If we already allocated provisioned, undo it
+                    if used_provisioned:
+                        self._provisioned_in_use[prov_key] = (
+                            self._provisioned_in_use.get(prov_key, 1) - 1
+                        )
+                        used_provisioned = False
                     raise TooManyRequestsException(
                         "Rate Exceeded. No unreserved concurrency available."
                     )
 
             self._function_counts[function_key] = self._function_counts.get(function_key, 0) + 1
             self._global_count += 1
+            return used_provisioned
 
-    def release(self, function_key: str) -> None:
+    def release(self, function_key: str, qualifier: str = "$LATEST") -> None:
         """Decrement concurrent execution count."""
         with self._lock:
             current = self._function_counts.get(function_key, 0)
             if current > 0:
                 self._function_counts[function_key] = current - 1
                 self._global_count = max(0, self._global_count - 1)
+
+            # Also release provisioned slot if one is in use
+            prov_key = f"{function_key}:{qualifier}"
+            prov_in_use = self._provisioned_in_use.get(prov_key, 0)
+            if prov_in_use > 0:
+                self._provisioned_in_use[prov_key] = prov_in_use - 1
 
     def get_function_count(self, function_key: str) -> int:
         with self._lock:
@@ -192,6 +231,21 @@ class ConcurrencyTracker:
     def delete_provisioned(self, function_key: str) -> None:
         with self._lock:
             self._provisioned.pop(function_key, None)
+            self._provisioned_in_use.pop(function_key, None)
+
+    def get_provisioned_in_use(self, function_key: str) -> int:
+        """Return number of provisioned concurrency slots currently in use."""
+        with self._lock:
+            return self._provisioned_in_use.get(function_key, 0)
+
+    def get_provisioned_utilization(self, function_key: str) -> float:
+        """Return provisioned concurrency utilization as a fraction (0.0 - 1.0)."""
+        with self._lock:
+            capacity = self._provisioned.get(function_key, 0)
+            if capacity == 0:
+                return 0.0
+            in_use = self._provisioned_in_use.get(function_key, 0)
+            return min(1.0, in_use / capacity)
 
     # -- account code size tracking --
 
@@ -221,6 +275,7 @@ class ConcurrencyTracker:
             self._global_count = 0
             self._reserved.clear()
             self._provisioned.clear()
+            self._provisioned_in_use.clear()
             self._total_code_size = 0
 
 

--- a/src/robotocore/services/lambda_/provider.py
+++ b/src/robotocore/services/lambda_/provider.py
@@ -769,6 +769,13 @@ def _put_provisioned_concurrency(
     }
     with _provisioned_lock:
         _provisioned_concurrency[key] = config
+
+    # Register with concurrency tracker so invocations route through provisioned pool
+    function_key = f"{account_id}:{region}:{func_name}"
+    prov_key = f"{function_key}:{qualifier}"
+    tracker = get_concurrency_tracker()
+    tracker.set_provisioned(prov_key, count)
+
     return config
 
 
@@ -777,7 +784,20 @@ def _get_provisioned_concurrency(
 ) -> dict | None:
     key = (account_id, region, func_name, qualifier)
     with _provisioned_lock:
-        return _provisioned_concurrency.get(key)
+        config = _provisioned_concurrency.get(key)
+        if config is None:
+            return None
+        # Enrich with live utilization data from the tracker
+        config = dict(config)  # copy to avoid mutating the store
+        function_key = f"{account_id}:{region}:{func_name}"
+        prov_key = f"{function_key}:{qualifier}"
+        tracker = get_concurrency_tracker()
+        utilization = tracker.get_provisioned_utilization(prov_key)
+        in_use = tracker.get_provisioned_in_use(prov_key)
+        allocated = config.get("AllocatedProvisionedConcurrentExecutions", 0)
+        config["ProvisionedConcurrencyUtilization"] = round(utilization, 4)
+        config["AvailableProvisionedConcurrentExecutions"] = max(0, allocated - in_use)
+        return config
 
 
 def _delete_provisioned_concurrency(
@@ -787,6 +807,11 @@ def _delete_provisioned_concurrency(
     with _provisioned_lock:
         if key in _provisioned_concurrency:
             del _provisioned_concurrency[key]
+            # Deregister from concurrency tracker
+            function_key = f"{account_id}:{region}:{func_name}"
+            prov_key = f"{function_key}:{qualifier}"
+            tracker = get_concurrency_tracker()
+            tracker.delete_provisioned(prov_key)
             return True
         return False
 
@@ -1190,10 +1215,13 @@ async def _invoke(
     # Track recursion depth for this invocation
     increment_depth(account_id, region, func_name)
 
-    # Acquire concurrency slot
+    # Determine qualifier for provisioned concurrency routing
+    qualifier = request.query_params.get("Qualifier", "$LATEST")
+
+    # Acquire concurrency slot — returns True if provisioned concurrency was used
     function_key = f"{account_id}:{region}:{func_name}"
     tracker = get_concurrency_tracker()
-    tracker.acquire(function_key)
+    used_provisioned = tracker.acquire(function_key, qualifier)
     try:
         if code_dir or code_zip:
             from robotocore.services.lambda_.docker_executor import get_executor_mode
@@ -1248,7 +1276,7 @@ async def _invoke(
             # No code — return a simple success (like Moto's simple mode)
             result, error_type, logs = "Simple Lambda happy path OK", None, ""
     finally:
-        tracker.release(function_key)
+        tracker.release(function_key, qualifier)
         decrement_depth(account_id, region, func_name)
 
     # Handle async invocation with destinations and DLQ
@@ -1260,10 +1288,16 @@ async def _invoke(
             daemon=True,
         ).start()
 
+    # Resolve executed version: use qualifier if it's a numeric version, else $LATEST
+    executed_version = qualifier if qualifier.isdigit() else "$LATEST"
+
     headers = {
         "x-amz-request-id": str(uuid.uuid4()),
-        "x-amz-executed-version": "$LATEST",
+        "x-amz-executed-version": executed_version,
     }
+
+    if used_provisioned:
+        headers["x-amz-log-type"] = "ProvisionedConcurrencyInvocation"
 
     if error_type:
         headers["x-amz-function-error"] = error_type
@@ -1363,9 +1397,12 @@ async def _invoke_with_response_stream(
     else:
         payload = str(result).encode()
 
+    qualifier = request.query_params.get("Qualifier", "$LATEST")
+    executed_version = qualifier if qualifier.isdigit() else "$LATEST"
+
     headers = {
         "x-amz-request-id": str(uuid.uuid4()),
-        "x-amz-executed-version": "$LATEST",
+        "x-amz-executed-version": executed_version,
         "content-type": "application/json",
     }
     return Response(

--- a/tests/unit/services/lambda_/test_provisioned_concurrency.py
+++ b/tests/unit/services/lambda_/test_provisioned_concurrency.py
@@ -1,0 +1,257 @@
+"""Unit tests for Lambda provisioned concurrency enforcement during invocations.
+
+Verifies that:
+- Provisioned concurrency slots are used before on-demand when capacity is available
+- When provisioned capacity is exhausted, invocations fall through to on-demand
+- Utilization metrics are tracked correctly
+- x-amz-executed-version header reflects the qualifier
+- Provisioned concurrency state is cleaned up on delete
+"""
+
+import pytest
+
+from robotocore.services.lambda_.limits import (
+    ConcurrencyTracker,
+    TooManyRequestsException,
+)
+
+
+class TestProvisionedConcurrencyRouting:
+    """Test that invocations route through provisioned pool when available."""
+
+    @pytest.fixture(autouse=True)
+    def tracker(self):
+        self.t = ConcurrencyTracker()
+
+    def test_acquire_uses_provisioned_when_available(self):
+        """When provisioned concurrency is set, acquire returns True (provisioned)."""
+        fn_key = "123:us-east-1:my-func"
+        prov_key = f"{fn_key}:1"
+        self.t.set_provisioned(prov_key, 5)
+
+        used_provisioned = self.t.acquire(fn_key, "1")
+        assert used_provisioned is True
+        assert self.t.get_provisioned_in_use(prov_key) == 1
+
+    def test_acquire_returns_false_without_provisioned(self):
+        """Without provisioned concurrency, acquire returns False (on-demand)."""
+        fn_key = "123:us-east-1:my-func"
+        used_provisioned = self.t.acquire(fn_key, "$LATEST")
+        assert used_provisioned is False
+
+    def test_provisioned_pool_exhausted_falls_through(self):
+        """When all provisioned slots are in use, new invocations use on-demand."""
+        fn_key = "123:us-east-1:my-func"
+        prov_key = f"{fn_key}:1"
+        self.t.set_provisioned(prov_key, 2)
+
+        # Fill provisioned pool
+        assert self.t.acquire(fn_key, "1") is True
+        assert self.t.acquire(fn_key, "1") is True
+
+        # Third invocation falls through to on-demand
+        assert self.t.acquire(fn_key, "1") is False
+        assert self.t.get_provisioned_in_use(prov_key) == 2
+
+    def test_release_frees_provisioned_slot(self):
+        """Releasing decrements provisioned in-use count."""
+        fn_key = "123:us-east-1:my-func"
+        prov_key = f"{fn_key}:1"
+        self.t.set_provisioned(prov_key, 2)
+
+        self.t.acquire(fn_key, "1")
+        self.t.acquire(fn_key, "1")
+        assert self.t.get_provisioned_in_use(prov_key) == 2
+
+        self.t.release(fn_key, "1")
+        assert self.t.get_provisioned_in_use(prov_key) == 1
+
+        self.t.release(fn_key, "1")
+        assert self.t.get_provisioned_in_use(prov_key) == 0
+
+    def test_provisioned_slot_reused_after_release(self):
+        """After release, the provisioned slot is available again."""
+        fn_key = "123:us-east-1:my-func"
+        prov_key = f"{fn_key}:1"
+        self.t.set_provisioned(prov_key, 1)
+
+        assert self.t.acquire(fn_key, "1") is True
+        # Pool full now
+        assert self.t.acquire(fn_key, "1") is False
+
+        self.t.release(fn_key, "1")
+        # Slot freed — should use provisioned again
+        assert self.t.acquire(fn_key, "1") is True
+
+
+class TestProvisionedUtilization:
+    """Test utilization metric calculation."""
+
+    @pytest.fixture(autouse=True)
+    def tracker(self):
+        self.t = ConcurrencyTracker()
+
+    def test_utilization_zero_when_no_provisioned(self):
+        fn_key = "123:us-east-1:my-func:1"
+        assert self.t.get_provisioned_utilization(fn_key) == 0.0
+
+    def test_utilization_zero_when_idle(self):
+        fn_key = "123:us-east-1:my-func"
+        prov_key = f"{fn_key}:1"
+        self.t.set_provisioned(prov_key, 10)
+        assert self.t.get_provisioned_utilization(prov_key) == 0.0
+
+    def test_utilization_partial(self):
+        fn_key = "123:us-east-1:my-func"
+        prov_key = f"{fn_key}:1"
+        self.t.set_provisioned(prov_key, 10)
+        self.t.acquire(fn_key, "1")
+        self.t.acquire(fn_key, "1")
+        assert self.t.get_provisioned_utilization(prov_key) == pytest.approx(0.2)
+
+    def test_utilization_full(self):
+        fn_key = "123:us-east-1:my-func"
+        prov_key = f"{fn_key}:1"
+        self.t.set_provisioned(prov_key, 2)
+        self.t.acquire(fn_key, "1")
+        self.t.acquire(fn_key, "1")
+        assert self.t.get_provisioned_utilization(prov_key) == pytest.approx(1.0)
+
+    def test_utilization_capped_at_one(self):
+        """Utilization should never exceed 1.0 even if tracking is off."""
+        fn_key = "123:us-east-1:my-func:1"
+        self.t.set_provisioned(fn_key, 1)
+        # Manually set in_use higher than capacity (shouldn't happen normally)
+        with self.t._lock:
+            self.t._provisioned_in_use[fn_key] = 5
+        assert self.t.get_provisioned_utilization(fn_key) == 1.0
+
+    def test_utilization_decreases_after_release(self):
+        fn_key = "123:us-east-1:my-func"
+        prov_key = f"{fn_key}:1"
+        self.t.set_provisioned(prov_key, 4)
+        self.t.acquire(fn_key, "1")
+        self.t.acquire(fn_key, "1")
+        assert self.t.get_provisioned_utilization(prov_key) == pytest.approx(0.5)
+
+        self.t.release(fn_key, "1")
+        assert self.t.get_provisioned_utilization(prov_key) == pytest.approx(0.25)
+
+
+class TestProvisionedConcurrencyCleanup:
+    """Test that delete clears both provisioned capacity and in-use counters."""
+
+    @pytest.fixture(autouse=True)
+    def tracker(self):
+        self.t = ConcurrencyTracker()
+
+    def test_delete_clears_provisioned_and_in_use(self):
+        fn_key = "123:us-east-1:my-func"
+        prov_key = f"{fn_key}:1"
+        self.t.set_provisioned(prov_key, 5)
+        self.t.acquire(fn_key, "1")
+
+        self.t.delete_provisioned(prov_key)
+        assert self.t.get_provisioned(prov_key) is None
+        assert self.t.get_provisioned_in_use(prov_key) == 0
+
+    def test_reset_clears_provisioned_in_use(self):
+        fn_key = "123:us-east-1:my-func"
+        prov_key = f"{fn_key}:1"
+        self.t.set_provisioned(prov_key, 5)
+        self.t.acquire(fn_key, "1")
+
+        self.t.reset()
+        assert self.t.get_provisioned(prov_key) is None
+        assert self.t.get_provisioned_in_use(prov_key) == 0
+        assert self.t.get_global_count() == 0
+
+
+class TestProvisionedWithReservedConcurrency:
+    """Test interaction between provisioned and reserved concurrency."""
+
+    @pytest.fixture(autouse=True)
+    def tracker(self, monkeypatch):
+        monkeypatch.setenv("LAMBDA_LIMITS_CONCURRENT_EXECUTIONS", "100")
+        monkeypatch.setenv("LAMBDA_LIMITS_MINIMUM_UNRESERVED_CONCURRENCY", "10")
+        self.t = ConcurrencyTracker()
+
+    def test_provisioned_with_reserved_limit(self):
+        """Provisioned concurrency is consumed within reserved limit."""
+        fn_key = "123:us-east-1:my-func"
+        prov_key = f"{fn_key}:1"
+        self.t.set_reserved(fn_key, 5)
+        self.t.set_provisioned(prov_key, 3)
+
+        # First 3 should use provisioned
+        assert self.t.acquire(fn_key, "1") is True
+        assert self.t.acquire(fn_key, "1") is True
+        assert self.t.acquire(fn_key, "1") is True
+
+        # Next 2 use on-demand (within reserved limit)
+        assert self.t.acquire(fn_key, "1") is False
+        assert self.t.acquire(fn_key, "1") is False
+
+        # 6th exceeds reserved limit of 5
+        with pytest.raises(TooManyRequestsException, match="reserved concurrency"):
+            self.t.acquire(fn_key, "1")
+
+    def test_provisioned_exhausted_still_respects_account_limit(self, monkeypatch):
+        """Even when provisioned is exhausted, account limit is enforced."""
+        monkeypatch.setenv("LAMBDA_LIMITS_CONCURRENT_EXECUTIONS", "3")
+        monkeypatch.setenv("LAMBDA_LIMITS_MINIMUM_UNRESERVED_CONCURRENCY", "0")
+        t = ConcurrencyTracker()
+        fn_key = "123:us-east-1:my-func"
+        prov_key = f"{fn_key}:1"
+        t.set_provisioned(prov_key, 1)
+
+        t.acquire(fn_key, "1")  # provisioned
+        t.acquire(fn_key, "1")  # on-demand
+        t.acquire(fn_key, "1")  # on-demand
+
+        with pytest.raises(TooManyRequestsException, match="Account concurrent"):
+            t.acquire(fn_key, "1")
+
+
+class TestMultipleQualifiers:
+    """Test provisioned concurrency with different qualifiers."""
+
+    @pytest.fixture(autouse=True)
+    def tracker(self):
+        self.t = ConcurrencyTracker()
+
+    def test_different_qualifiers_independent_pools(self):
+        """Each qualifier has its own provisioned concurrency pool."""
+        fn_key = "123:us-east-1:my-func"
+        prov_key_v1 = f"{fn_key}:1"
+        prov_key_v2 = f"{fn_key}:2"
+        self.t.set_provisioned(prov_key_v1, 2)
+        self.t.set_provisioned(prov_key_v2, 3)
+
+        assert self.t.acquire(fn_key, "1") is True
+        assert self.t.acquire(fn_key, "2") is True
+        assert self.t.get_provisioned_in_use(prov_key_v1) == 1
+        assert self.t.get_provisioned_in_use(prov_key_v2) == 1
+
+    def test_latest_qualifier_no_provisioned(self):
+        """$LATEST qualifier without provisioned config uses on-demand."""
+        fn_key = "123:us-east-1:my-func"
+        prov_key = f"{fn_key}:1"
+        self.t.set_provisioned(prov_key, 5)
+
+        # Invoke with $LATEST — no provisioned config for $LATEST
+        assert self.t.acquire(fn_key, "$LATEST") is False
+
+    def test_qualifier_with_provisioned_version_specific(self):
+        """Provisioned concurrency on version 1 doesn't affect version 2."""
+        fn_key = "123:us-east-1:my-func"
+        prov_key_v1 = f"{fn_key}:1"
+        self.t.set_provisioned(prov_key_v1, 1)
+
+        # Version 1 uses provisioned
+        assert self.t.acquire(fn_key, "1") is True
+        # Version 1 pool full
+        assert self.t.acquire(fn_key, "1") is False
+
+        # Version 2 never had provisioned — always on-demand
+        assert self.t.acquire(fn_key, "2") is False


### PR DESCRIPTION
## Summary
- Implement runtime enforcement of Lambda provisioned concurrency (previously stored but never used during invocations)
- `ConcurrencyTracker.acquire()` now routes through provisioned pool first, falls back to on-demand
- `_get_provisioned_concurrency` returns live utilization metrics
- `_invoke` sets `x-amz-log-type: ProvisionedConcurrencyInvocation` header when provisioned capacity used
- `x-amz-executed-version` header reflects actual qualifier

## Test plan
- [x] 18 new tests covering pool routing, utilization, cleanup, multi-qualifier isolation
- [x] All 360 Lambda unit tests pass
- [x] ruff lint clean
- [ ] CI checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)