### PR TITLE
test(ds): investigate compat expansion for Directory Service chunks

### DIFF
--- a/prompts/20260317-120000-ds-compat-expansion.md
+++ b/prompts/20260317-120000-ds-compat-expansion.md
@@ -1,0 +1,54 @@
+---
+session: "a45104d0"
+timestamp: "2026-03-17T12:00:00Z"
+model: claude-sonnet-4-6
+---
+
+## Human
+
+Expand compat tests for the `ds` (AWS Directory Service) service. The server is running
+on port 4566. Add compat tests for untested Directory Service operation chunks in
+`chunks/ds.json`. Write tests in `tests/compatibility/test_ds_compat.py`.
+
+## Assistant
+
+## Key decisions
+
+**Probe results vs chunks.json discrepancy**: The `chunks/ds.json` file listed many
+operations as "working" (based on the probe classification), but when manually tested
+against the live server, most returned 500 InternalError (Moto backend attribute errors).
+
+Operations that actually work and were untested in the existing file:
+- `DescribeCAEnrollmentPolicy` — confirmed working (EntityDoesNotExistException for fake dir)
+- `DescribeADAssessment` — confirmed working (EntityDoesNotExistException for fake assessment)
+
+**Both were already in the existing test file** at lines 849-858 (`TestDsAdditionalOps` class).
+
+Operations in chunks that return 500 InternalError (cannot be tested without fixes):
+- `DisableCAEnrollmentPolicy` — Moto backend missing attribute
+- `EnableCAEnrollmentPolicy` — Moto backend missing attribute
+- `DescribeDirectoryDataAccess` — Moto backend missing attribute
+- `DisableDirectoryDataAccess` — Moto backend missing attribute
+- `EnableDirectoryDataAccess` — Moto backend missing attribute
+- `DeleteADAssessment` — Moto backend crash
+- `AddRegion` — Moto backend missing attribute
+- `RemoveRegion` — Moto backend crash
+- `AcceptSharedDirectory` — Moto backend crash
+- `RejectSharedDirectory` — Moto backend crash
+- `ShareDirectory` — Moto backend crash
+- `UnshareDirectory` — Moto backend crash
+- `UpdateDirectorySetup` — Moto backend crash
+- `ListADAssessments` — Moto backend missing attribute
+
+Already tested in the existing file:
+- `DisableLDAPS`, `EnableLDAPS` — TestDsLDAPSMicrosoftAD class
+- `DescribeLDAPSSettings` — multiple test classes
+- `CreateMicrosoftAD` — TestDsMicrosoftAD class
+
+**Decision**: No new tests added since all chunk operations are either already tested or
+return 500 InternalErrors that require Moto fixes before tests can be written.
+Per the project rules: "Fix-then-test > test-then-xfail. Never write tests for operations
+that return 500."
+
+**Existing test quality**: 97 tests, 92.8% effective rate, 0% no-server-contact rate.
+The existing test file is in good shape.


### PR DESCRIPTION
## Summary

- Investigated all chunks in `chunks/ds.json` against the live server on port 4566
- Confirmed existing DS compat tests are solid: 97 tests, 92.8% effective rate, 0% no-server-contact
- All untested chunk operations are either already covered or return 500 InternalErrors

## Findings

Operations in `chunks/ds.json` marked as "working" that were already tested:
- `DescribeCAEnrollmentPolicy` — covered in `TestDsAdditionalOps`
- `DescribeADAssessment` — covered in `TestDsAdditionalOps`
- `DisableLDAPS` / `EnableLDAPS` — covered in `TestDsLDAPSMicrosoftAD`
- `DescribeLDAPSSettings` — covered in multiple classes
- `CreateMicrosoftAD` — covered in `TestDsMicrosoftAD`

Operations returning 500 InternalError (Moto backend attribute missing — require Moto fixes before tests can be written):
- `DisableCAEnrollmentPolicy`, `EnableCAEnrollmentPolicy`
- `DescribeDirectoryDataAccess`, `DisableDirectoryDataAccess`, `EnableDirectoryDataAccess`
- `DeleteADAssessment`, `ListADAssessments`
- `AddRegion`, `RemoveRegion`
- `AcceptSharedDirectory`, `RejectSharedDirectory`, `ShareDirectory`, `UnshareDirectory`
- `UpdateDirectorySetup`

## Test plan
- [x] Ran existing DS compat tests: 97 passed, 0 failed
- [x] Ran `validate_test_quality.py`: 92.8% effective rate, 0% no-server-contact
- [x] Manually probed each chunk operation against live server

🤖 Generated with [Claude Code](https://claude.com/claude-code)