### PR TITLE
feat(compat): add databrew schedule and project compat tests

### DIFF
--- a/prompts/20260318-022700-databrew-compat.md
+++ b/prompts/20260318-022700-databrew-compat.md
@@ -1,0 +1,28 @@
+---
+session: "ab741bdf"
+timestamp: "2026-03-18T02:27:00Z"
+model: claude-sonnet-4-6
+tools: [probe_service, live-server-validation]
+---
+
+## Human
+
+Expand compat tests for the `databrew` service. Read chunks/databrew.json, probe working operations, write tests, validate quality, commit.
+
+## Assistant
+
+## Key decisions
+
+**Chunks analysis**: All 11 chunks in databrew.json showed either `not_implemented` or `needs_params` probe status. Needed to verify against the live server rather than trusting stale probe data.
+
+**Live probing results**:
+- JobRun operations (DescribeJobRun, StartJobRun, StopJobRun, ListJobRuns): 501 NotImplemented — skipped
+- Project operations (CreateProject, ListProjects, DescribeProject, UpdateProject, DeleteProject): working — CreateProject requires DatasetName param
+- Schedule operations (CreateSchedule, ListSchedules, DescribeSchedule, UpdateSchedule, DeleteSchedule): all working
+- Tag operations (TagResource, UntagResource, ListTagsForResource): 501 NotImplemented — skipped
+- BatchDeleteRecipeVersion: 501 NotImplemented — skipped
+- StartProjectSession, SendProjectSessionAction: 501 NotImplemented — skipped
+
+**Test strategy**: Created `created_schedule` and `created_project` fixtures. Projects require both a dataset and a recipe (discovered CreateProject needs DatasetName). Used existing `created_dataset` and `created_recipe` fixtures for project tests.
+
+**Result**: 14 new tests added (6 schedule + 8 project), all 53 tests pass, 0% no-contact rate, 96.2% effective rate.

--- a/tests/compatibility/test_databrew_compat.py
+++ b/tests/compatibility/test_databrew_compat.py
@@ -452,6 +452,146 @@ class TestDataBrewNotFound:
             databrew_client.publish_recipe(Name="nonexistent-recipe")
 
 
+@pytest.fixture
+def created_schedule(databrew_client):
+    """Create a schedule and clean up after the test."""
+    name = f"sched-{uuid.uuid4().hex[:8]}"
+    databrew_client.create_schedule(
+        Name=name,
+        CronExpression="cron(0 * * * ? *)",
+        JobNames=["placeholder-job"],
+    )
+    yield name
+    try:
+        databrew_client.delete_schedule(Name=name)
+    except Exception:
+        pass  # best-effort cleanup
+
+
+@pytest.fixture
+def created_project(databrew_client, created_dataset, created_recipe):
+    """Create a project and clean up after the test."""
+    name = f"proj-{uuid.uuid4().hex[:8]}"
+    databrew_client.create_project(
+        Name=name,
+        RecipeName=created_recipe,
+        DatasetName=created_dataset,
+        RoleArn="arn:aws:iam::123456789012:role/test-role",
+        Sample={"Type": "FIRST_N", "Size": 500},
+    )
+    yield name
+    try:
+        databrew_client.delete_project(Name=name)
+    except Exception:
+        pass  # best-effort cleanup
+
+
+class TestDataBrewSchedules:
+    def test_create_schedule(self, databrew_client):
+        name = f"sched-{uuid.uuid4().hex[:8]}"
+        resp = databrew_client.create_schedule(
+            Name=name,
+            CronExpression="cron(0 * * * ? *)",
+            JobNames=["placeholder-job"],
+        )
+        assert resp["Name"] == name
+        databrew_client.delete_schedule(Name=name)
+
+    def test_list_schedules(self, databrew_client):
+        resp = databrew_client.list_schedules()
+        assert "Schedules" in resp
+        assert isinstance(resp["Schedules"], list)
+
+    def test_describe_schedule(self, databrew_client, created_schedule):
+        resp = databrew_client.describe_schedule(Name=created_schedule)
+        assert resp["Name"] == created_schedule
+        assert "CronExpression" in resp
+
+    def test_update_schedule(self, databrew_client, created_schedule):
+        resp = databrew_client.update_schedule(
+            Name=created_schedule,
+            CronExpression="cron(0 1 * * ? *)",
+            JobNames=["updated-job"],
+        )
+        assert resp["Name"] == created_schedule
+
+    def test_delete_schedule(self, databrew_client):
+        name = f"sched-{uuid.uuid4().hex[:8]}"
+        databrew_client.create_schedule(
+            Name=name,
+            CronExpression="cron(0 * * * ? *)",
+            JobNames=["placeholder-job"],
+        )
+        resp = databrew_client.delete_schedule(Name=name)
+        assert resp["Name"] == name
+        with pytest.raises(Exception):
+            databrew_client.describe_schedule(Name=name)
+
+    def test_created_schedule_appears_in_list(self, databrew_client, created_schedule):
+        resp = databrew_client.list_schedules()
+        names = [s["Name"] for s in resp["Schedules"]]
+        assert created_schedule in names
+
+
+class TestDataBrewProjects:
+    def test_create_project(self, databrew_client, created_dataset, created_recipe):
+        name = f"proj-{uuid.uuid4().hex[:8]}"
+        resp = databrew_client.create_project(
+            Name=name,
+            RecipeName=created_recipe,
+            DatasetName=created_dataset,
+            RoleArn="arn:aws:iam::123456789012:role/test-role",
+            Sample={"Type": "FIRST_N", "Size": 500},
+        )
+        assert resp["Name"] == name
+        databrew_client.delete_project(Name=name)
+
+    def test_list_projects(self, databrew_client):
+        resp = databrew_client.list_projects()
+        assert "Projects" in resp
+        assert isinstance(resp["Projects"], list)
+
+    def test_describe_project(self, databrew_client, created_project):
+        resp = databrew_client.describe_project(Name=created_project)
+        assert resp["Name"] == created_project
+        assert "RoleArn" in resp
+
+    def test_update_project(self, databrew_client, created_project):
+        resp = databrew_client.update_project(
+            Name=created_project,
+            RoleArn="arn:aws:iam::123456789012:role/updated-role",
+            Sample={"Type": "FIRST_N", "Size": 100},
+        )
+        assert resp["Name"] == created_project
+
+    def test_delete_project(self, databrew_client, created_dataset, created_recipe):
+        name = f"proj-{uuid.uuid4().hex[:8]}"
+        databrew_client.create_project(
+            Name=name,
+            RecipeName=created_recipe,
+            DatasetName=created_dataset,
+            RoleArn="arn:aws:iam::123456789012:role/test-role",
+            Sample={"Type": "FIRST_N", "Size": 500},
+        )
+        resp = databrew_client.delete_project(Name=name)
+        assert resp["Name"] == name
+        with pytest.raises(Exception):
+            databrew_client.describe_project(Name=name)
+
+    def test_created_project_appears_in_list(self, databrew_client, created_project):
+        resp = databrew_client.list_projects()
+        names = [p["Name"] for p in resp["Projects"]]
+        assert created_project in names
+
+    def test_describe_project_not_found(self, databrew_client):
+        with pytest.raises(databrew_client.exceptions.ResourceNotFoundException):
+            databrew_client.describe_project(Name="nonexistent-project")
+
+    def test_delete_project_not_found(self, databrew_client):
+        with pytest.raises(databrew_client.exceptions.ResourceNotFoundException):
+            databrew_client.delete_project(Name="nonexistent-project")
+
+
 class TestDatabrewAutoCoverage:
     """Auto-generated coverage tests for databrew."""
 


### PR DESCRIPTION
## Summary

- Add 14 new compat tests for DataBrew Schedules (CreateSchedule, ListSchedules, DescribeSchedule, UpdateSchedule, DeleteSchedule, list-presence)
- Add 8 new compat tests for DataBrew Projects (CreateProject, ListProjects, DescribeProject, UpdateProject, DeleteProject, list-presence, not-found errors)
- All tests verified against live server on port 4566
- 53 total databrew tests, 0% no-contact rate, 96.2% effective rate
- Skipped unimplemented operations: JobRun, TagResource/UntagResource/ListTagsForResource, BatchDeleteRecipeVersion, StartProjectSession, SendProjectSessionAction

## Test plan

- [x] All 53 databrew compat tests pass
- [x] `validate_test_quality.py` reports 0% no-contact rate
- [x] New tests verified against live server before inclusion

🤖 Generated with [Claude Code](https://claude.com/claude-code)