### PR TITLE
feat(compat): expand lakeformation compat tests with LFTagExpression and IdentityCenter

### DIFF
--- a/prompts/20260318-022018-lakeformation-compat.md
+++ b/prompts/20260318-022018-lakeformation-compat.md
@@ -1,0 +1,28 @@
+---
+session: "a438102c"
+timestamp: "2026-03-18T02:20:18Z"
+model: claude-sonnet-4-6
+sequence: 1
+---
+
+## Human
+Expand lakeformation compat tests. Add tests for untested operations from chunks/lakeformation.json.
+
+## Assistant
+Read chunks/lakeformation.json and the existing test file. The chunks file showed many operations as "untested" but the existing test file (785 lines) already covered most of them due to prior work.
+
+Probed the live server and found two additional working operations not yet tested:
+- `GetLFTagExpression` — returns EntityNotFoundException for fake name (confirmed working)
+- `ListLFTagExpressions` — returns empty list (confirmed working)
+- `DescribeLakeFormationIdentityCenterConfiguration` — returns EntityNotFoundException (confirmed working)
+
+The chunks file had these as `not_implemented` but the live probe showed them working.
+
+## Key decisions
+**LFTagExpression chunk**: Probe showed `GetLFTagExpression` and `ListLFTagExpressions` as working despite the chunks JSON saying `not_implemented`. Used the live probe output as ground truth. Wrote tests using the "fake ID → assert EntityNotFoundException" and "list → assert response key" patterns.
+
+**LakeFormationIdentityCenter chunk**: `DescribeLakeFormationIdentityCenterConfiguration` was listed as working in the probe but untested. Since no Identity Center configuration exists by default, it raises EntityNotFoundException — tested that.
+
+**Skipped non-implemented operations**: `AssumeDecoratedRoleWithSAML`, `ExtendTransaction`, `CreateLFTagExpression`, `DeleteLFTagExpression`, `UpdateLFTagExpression`, `DeleteObjectsOnCancel`, `StartQueryPlanning` (wrong endpoint), `GetTableObjects`, `ListTableStorageOptimizers`, `GetTemporaryDataLocationCredentials`, `ListLakeFormationOptIns` — all either 501 or require external services.
+
+**Quality gate passed**: 0% no-server-contact rate, 81.8% effective test rate. 55 total tests, all passing.

--- a/tests/compatibility/test_lakeformation_compat.py
+++ b/tests/compatibility/test_lakeformation_compat.py
@@ -726,6 +726,44 @@ class TestLakeFormationDataCellsFilterCRUD:
         assert exc.value.response["Error"]["Code"] == "EntityNotFoundException"
 
 
+class TestLakeFormationLFTagExpressions:
+    """Tests for LFTagExpression operations: ListLFTagExpressions, GetLFTagExpression."""
+
+    @pytest.fixture
+    def client(self):
+        return make_client("lakeformation")
+
+    def test_list_lf_tag_expressions_empty(self, client):
+        """ListLFTagExpressions returns a response with LFTagExpressions list."""
+        resp = client.list_lf_tag_expressions()
+        assert "LFTagExpressions" in resp
+        assert isinstance(resp["LFTagExpressions"], list)
+
+    def test_get_lf_tag_expression_not_found(self, client):
+        """GetLFTagExpression raises EntityNotFoundException for nonexistent expression."""
+        from botocore.exceptions import ClientError as BotoClientError
+
+        with pytest.raises(BotoClientError) as exc:
+            client.get_lf_tag_expression(Name="nonexistent-expression-xyz")
+        assert exc.value.response["Error"]["Code"] == "EntityNotFoundException"
+
+
+class TestLakeFormationIdentityCenter:
+    """Tests for DescribeLakeFormationIdentityCenterConfiguration."""
+
+    @pytest.fixture
+    def client(self):
+        return make_client("lakeformation")
+
+    def test_describe_identity_center_configuration_not_found(self, client):
+        """DescribeLakeFormationIdentityCenterConfiguration raises EntityNotFoundException."""
+        from botocore.exceptions import ClientError as BotoClientError
+
+        with pytest.raises(BotoClientError) as exc:
+            client.describe_lake_formation_identity_center_configuration()
+        assert exc.value.response["Error"]["Code"] == "EntityNotFoundException"
+
+
 class TestLakeFormationLFTags:
     """Tests for LF Tag full lifecycle and resource tagging."""
 


### PR DESCRIPTION
## Summary
- Add 3 new compat tests for LakeFormation operations that were working on the live server but not yet covered
- `ListLFTagExpressions` — asserts `LFTagExpressions` key in response
- `GetLFTagExpression` — asserts `EntityNotFoundException` for nonexistent expression name
- `DescribeLakeFormationIdentityCenterConfiguration` — asserts `EntityNotFoundException` when not configured
- All tests verified against live server (port 4566) before inclusion

## Test plan
- [x] All 55 lakeformation compat tests pass (`ENDPOINT_URL=http://localhost:4566 uv run pytest tests/compatibility/test_lakeformation_compat.py`)
- [x] Quality gate passed: 0% no-server-contact rate, 81.8% effective test rate
- [x] `ruff` lint clean
- [x] `lint_project.py` structural lint passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)