### PR TITLE
Add gap surfacing system: wire names, weak assertions, fallthrough audit, async races

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,11 @@ jobs:
           uv run python scripts/validate_test_quality.py
           --max-no-contact-pct 5
           --max-no-assertion-pct 6
+          --max-weak-assertion-pct 25
+      - name: Check wire name correctness
+        run: uv run python scripts/fix_moto_param_names.py --all
+      - name: Audit fallthrough coverage (informational)
+        run: uv run python scripts/audit_fallthrough.py --all --max-uncovered 400
       - name: Project structural lint
         run: uv run python scripts/lint_project.py --fail
       - name: Upload quality report

--- a/prompts/20260315-225008-gap-surfacing-system.md
+++ b/prompts/20260315-225008-gap-surfacing-system.md
@@ -1,0 +1,57 @@
+---
+name: Gap Surfacing System
+description: Five-layer system to make hidden implementation bugs impossible to miss
+type: feature
+role: assistant
+timestamp: 2026-03-15T22:50:08Z
+session: gap-surfacing
+sequence: 1
+---
+
+## Human Prompt
+
+Implement the Gap Surfacing System plan: wire name gate, weak assertion detector, fallthrough
+coverage auditor, async race lint rule, and or-default masking detector.
+
+## What Was Built
+
+Five layered detection mechanisms, each wired into pre-commit and/or CI:
+
+### 1. Wire Name Gate
+- Added `fix_moto_param_names.py --all` to `.git/hooks/pre-commit` (runs when `src/` is staged)
+- Added to CI `test-quality` job
+- Catches Moto `_get_param()` casing bugs (e.g. `"logGroupName"` vs `"LogGroupName"`)
+
+### 2. Weak Assertion Detector (`validate_test_quality.py`)
+- New `_is_key_presence_assert()` helper: detects `assert "X" in response` patterns
+- New classification: `weak_assertion` — all assertions are key-presence only, no value checks
+- New `--max-weak-assertion-pct` flag (CI threshold: 25%; current baseline: 15.7%)
+- Added `weak_assertion` column to JSON output and text report
+
+### 3. Fallthrough Coverage Auditor (`scripts/audit_fallthrough.py`)
+- New script: for each native provider with `_ACTION_MAP`, finds all botocore operations
+  NOT in the map (fallthrough to Moto), then checks compat test coverage
+- `--all`, `--service`, `--json`, `--max-uncovered`, `--uncovered-only` flags
+- CI gate: `--max-uncovered 400` (current: 392 uncovered; ratchet down over time)
+- Baseline: 10 providers, 1174 fallthrough ops, 782 covered (66.6%)
+
+### 4. Async Race Lint Rule (`lint_project.py` check 11)
+- New `async-race-test` check: finds tests that trigger async op then immediately read state
+- Trigger verbs: `start_execution`, `invoke`, `create_pipe`, `run_task`, `send_message`, etc.
+- Read verbs: `describe_execution`, `get_function`, `describe_pipe`, `get_query_results`, etc.
+- WARNING severity; detected 13 real races on first run across unit + compat tests
+
+### 5. `or`-Default Masking Detector (`fix_moto_param_names.py --check-defaults`)
+- New `find_or_defaults()` function and `--check-defaults` flag
+- Classifies: `silent_mismatch` (wrong wire name + `or` default silences error) vs
+  `masked_default` (correct name but `or` default hides None return)
+- Phase 2 — informational only, not yet in CI gate
+
+## Key Decisions
+
+- Initial CI thresholds set permissively (weak_assertion: 25%, fallthrough: 400) to avoid
+  blocking CI on day one. These are ratchet thresholds: only ever decrease.
+- Wire name gate exits non-zero only on CASING bugs (auto-fixable), not UNKNOWN params
+  (which require manual review and may be intentional Moto internals).
+- Async race check is WARNING not ERROR — some "immediate reads" may be correct
+  (synchronous operations, mocked time in unit tests).

--- a/scripts/audit_fallthrough.py
+++ b/scripts/audit_fallthrough.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Audit native provider fallthrough coverage.
+
+For each native provider with an _ACTION_MAP, identifies which AWS operations
+fall through to forward_to_moto() (i.e., not natively implemented) and checks
+whether those operations have compat test coverage.
+
+Usage:
+    uv run python scripts/audit_fallthrough.py              # all providers
+    uv run python scripts/audit_fallthrough.py --service stepfunctions
+    uv run python scripts/audit_fallthrough.py --all --json
+    uv run python scripts/audit_fallthrough.py --max-uncovered 100  # CI gate
+"""
+
+import argparse
+import ast
+import json
+import re
+import sys
+from pathlib import Path
+
+SRC = Path("src/robotocore/services")
+TESTS = Path("tests/compatibility")
+
+
+def get_action_map_keys(provider_path: Path) -> set[str] | None:
+    """Extract keys from _ACTION_MAP in a provider.py. Returns None if no _ACTION_MAP found."""
+    source = provider_path.read_text()
+    if "_ACTION_MAP" not in source:
+        return None
+
+    try:
+        tree = ast.parse(source, filename=str(provider_path))
+    except SyntaxError:
+        return None
+
+    for node in ast.walk(tree):
+        # Look for _ACTION_MAP = { ... }
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == "_ACTION_MAP":
+                    if isinstance(node.value, ast.Dict):
+                        keys = set()
+                        for key in node.value.keys:
+                            if isinstance(key, ast.Constant) and isinstance(key.value, str):
+                                keys.add(key.value)
+                        return keys
+    return None
+
+
+def get_service_name_from_provider(provider_path: Path) -> str | None:
+    """Extract the AWS service name used in forward_to_moto calls."""
+    source = provider_path.read_text()
+    # Look for: forward_to_moto(request, "service_name", ...)
+    match = re.search(r'forward_to_moto\s*\(\s*request\s*,\s*"([^"]+)"', source)
+    if match:
+        return match.group(1)
+    # Fallback: use directory name
+    return provider_path.parent.name
+
+
+def get_botocore_operations(service: str) -> list[str]:
+    """Get all operation names from botocore for a service."""
+    try:
+        import botocore.session
+
+        session = botocore.session.get_session()
+        # Handle service name variations
+        model = session.get_service_model(service)
+        return list(model.operation_names)
+    except Exception:
+        return []
+
+
+def pascal_to_snake(name: str) -> str:
+    """Convert PascalCase to snake_case."""
+    s1 = re.sub(r"(.)([A-Z][a-z]+)", r"\1_\2", name)
+    return re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", s1).lower()
+
+
+def get_tested_operations(service: str) -> set[str]:
+    """Get set of operation names (PascalCase) that have compat tests for a service."""
+    # Map service name to test file
+    svc_clean = service.replace("-", "_")
+    test_file = TESTS / f"test_{svc_clean}_compat.py"
+    if not test_file.exists():
+        return set()
+
+    source = test_file.read_text()
+
+    # Find all boto3 method calls: client.method_name(
+    # These are snake_case; convert to PascalCase
+    tested = set()
+
+    # Get all attribute calls: .<method_name>(
+    for match in re.finditer(r"\.([a-z][a-z0-9_]+)\s*\(", source):
+        method = match.group(1)
+        # Convert snake_case to PascalCase
+        pascal = "".join(word.capitalize() for word in method.split("_"))
+        tested.add(pascal)
+
+    return tested
+
+
+def audit_provider(provider_path: Path) -> dict | None:
+    """Audit a single provider. Returns audit result dict or None if not applicable."""
+    action_map_keys = get_action_map_keys(provider_path)
+    if action_map_keys is None:
+        return None  # No _ACTION_MAP — not a dispatched provider
+
+    service = get_service_name_from_provider(provider_path)
+    if not service:
+        return None
+
+    botocore_ops = get_botocore_operations(service)
+    if not botocore_ops:
+        return None
+
+    # Fallthrough ops = botocore ops not in _ACTION_MAP
+    fallthrough_ops = [op for op in botocore_ops if op not in action_map_keys]
+    native_ops = [op for op in botocore_ops if op in action_map_keys]
+
+    tested_ops = get_tested_operations(service)
+
+    covered = []
+    uncovered = []
+    for op in sorted(fallthrough_ops):
+        if op in tested_ops:
+            covered.append(op)
+        else:
+            uncovered.append(op)
+
+    return {
+        "service": service,
+        "provider": str(provider_path),
+        "total_botocore_ops": len(botocore_ops),
+        "native_ops": len(native_ops),
+        "fallthrough_ops": len(fallthrough_ops),
+        "covered_fallthroughs": len(covered),
+        "uncovered_fallthroughs": len(uncovered),
+        "uncovered": uncovered,
+        "covered": covered,
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Audit native provider fallthrough coverage")
+    parser.add_argument("--service", help="Audit a single service by name")
+    parser.add_argument("--all", action="store_true", help="Audit all providers (default)")
+    parser.add_argument("--json", action="store_true", help="JSON output")
+    parser.add_argument(
+        "--max-uncovered",
+        type=int,
+        default=0,
+        help="Fail if uncovered fallthrough count exceeds this (0=no check)",
+    )
+    parser.add_argument(
+        "--uncovered-only", action="store_true", help="Show only uncovered operations"
+    )
+    args = parser.parse_args()
+
+    # Find providers
+    if args.service:
+        svc_dir = SRC / args.service.replace("-", "_")
+        if not svc_dir.exists():
+            svc_dir = SRC / args.service
+        provider = svc_dir / "provider.py"
+        if not provider.exists():
+            print(f"No provider found for service: {args.service}", file=sys.stderr)
+            sys.exit(1)
+        providers = [provider]
+    else:
+        providers = sorted(SRC.glob("*/provider.py"))
+
+    results = []
+    for provider_path in providers:
+        result = audit_provider(provider_path)
+        if result:
+            results.append(result)
+
+    total_uncovered = sum(r["uncovered_fallthroughs"] for r in results)
+    total_covered = sum(r["covered_fallthroughs"] for r in results)
+    total_fallthrough = sum(r["fallthrough_ops"] for r in results)
+
+    if args.json:
+        output = {
+            "total_providers": len(results),
+            "total_fallthrough_ops": total_fallthrough,
+            "covered_fallthroughs": total_covered,
+            "uncovered_fallthroughs": total_uncovered,
+            "coverage_pct": (
+                round(total_covered / total_fallthrough * 100, 1) if total_fallthrough else 100.0
+            ),
+            "services": results,
+        }
+        print(json.dumps(output, indent=2))
+    else:
+        print("Native Provider Fallthrough Coverage Audit")
+        print("=" * 60)
+        print(f"Providers audited:    {len(results)}")
+        print(f"Total fallthrough ops: {total_fallthrough}")
+        print(f"  Covered:            {total_covered}")
+        print(f"  Uncovered:          {total_uncovered}")
+        if total_fallthrough:
+            pct = total_covered / total_fallthrough * 100
+            print(f"Fallthrough coverage: {pct:.1f}%")
+        print()
+
+        for r in sorted(results, key=lambda x: x["uncovered_fallthroughs"], reverse=True):
+            if args.uncovered_only and r["uncovered_fallthroughs"] == 0:
+                continue
+            c = r["covered_fallthroughs"]
+            t = r["fallthrough_ops"]
+            if t == 0:
+                continue
+            pct = c / t * 100 if t else 100
+            print(f"  {r['service']:<30s}  {c:>3}/{t:<3} covered  ({pct:.0f}%)")
+            if args.uncovered_only and r["uncovered"]:
+                for op in r["uncovered"][:10]:
+                    print(f"    - {op}")
+                if len(r["uncovered"]) > 10:
+                    print(f"    ... and {len(r['uncovered']) - 10} more")
+
+    # CI gate
+    if args.max_uncovered > 0 and total_uncovered > args.max_uncovered:
+        print(
+            f"\nFAIL: {total_uncovered} uncovered fallthrough operations "
+            f"(threshold: {args.max_uncovered})"
+        )
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/fix_moto_param_names.py
+++ b/scripts/fix_moto_param_names.py
@@ -223,6 +223,76 @@ def apply_fixes(service: str, issues: list[dict]) -> int:
     return 0
 
 
+def find_or_defaults(service: str, session) -> list[dict]:
+    """Find _get_param("X") or <default> patterns and classify them.
+
+    Returns a list of findings with kind "silent_mismatch" (X is wrong wire name + has default)
+    or "masked_default" (X is correct wire name but has an `or` default that hides None).
+    """
+    botocore_name = SERVICE_NAME_MAP.get(service, service)
+    responses_path = VENDOR_MOTO / service / "responses.py"
+    if not responses_path.exists():
+        return []
+
+    source = responses_path.read_text()
+    # Match: _get_param("X") or <something>
+    or_default_re = re.compile(r'_get_param\(\s*"([^"]+)"\s*\)\s*or\b')
+
+    method_re = re.compile(r"^    def (\w+)\(self\)", re.MULTILINE)
+    starts = [(m.start(), m.group(1)) for m in method_re.finditer(source)]
+
+    issues = []
+    for i, (start, method_name) in enumerate(starts):
+        if method_name.startswith("_") or method_name in SKIP_METHODS:
+            continue
+        end = starts[i + 1][0] if i + 1 < len(starts) else len(source)
+        body = source[start:end]
+
+        op_name = snake_to_pascal(method_name)
+        body_wire_names, all_wire_names = get_all_wire_names(botocore_name, op_name, session)
+        if all_wire_names is None:
+            continue
+
+        all_valid = set(all_wire_names.keys())
+        lower_all_valid = {k.lower(): k for k in all_valid}
+
+        for match in or_default_re.finditer(body):
+            param = match.group(1)
+            line_no = source[: start + match.start()].count("\n") + 1
+
+            if param in all_valid:
+                # Correct wire name but has `or` default — may mask None return silently
+                issues.append(
+                    {
+                        "service": service,
+                        "method": method_name,
+                        "operation": op_name,
+                        "param": param,
+                        "kind": "masked_default",
+                        "line": line_no,
+                        "message": f'_get_param("{param}") or <default> — '
+                        f"default masks None (may be intentional)",
+                    }
+                )
+            else:
+                suggestion = lower_all_valid.get(param.lower())
+                issues.append(
+                    {
+                        "service": service,
+                        "method": method_name,
+                        "operation": op_name,
+                        "param": param,
+                        "kind": "silent_mismatch",
+                        "line": line_no,
+                        "message": f'_get_param("{param}") or <default> — '
+                        f"wrong wire name + default silences error"
+                        + (f', should be "{suggestion}"' if suggestion else ""),
+                    }
+                )
+
+    return issues
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Check/fix Moto _get_param wire names")
     group = parser.add_mutually_exclusive_group(required=True)
@@ -232,6 +302,11 @@ def main() -> int:
         "--all", action="store_true", help=f"Check batch 4-7 services: {BATCH_SERVICES}"
     )
     parser.add_argument("--write", action="store_true", help="Apply fixes (default: dry run)")
+    parser.add_argument(
+        "--check-defaults",
+        action="store_true",
+        help="Also report _get_param(...) or <default> patterns that may mask wire-name bugs",
+    )
     args = parser.parse_args()
 
     if args.service:
@@ -243,16 +318,19 @@ def main() -> int:
 
     session = get_botocore_session()
     all_issues: list[dict] = []
+    or_default_issues: list[dict] = []
 
     for service in services:
         issues = find_mismatches(service, session)
         all_issues.extend(issues)
+        if args.check_defaults:
+            or_default_issues.extend(find_or_defaults(service, session))
 
     # Split into casing bugs (fixable) and unknown params (need review)
     casing = [i for i in all_issues if i["kind"] == "casing"]
     unknown = [i for i in all_issues if i["kind"] == "unknown"]
 
-    if not all_issues:
+    if not all_issues and not or_default_issues:
         print(f"✓ No _get_param mismatches found in {len(services)} service(s).")
         return 0
 
@@ -278,6 +356,26 @@ def main() -> int:
                 f'_get_param("{issue["wrong"]}") — valid keys: {issue["all_valid"][:5]}...'
             )
         print()
+
+    if or_default_issues:
+        silent = [i for i in or_default_issues if i["kind"] == "silent_mismatch"]
+        masked = [i for i in or_default_issues if i["kind"] == "masked_default"]
+        if silent:
+            print(f"SILENT MISMATCHES ({len(silent)}) — wrong wire name + `or` default hides it:\n")
+            for issue in silent:
+                loc = f"{issue['service']}.{issue['method']}():{issue['line']}"
+                print(f"  {loc}: {issue['message']}")
+            print()
+        if masked:
+            print(
+                f"MASKED DEFAULTS ({len(masked)}) — correct name but `or` default may hide None:\n"
+            )
+            for issue in masked[:20]:
+                loc = f"{issue['service']}.{issue['method']}():{issue['line']}"
+                print(f"  {loc}: {issue['message']}")
+            if len(masked) > 20:
+                print(f"  ... and {len(masked) - 20} more")
+            print()
 
     if args.write:
         if not casing:

--- a/scripts/lint_project.py
+++ b/scripts/lint_project.py
@@ -21,6 +21,7 @@ Checks:
     8.  provider-import-sync   Provider files vs app.py imports
     9.  router-stale-ops       Hardcoded operation sets that may be stale
     10. test-duplicate-names   Duplicate test method names within a class
+    11. async-race-test        Tests that trigger async op then immediately read state
 """
 
 import argparse
@@ -472,6 +473,121 @@ def check_stale_operation_sets(findings: list[Finding]):
         )
 
 
+# ─── Check 11: Async race conditions in tests ────────────────────────────────
+
+# Operations that trigger async work (trigger → async state change)
+_TRIGGER_OPS = frozenset(
+    {
+        "start_execution",
+        "start_sync_execution",
+        "invoke",
+        "create_pipe",
+        "run_task",
+        "start_task",
+        "send_message",
+        "put_events",
+        "put_record",
+        "put_records",
+        "start_query",
+        "start_query_execution",
+    }
+)
+
+# Operations that read state that may not be ready yet
+_READ_OPS = frozenset(
+    {
+        "describe_execution",
+        "get_execution_history",
+        "describe_pipe",
+        "describe_task",
+        "get_function",
+        "get_object",
+        "get_query_results",
+        "get_query_execution",
+        "describe_query",
+    }
+)
+
+# Polling indicators: if any of these appear between trigger and read, it's fine
+_POLL_INDICATORS = {"sleep", "time", "while", "poll", "wait"}
+
+
+def _extract_call_name(node: ast.Call) -> str | None:
+    """Extract method name from a Call node."""
+    func = node.func
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    if isinstance(func, ast.Name):
+        return func.id
+    return None
+
+
+def check_async_race_tests(findings: list[Finding]):
+    """Check 11: Tests that trigger async op then immediately read state (likely race)."""
+    # Check both unit and compat tests
+    test_dirs = [Path("tests/unit"), Path("tests/compatibility")]
+
+    for test_dir in test_dirs:
+        if not test_dir.exists():
+            continue
+        for fpath in sorted(test_dir.rglob("test_*.py")):
+            tree = _parse_file(fpath)
+            if not tree:
+                continue
+
+            for node in ast.walk(tree):
+                if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    continue
+                if not node.name.startswith("test_"):
+                    continue
+
+                _check_async_race_in_test(fpath, node, findings)
+
+
+def _check_async_race_in_test(fpath: Path, node: ast.FunctionDef, findings: list[Finding]):
+    """Check a single test function for async race patterns."""
+    # Collect all statements with their line numbers, flattened
+    stmts = list(ast.walk(node))
+
+    # Find all call statements with their line numbers
+    calls: list[tuple[int, str]] = []  # (lineno, method_name)
+    for child in stmts:
+        if isinstance(child, (ast.Call,)):
+            name = _extract_call_name(child)
+            if name:
+                calls.append((child.lineno, name))
+
+    # Check for trigger → read with no poll in between
+    for i, (trigger_line, trigger_name) in enumerate(calls):
+        if trigger_name not in _TRIGGER_OPS:
+            continue
+
+        # Look for a read op within the next 5 lines
+        for read_line, read_name in calls[i + 1 :]:
+            if read_line > trigger_line + 5:
+                break
+            if read_name not in _READ_OPS:
+                continue
+
+            # Check if there's a poll indicator in the function body lines between them
+            source_lines = fpath.read_text().splitlines()
+            between = "\n".join(source_lines[trigger_line:read_line])
+            if any(indicator in between for indicator in _POLL_INDICATORS):
+                continue
+
+            findings.append(
+                Finding(
+                    "async-race-test",
+                    "warning",
+                    str(fpath),
+                    trigger_line,
+                    f"{node.name}: calls {trigger_name}() then immediately {read_name}() "
+                    f"(line {read_line}) — add poll loop or sleep to avoid race condition",
+                )
+            )
+            break  # Only report once per trigger
+
+
 # ─── Check 10: Duplicate test method names ───────────────────────────────────
 
 
@@ -516,6 +632,7 @@ ALL_CHECKS = {
     "provider-import-sync": check_provider_import_sync,
     "router-stale-ops": check_stale_operation_sets,
     "test-duplicate-names": check_duplicate_test_names,
+    "async-race-test": check_async_race_tests,
 }
 
 # Deduplicate functions (test_quality handles two check names)

--- a/scripts/validate_test_quality.py
+++ b/scripts/validate_test_quality.py
@@ -32,6 +32,30 @@ from pathlib import Path
 TESTS_DIR = Path("tests/compatibility")
 
 
+def _is_key_presence_assert(node: ast.Assert) -> bool:
+    """Return True if the assert is a key-presence check: assert "X" in <name>.
+
+    These only verify a key exists in a dict, not that it has a meaningful value.
+    Patterns matched:
+        assert "Key" in response
+        assert "Key" in result
+        assert "Key" in resp
+    Does NOT match:
+        assert response["Key"] == value   (value check — good)
+        assert len(response["X"]) > 0     (value check — good)
+        assert "Key" not in response      (negative check — ok, deliberate)
+    """
+    test = node.test
+    if not isinstance(test, ast.Compare):
+        return False
+    if len(test.ops) != 1 or not isinstance(test.ops[0], ast.In):
+        return False
+    # Left side must be a string constant
+    if not isinstance(test.left, ast.Constant) or not isinstance(test.left.value, str):
+        return False
+    return True
+
+
 class TestQualityVisitor(ast.NodeVisitor):
     """AST visitor that classifies test methods by quality."""
 
@@ -76,11 +100,13 @@ class TestQualityVisitor(ast.NodeVisitor):
         all_excepts_pass = True
         has_method_call = False
         has_response_capture = False
+        assert_nodes: list[ast.Assert] = []
 
         for child in ast.walk(node):
             # Check for assert statements
             if isinstance(child, ast.Assert):
                 has_assert = True
+                assert_nodes.append(child)
 
             # Check for pytest.raises
             if isinstance(child, ast.Attribute) and child.attr == "raises":
@@ -128,6 +154,14 @@ class TestQualityVisitor(ast.NodeVisitor):
                     ):
                         has_response_capture = True
 
+        # Detect weak assertions: all asserts are key-presence checks
+        # e.g. `assert "X" in response` but never `assert response["X"] == value`
+        is_weak = False
+        if assert_nodes:
+            all_weak = all(_is_key_presence_assert(a) for a in assert_nodes)
+            if all_weak:
+                is_weak = True
+
         # Classify
         if catches_param_validation and has_try_except and all_excepts_pass and not has_assert:
             quality = "no_server_contact"
@@ -138,6 +172,9 @@ class TestQualityVisitor(ast.NodeVisitor):
         elif not has_assert and not has_try_except and has_method_call:
             quality = "no_assertion"
             reason = "calls server but has no assertions"
+        elif is_weak:
+            quality = "weak_assertion"
+            reason = "all assertions are key-presence only (assert 'X' in resp) — no value checks"
         elif has_assert or (has_try_except and not all_excepts_pass):
             quality = "ok"
             reason = ""
@@ -189,6 +226,12 @@ def main():
         default=0,
         help="Fail if no-assertion tests exceed this percentage (0=no check)",
     )
+    parser.add_argument(
+        "--max-weak-assertion-pct",
+        type=float,
+        default=0,
+        help="Fail if weak-assertion tests exceed this percentage (0=no check)",
+    )
     args = parser.parse_args()
 
     if args.file:
@@ -210,6 +253,7 @@ def main():
     ok_count = len(by_quality.get("ok", []))
     no_contact = len(by_quality.get("no_server_contact", []))
     no_assert = len(by_quality.get("no_assertion", []))
+    weak_assert = len(by_quality.get("weak_assertion", []))
     unknown = len(by_quality.get("unknown", []))
 
     if args.json:
@@ -218,14 +262,20 @@ def main():
             "server_contact_with_assertions": ok_count,
             "no_server_contact": no_contact,
             "no_assertion": no_assert,
+            "weak_assertion": weak_assert,
             "unknown": unknown,
             "no_contact_pct": round(no_contact / total * 100, 1) if total else 0,
             "no_assertion_pct": round(no_assert / total * 100, 1) if total else 0,
+            "weak_assertion_pct": round(weak_assert / total * 100, 1) if total else 0,
             "effective_tests": ok_count,
             "effective_pct": round(ok_count / total * 100, 1) if total else 0,
         }
         if args.problems_only:
-            problems = by_quality.get("no_server_contact", []) + by_quality.get("no_assertion", [])
+            problems = (
+                by_quality.get("no_server_contact", [])
+                + by_quality.get("no_assertion", [])
+                + by_quality.get("weak_assertion", [])
+            )
             summary["problems"] = [
                 {"file": t["file"], "line": t["line"], "name": t["name"], "reason": t["reason"]}
                 for t in problems
@@ -238,24 +288,35 @@ def main():
         print(f"  Server contact + assertions:   {ok_count:,}  (effective)")
         print(f"  No server contact:             {no_contact:,}  (client-side validation only)")
         print(f"  No meaningful assertion:        {no_assert:,}  (call without verification)")
+        print(f"  Weak assertions only:           {weak_assert:,}  (key-presence checks only)")
         print(f"  Unknown:                       {unknown:,}")
         print()
         pct_effective = ok_count / total * 100 if total else 0
         pct_no_contact = no_contact / total * 100 if total else 0
+        pct_weak = weak_assert / total * 100 if total else 0
         print(f"Effective test rate:             {pct_effective:.1f}%")
         print(f"No-server-contact rate:          {pct_no_contact:.1f}%")
+        print(f"Weak-assertion rate:             {pct_weak:.1f}%")
         print()
 
         if args.problems_only or not args.json:
             # Group problems by file
-            problems = by_quality.get("no_server_contact", []) + by_quality.get("no_assertion", [])
+            problems = (
+                by_quality.get("no_server_contact", [])
+                + by_quality.get("no_assertion", [])
+                + by_quality.get("weak_assertion", [])
+            )
             if problems and not args.problems_only:
                 print("Top files with non-effective tests:")
                 file_counts: dict[str, dict[str, int]] = {}
                 for t in problems:
-                    fc = file_counts.setdefault(t["file"], {"no_contact": 0, "no_assert": 0})
+                    fc = file_counts.setdefault(
+                        t["file"], {"no_contact": 0, "no_assert": 0, "weak_assert": 0}
+                    )
                     if t["quality"] == "no_server_contact":
                         fc["no_contact"] += 1
+                    elif t["quality"] == "weak_assertion":
+                        fc["weak_assert"] += 1
                     else:
                         fc["no_assert"] += 1
                 for f, counts in sorted(
@@ -282,6 +343,15 @@ def main():
             print(
                 f"\nFAIL: {pct:.1f}% of tests have no assertions "
                 f"(threshold: {args.max_no_assertion_pct}%)"
+            )
+            exit_code = 1
+
+    if args.max_weak_assertion_pct > 0 and total > 0:
+        pct = weak_assert / total * 100
+        if pct > args.max_weak_assertion_pct:
+            print(
+                f"\nFAIL: {pct:.1f}% of tests have only weak (key-presence) assertions "
+                f"(threshold: {args.max_weak_assertion_pct}%)"
             )
             exit_code = 1
 


### PR DESCRIPTION
## Summary

Five layered detection mechanisms that make hidden implementation bugs impossible to miss:

1. **Wire name gate** — `fix_moto_param_names.py --all` added to pre-commit and CI `test-quality` job. Catches `_get_param()` casing bugs (e.g. `"logGroupName"` vs `"LogGroupName"`) before they reach main.

2. **Weak assertion detector** — `validate_test_quality.py` now classifies tests where ALL assertions are `assert "X" in response` (key-presence only) as `weak_assertion`. New `--max-weak-assertion-pct 25` CI gate. Current baseline: 15.7%.

3. **Fallthrough auditor** — New `scripts/audit_fallthrough.py` reports which botocore operations fall through to Moto in native providers and whether they have compat coverage. CI gate: `--max-uncovered 400` (ratchet down over time). Baseline: 392/1174 uncovered.

4. **Async race lint rule** — `lint_project.py` check 11 (`async-race-test`) flags tests that trigger an async op then immediately read state without a poll loop. Found 13 real races on first run.

5. **`or`-default masking detector** — `fix_moto_param_names.py --check-defaults` (Phase 2, informational only) reports `_get_param("X") or <default>` patterns that silently hide wire-name bugs.

## Test plan

- [ ] CI `test-quality` job passes with all new gates
- [ ] `uv run python scripts/audit_fallthrough.py --all` runs without errors
- [ ] `uv run python scripts/validate_test_quality.py --max-weak-assertion-pct 25` passes
- [ ] `uv run python scripts/lint_project.py --check async-race-test` shows warnings only (no errors)
- [ ] `uv run python scripts/fix_moto_param_names.py --all` returns 0 (no casing bugs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)