### PR TITLE
feat(compat): cloudtrail DeleteResourcePolicy, ListDashboards, GetImport tests

### DIFF
--- a/prompts/20260317-120000-cloudtrail-compat.md
+++ b/prompts/20260317-120000-cloudtrail-compat.md
@@ -1,0 +1,27 @@
+---
+session: "ae4d71e3"
+timestamp: "2026-03-17T12:00:00Z"
+model: claude-sonnet-4-6
+tools: [probe_service, validate_test_quality]
+---
+
+## Human
+
+Expand compat tests for the `cloudtrail` service using chunks/cloudtrail.json. Server is running on port 4566. Write tests in tests/compatibility/test_cloudtrail_compat.py. Run each test against the live server before keeping it — delete any that return 501 or NotImplementedError.
+
+## Assistant
+
+## Key decisions
+
+**Probed before writing**: Ran `probe_service.py --service cloudtrail` to get fresh probe data. The chunks file had stale probe results — it showed `ListDashboards` as `not_implemented` but the live server returns `{'Dashboards': [], 'ResponseMetadata': {...}}`. Always trust the live probe over cached chunks.
+
+**Operations excluded (not implemented)**: `LookupEvents`, `ListPublicKeys`, `ListInsightsMetricData`, `SearchSampleQueries`, `GenerateQuery`, `ListImportFailures`, `StartDashboardRefresh`, `PutEventConfiguration`, `StartEventDataStoreIngestion`, `StopEventDataStoreIngestion` — all return 501. No tests written for these.
+
+**Operations added**:
+1. `DeleteResourcePolicy` — tested end-to-end (put policy → delete → verify gone via get), plus nonexistent-ARN error case
+2. `ListDashboards` — two tests: empty list structure check and response structure check
+3. `GetImport` with nonexistent UUID — asserts `ImportNotFoundException` (needs proper UUID v4 format — boto3 validates min length 36)
+
+**Why GetImport uses a fake UUID**: boto3 client validates `ImportId` must be at least 36 chars (UUID format). Using `str(uuid.uuid4())` satisfies client-side validation and triggers server-side `ImportNotFoundException` — proving the implementation is live.
+
+**Test quality**: 97.8% effective rate (88/90 server-contacting tests). The 2 "weak" flags are `ListDashboards` tests with key-presence checks, which are appropriate for list operations that return empty collections.

--- a/tests/compatibility/test_cloudtrail_compat.py
+++ b/tests/compatibility/test_cloudtrail_compat.py
@@ -1207,3 +1207,71 @@ class TestCloudTrailResourcePolicy:
         finally:
             cloudtrail.delete_trail(Name=trail)
             s3.delete_bucket(Bucket=bucket)
+
+    def test_delete_resource_policy(self, cloudtrail, s3):
+        """DeleteResourcePolicy removes the resource policy for a trail ARN."""
+        import json
+
+        bucket = _unique("ct-drp-bucket")
+        trail = _unique("ct-drp-trail")
+        s3.create_bucket(Bucket=bucket)
+        try:
+            trail_resp = cloudtrail.create_trail(Name=trail, S3BucketName=bucket)
+            trail_arn = trail_resp["TrailARN"]
+            policy = json.dumps(
+                {
+                    "Version": "2012-10-17",
+                    "Statement": [
+                        {
+                            "Sid": "test-policy",
+                            "Effect": "Allow",
+                            "Principal": {"Service": "cloudtrail.amazonaws.com"},
+                            "Action": "cloudtrail:CreateTrail",
+                            "Resource": trail_arn,
+                        }
+                    ],
+                }
+            )
+            cloudtrail.put_resource_policy(ResourceArn=trail_arn, ResourcePolicy=policy)
+            del_resp = cloudtrail.delete_resource_policy(ResourceArn=trail_arn)
+            assert del_resp["ResponseMetadata"]["HTTPStatusCode"] == 200
+            with pytest.raises(ClientError) as exc_info:
+                cloudtrail.get_resource_policy(ResourceArn=trail_arn)
+            assert exc_info.value.response["Error"]["Code"] == "ResourceNotFoundException"
+        finally:
+            cloudtrail.delete_trail(Name=trail)
+            s3.delete_bucket(Bucket=bucket)
+
+    def test_delete_resource_policy_nonexistent(self, cloudtrail):
+        """DeleteResourcePolicy for a nonexistent resource raises ResourceNotFoundException."""
+        fake_arn = "arn:aws:cloudtrail:us-east-1:123456789012:trail/nonexistent-trail"
+        with pytest.raises(ClientError) as exc_info:
+            cloudtrail.delete_resource_policy(ResourceArn=fake_arn)
+        assert exc_info.value.response["Error"]["Code"] == "ResourceNotFoundException"
+
+
+class TestCloudTrailDashboardList:
+    """Tests for ListDashboards operation."""
+
+    def test_list_dashboards_empty(self, cloudtrail):
+        """ListDashboards returns a Dashboards list (may be empty)."""
+        resp = cloudtrail.list_dashboards()
+        assert "Dashboards" in resp
+        assert isinstance(resp["Dashboards"], list)
+
+    def test_list_dashboards_response_structure(self, cloudtrail):
+        """ListDashboards response contains expected keys."""
+        resp = cloudtrail.list_dashboards()
+        assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200
+        assert "Dashboards" in resp
+
+
+class TestCloudTrailImportGet:
+    """Tests for GetImport operation with nonexistent import ID."""
+
+    def test_get_import_nonexistent(self, cloudtrail):
+        """GetImport for a nonexistent import ID raises ImportNotFoundException."""
+        fake_import_id = str(uuid.uuid4())
+        with pytest.raises(ClientError) as exc_info:
+            cloudtrail.get_import(ImportId=fake_import_id)
+        assert exc_info.value.response["Error"]["Code"] == "ImportNotFoundException"


### PR DESCRIPTION
## Summary

- Adds 5 new compat tests for CloudTrail operations verified against live server (port 4566)
- `DeleteResourcePolicy`: end-to-end (put → delete → verify gone) + nonexistent ARN error case
- `ListDashboards`: response structure check and empty list assertion
- `GetImport`: nonexistent import ID raises `ImportNotFoundException`
- Skipped 501 not-implemented operations: `LookupEvents`, `ListPublicKeys`, `ListInsightsMetricData`, `SearchSampleQueries`, `GenerateQuery`, `ListImportFailures`

## Test plan

- [x] All 90 tests pass: `ENDPOINT_URL=http://localhost:4566 uv run pytest tests/compatibility/test_cloudtrail_compat.py -q`
- [x] Quality gate passes: 97.8% effective rate (88/90 server-contacting tests)
- [x] `uv run python scripts/validate_test_quality.py --file tests/compatibility/test_cloudtrail_compat.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)