### PR TITLE
Fix test_describe_execution race: poll for completion instead of immediate assert

### DIFF
--- a/prompts/20260315-083500-fix-sfn-race.md
+++ b/prompts/20260315-083500-fix-sfn-race.md
@@ -1,0 +1,23 @@
+---
+name: Fix Step Functions describe_execution race condition in unit test
+description: test_describe_execution was flaky on Python 3.13 due to async background thread
+type: session
+role: assistant
+timestamp: 2026-03-15T08:35:00Z
+session: fix-sfn-race
+sequence: 1
+---
+
+## Human Prompt
+
+Fix failing CI: test_describe_execution asserts 'RUNNING' == 'SUCCEEDED'.
+
+## Root Cause
+
+`_start_execution` launches execution in a background thread. The test immediately
+called `_describe_execution` before the thread completed, getting `RUNNING` status.
+This is a pre-existing race condition that manifested on Python 3.13's faster scheduler.
+
+## Fix
+
+Poll in the test until status leaves `RUNNING` (up to 5s timeout), then assert SUCCEEDED.

--- a/tests/unit/services/test_stepfunctions_provider.py
+++ b/tests/unit/services/test_stepfunctions_provider.py
@@ -207,6 +207,8 @@ class TestExecutionOperations:
             )
 
     def test_describe_execution(self):
+        import time
+
         _create_state_machine(
             {"name": "sm1", "definition": _SIMPLE_DEFINITION, "roleArn": "r"},
             "us-east-1",
@@ -218,7 +220,15 @@ class TestExecutionOperations:
             "us-east-1",
             "123",
         )
-        result = _describe_execution({"executionArn": start["executionArn"]}, "us-east-1", "123")
+        # Execution runs in background thread — poll until it leaves RUNNING
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            result = _describe_execution(
+                {"executionArn": start["executionArn"]}, "us-east-1", "123"
+            )
+            if result["status"] != "RUNNING":
+                break
+            time.sleep(0.05)
         assert result["status"] == "SUCCEEDED"
         assert result["name"] == "exec1"
 


### PR DESCRIPTION
## Summary
- `test_describe_execution` was flaky on Python 3.13: execution runs in a background thread, test checked status immediately and got `RUNNING` instead of `SUCCEEDED`
- Fix: poll up to 5s for status to leave RUNNING before asserting SUCCEEDED

## Test plan
- [ ] `unit: services (3.12)` and `unit: services (3.13)` both pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)