### PR TITLE
feat(datasync): add compat tests for UpdateAgent and DeleteAgent

### DIFF
--- a/prompts/20260317-022000-datasync-compat.md
+++ b/prompts/20260317-022000-datasync-compat.md
@@ -1,0 +1,39 @@
+---
+session: "a8f2f657"
+timestamp: "2026-03-17T02:20:00Z"
+model: claude-sonnet-4-6
+tools: [worktree-agent]
+sequence: 1
+---
+
+## Human
+
+Expand compat tests for the `datasync` service. The server is running on port 4566.
+
+Goal: add compat tests for untested DataSync operation chunks in `chunks/datasync.json`. Write tests in `tests/compatibility/test_datasync_compat.py`.
+
+Rules: run each test against the live server before keeping it. Never catch ParamValidationError. Every test must assert something.
+
+## Assistant
+
+## Key decisions
+
+**What chunks/datasync.json showed**: All 16 chunks had `working_untested_count: 0` — the probe had classified every untested operation as `not_implemented`. However, `DeleteAgent` and `UpdateAgent` were marked `not_implemented` based on the probe returning `InvalidRequestException` for fake ARNs, which the probe script misclassified as "not implemented."
+
+**Root cause of probe misclassification**: `DeleteAgent` and `UpdateAgent` return `InvalidRequestException` when given a nonexistent agent ARN. The probe script treats any non-200 response to a param-less call as "not_implemented," but these operations ARE implemented — they just require a real resource to operate on.
+
+**Verification approach**: Manually tested all untested operations against the live server:
+- `UpdateAgent` + `DeleteAgent`: work correctly with real agent ARNs
+- All `UpdateLocation*` ops (S3, SMB, NFS, EFS, HDFS, FSx variants, AzureBlob, ObjectStorage): return `NotImplemented` 501
+- `UpdateTaskExecution`, `ListTaskExecutions`, `ListTagsForResource`, `TagResource`, `UntagResource`: return `NotImplemented` 501
+
+**Tests added** (5 new tests in `TestDataSyncAgentUpdateDeleteOperations`):
+1. `test_update_agent` — creates agent, calls UpdateAgent, verifies name changed via DescribeAgent
+2. `test_delete_agent` — creates agent, deletes it, verifies DescribeAgent raises InvalidRequestException
+3. `test_delete_agent_removes_from_list` — verifies deleted agent no longer appears in ListAgents
+4. `test_update_agent_nonexistent` — fake ARN → InvalidRequestException
+5. `test_delete_agent_nonexistent` — fake ARN → InvalidRequestException
+
+**Quality gate**: 96.4% effective test rate, 0% no-server-contact rate. The 2 "weak assertion" tests were pre-existing (key-presence checks on describe results, which is acceptable since the create/describe pattern already validates the operation works).
+
+**What was skipped**: All Update* location operations and `ListTaskExecutions`/`ListTagsForResource`/tag operations — these genuinely return 501 from Moto and would need Moto fixes or native provider implementations before tests can be written.

--- a/tests/compatibility/test_datasync_compat.py
+++ b/tests/compatibility/test_datasync_compat.py
@@ -316,6 +316,68 @@ class TestDataSyncAgentOperations:
         assert "Status" in desc
 
 
+class TestDataSyncAgentUpdateDeleteOperations:
+    """Tests for DataSync Agent UpdateAgent and DeleteAgent operations."""
+
+    def test_update_agent(self, datasync):
+        """UpdateAgent changes the agent's name."""
+        create_resp = datasync.create_agent(
+            ActivationKey="AAAAA-BBBBB-CCCCC-DDDDD-UUUUU",
+            AgentName=_unique("upd-agent"),
+        )
+        agent_arn = create_resp["AgentArn"]
+
+        datasync.update_agent(AgentArn=agent_arn, Name="updated-agent-name")
+
+        desc = datasync.describe_agent(AgentArn=agent_arn)
+        assert desc["Name"] == "updated-agent-name"
+
+    def test_delete_agent(self, datasync):
+        """DeleteAgent removes the agent; DescribeAgent raises InvalidRequestException."""
+        create_resp = datasync.create_agent(
+            ActivationKey="AAAAA-BBBBB-CCCCC-DDDDD-VVVVV",
+            AgentName=_unique("del-agent"),
+        )
+        agent_arn = create_resp["AgentArn"]
+
+        datasync.delete_agent(AgentArn=agent_arn)
+
+        with pytest.raises(ClientError) as exc:
+            datasync.describe_agent(AgentArn=agent_arn)
+        assert exc.value.response["Error"]["Code"] == "InvalidRequestException"
+
+    def test_delete_agent_removes_from_list(self, datasync):
+        """DeleteAgent causes the agent to no longer appear in ListAgents."""
+        create_resp = datasync.create_agent(
+            ActivationKey="AAAAA-BBBBB-CCCCC-DDDDD-WWWWW",
+            AgentName=_unique("dellist-agent"),
+        )
+        agent_arn = create_resp["AgentArn"]
+
+        datasync.delete_agent(AgentArn=agent_arn)
+
+        list_resp = datasync.list_agents()
+        arns = [a["AgentArn"] for a in list_resp["Agents"]]
+        assert agent_arn not in arns
+
+    def test_update_agent_nonexistent(self, datasync):
+        """UpdateAgent for nonexistent agent raises InvalidRequestException."""
+        with pytest.raises(ClientError) as exc:
+            datasync.update_agent(
+                AgentArn="arn:aws:datasync:us-east-1:123456789012:agent/agent-00000000000000000",
+                Name="new-name",
+            )
+        assert exc.value.response["Error"]["Code"] == "InvalidRequestException"
+
+    def test_delete_agent_nonexistent(self, datasync):
+        """DeleteAgent for nonexistent agent raises InvalidRequestException."""
+        with pytest.raises(ClientError) as exc:
+            datasync.delete_agent(
+                AgentArn="arn:aws:datasync:us-east-1:123456789012:agent/agent-00000000000000000"
+            )
+        assert exc.value.response["Error"]["Code"] == "InvalidRequestException"
+
+
 class TestDataSyncLocationAzureBlobOperations:
     """Tests for DataSync Azure Blob location operations."""
 


### PR DESCRIPTION
## Summary

- Adds 5 new compat tests for DataSync `UpdateAgent` and `DeleteAgent` operations
- These operations were incorrectly classified as `not_implemented` by the probe script (they return `InvalidRequestException` for fake ARNs, which the probe misread as "not implemented")
- All other untested DataSync operations (`UpdateLocation*`, `UpdateTaskExecution`, `ListTaskExecutions`, `ListTagsForResource`, `TagResource`, `UntagResource`) are genuinely not implemented in Moto and are skipped

## Test plan

- [x] All 56 datasync compat tests pass against live server on port 4566
- [x] `validate_test_quality.py` reports 96.4% effective test rate, 0% no-server-contact
- [x] Prompt log included in same commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)