### PR TITLE
feat(compat): expand backup compat tests for scan jobs and tiering

### DIFF
--- a/prompts/20260317-000000-backup-compat.md
+++ b/prompts/20260317-000000-backup-compat.md
@@ -1,0 +1,34 @@
+---
+session: "a50d1824"
+timestamp: "2026-03-17T00:00:00Z"
+model: claude-sonnet-4-6
+sequence: 1
+---
+
+## Human
+Expand backup compat tests for untested operations defined in chunks/backup.json.
+
+## Assistant
+
+### Analysis
+Read chunks/backup.json — all chunks had `working_untested_count: 0` because the probe_status used stale data showing most ops as `not_implemented`. Re-probed live server and found discrepancies.
+
+### Live probe results (diverge from chunks file)
+The chunks file showed `DescribeScanJob`, `ListScanJobs`, `GetTieringConfiguration`, and `ListTieringConfigurations` as `not_implemented`, but live server probe returned:
+- `list_scan_jobs`: OK (returns `ScanJobs` key)
+- `describe_scan_job`: working (ResourceNotFoundException with fake ID)
+- `list_tiering_configurations`: OK (returns `TieringConfigurations` key)
+- `get_tiering_configuration`: working (ResourceNotFoundException with fake name)
+
+### Key decisions
+**ScanJob**: Used `list_scan_jobs` → assert key exists, and `describe_scan_job` with fake ID → assert ResourceNotFoundException. Direct patterns, no setup needed.
+
+**TieringConfiguration**: Same pattern — list returns key, get with fake name returns ResourceNotFoundException.
+
+**Operations skipped** (confirmed 501 in live probe): `ListScanJobSummaries`, `ListBackupPlanVersions`, `ListBackupSelections`, `ListProtectedResourcesByBackupVault`, `ListRecoveryPointsByBackupVault`, `ListRestoreAccessBackupVaults`, `ListIndexedRecoveryPoints`, `GetBackupPlan`, `GetLegalHold`, `GetRecoveryPointIndexDetails`, `GetRestoreTestingInferredMetadata`.
+
+### Results
+- 4 new tests added in 2 new classes
+- All 4 pass against live server
+- Quality gate: 0.0% no-server-contact rate (well under 5% CI limit)
+- 140 total tests, 89.3% effective rate

--- a/tests/compatibility/test_backup_compat.py
+++ b/tests/compatibility/test_backup_compat.py
@@ -2086,3 +2086,31 @@ class TestBackupAdditionalOperations:
             )
         finally:
             backup.delete_backup_vault(BackupVaultName=vault_name)
+
+
+class TestBackupScanJobOperations:
+    def test_list_scan_jobs_returns_key(self, backup):
+        """ListScanJobs returns a ScanJobs list key."""
+        resp = backup.list_scan_jobs()
+        assert "ScanJobs" in resp
+
+    def test_describe_scan_job_not_found(self, backup):
+        """DescribeScanJob with fake ID returns ResourceNotFoundException."""
+        with pytest.raises(ClientError) as exc_info:
+            backup.describe_scan_job(ScanJobId="fake-scan-job-id-00000000")
+        err = exc_info.value.response["Error"]
+        assert err["Code"] in ("ResourceNotFoundException", "NotFoundException")
+
+
+class TestBackupTieringConfigurationOperations:
+    def test_list_tiering_configurations_returns_key(self, backup):
+        """ListTieringConfigurations returns a TieringConfigurations list key."""
+        resp = backup.list_tiering_configurations()
+        assert "TieringConfigurations" in resp
+
+    def test_get_tiering_configuration_not_found(self, backup):
+        """GetTieringConfiguration with fake name returns ResourceNotFoundException."""
+        with pytest.raises(ClientError) as exc_info:
+            backup.get_tiering_configuration(TieringConfigurationName="nonexistent-tiering-cfg")
+        err = exc_info.value.response["Error"]
+        assert err["Code"] in ("ResourceNotFoundException", "NotFoundException")


### PR DESCRIPTION
## Summary

- Add `TestBackupScanJobOperations` with tests for `ListScanJobs` and `DescribeScanJob`
- Add `TestBackupTieringConfigurationOperations` with tests for `ListTieringConfigurations` and `GetTieringConfiguration`
- These 4 operations were working on the live server but untested; chunks file had stale `not_implemented` probe status

## Test plan

- [x] All 4 new tests run against live server on port 4566 and pass
- [x] `validate_test_quality.py`: 0.0% no-server-contact rate (limit: 5%)
- [x] 140 total tests in file, 89.3% effective rate
- [x] Skipped confirmed 501 operations: `ListScanJobSummaries`, `ListBackupPlanVersions`, `ListBackupSelections`, `ListProtectedResourcesByBackupVault`, `ListRecoveryPointsByBackupVault`, and others

🤖 Generated with [Claude Code](https://claude.com/claude-code)