### PR TITLE
feat: add /review-pr skill and improve prompt log spec

### DIFF
--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -1,0 +1,151 @@
+# Skill: Review a Pull Request
+
+Review, improve, and merge an open pull request. The submitter did the work — your job is to get their PR merged cleanly, giving them full credit.
+
+**Argument**: PR number or URL (e.g., `/review-pr 191` or `/review-pr https://github.com/robotocore/robotocore/pull/191`)
+
+## Philosophy
+
+The submitter's PR is **their contribution**. Prioritize merging it in the shape they submitted it. Fix only what blocks CI or violates project rules. If you want to make further improvements, do that in a follow-up PR *after* theirs is merged. Never rewrite their approach — if the approach itself is wrong, request changes and explain why.
+
+## Process
+
+### 1. Gather context
+
+```bash
+gh pr view $PR --json title,body,state,author,headRefName,baseRefName,mergeable,mergeStateStatus,commits,comments,reviews
+gh pr diff $PR
+gh pr checks $PR
+```
+
+Capture: author login, branch names, current CI status, whether it's from a fork.
+
+### 2. Welcome first-time contributors
+
+Check if this is the author's first PR to this repo:
+
+```bash
+gh pr list --author $AUTHOR --state merged --limit 1 --json number
+```
+
+If empty (no prior merged PRs), leave a warm welcome comment:
+
+> Welcome to robotocore, @{author}! Thanks for your first contribution — we're glad to have you here. Let me take a look at this.
+
+For returning contributors, a simple "Thanks for this, @{author}" is enough.
+
+### 3. Check for prompt log (gate — exit early if missing)
+
+The PR **must** include a `prompts/*.md` file if it touches `src/`, `tests/`, or `scripts/`. Check:
+
+```bash
+gh pr diff $PR --name-only | grep -E '^(src/|tests/|scripts/)'
+gh pr diff $PR --name-only | grep '^prompts/'
+```
+
+If source files changed but no prompt log exists:
+- Leave a review requesting changes with this message:
+
+> This PR changes source/test files but doesn't include a prompt log entry. We track AI and human decision provenance in `prompts/` — see [prompts/PROMPTLOG.md](prompts/PROMPTLOG.md) for the format.
+>
+> Please add a file at `prompts/{YYYYMMDD-HHMMSS}-{slug}.md` documenting the human prompt and key decisions behind this change. If this was written entirely by a human without AI assistance, a brief entry noting that is fine too — the log is about provenance, not policing tools.
+
+- **Do not approve.** Stop here. The contributor needs to push the prompt log.
+
+**Exception**: If the PR only touches docs, CI config, or non-code files, the prompt log is not required.
+
+### 4. Critical code review
+
+Review the diff from **all of these angles**, picking fresh specific concerns each time (don't repeat the same generic checklist):
+
+**Correctness & AWS fidelity**
+- Does the implementation match real AWS behavior? Check botocore's service-2.json for the operation shape.
+- Are response fields, error codes, and status codes correct?
+- For native providers: does it handle both the happy path and error cases?
+
+**Security**
+- No hardcoded secrets, no command injection, no unsanitized XML/HTML.
+- Exception handlers don't swallow errors silently (project rule: never `except: pass`).
+- Inputs that end up in XML responses use `xml_escape()`.
+
+**Test quality**
+- Every test MUST contact the server (no tests that only catch `ParamValidationError`).
+- Every test MUST assert something meaningful about the response.
+- Tests clean up resources they create (use `try/finally`).
+- No speculative xfails — if it doesn't work, don't test it.
+
+**Wire format & protocol**
+- For native providers: does the XML/JSON response match botocore's expected shape?
+- Are operation names PascalCase matching the AWS API?
+- Multi-value query params use the `.member.N` convention where AWS does.
+
+**Project conventions**
+- `ruff` clean (line-length 100, rules E/F/I/N/W/UP).
+- No `except ...: pass` without logging or comment.
+- Imports: stdlib → third-party → local, blank-line separated.
+- Test files mirror source structure.
+
+**Integration risk**
+- Could this break existing tests? (Check for shared state, hardcoded resource names that collide.)
+- Does it register new routes that might shadow existing ones?
+- If it modifies Moto vendor code, is the fix on a feature branch and pushed to the fork?
+
+Leave inline review comments on specific lines for anything notable — both praise ("nice catch on the audience validation") and issues. Be specific and constructive, never dismissive.
+
+### 5. Fix what blocks the merge
+
+If CI fails or there are small issues (lint, bare except blocks, missing import), **fix them yourself** by pushing commits to the PR branch:
+
+```bash
+# For PRs from the same repo:
+git fetch origin $BRANCH && git checkout $BRANCH
+
+# For PRs from forks (check maintainerCanModify first):
+gh pr view $PR --json maintainerCanModify,headRepositoryOwner,headRepository
+git remote add $FORK_OWNER https://github.com/$FORK_OWNER/$REPO.git
+git fetch $FORK_OWNER $BRANCH
+git checkout -b pr-$PR FETCH_HEAD
+# ... make fixes ...
+git push $FORK_OWNER HEAD:$BRANCH
+```
+
+**Rules for fixup commits:**
+- Only fix what blocks CI or violates hard project rules.
+- Keep fixes minimal — don't refactor their code.
+- Use clear commit messages: `fix(lint): add logging to bare except block in PR #$PR`
+- Always attribute: `Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>`
+
+If the PR needs a prompt log and was submitted by someone who may not know the format, **you may add one for them** — capture their intent from the PR description.
+
+### 6. Approve and auto-merge
+
+Once CI is green and the review is clean:
+
+```bash
+gh pr review $PR --approve --body "Looks good! $SUMMARY. Thanks @$AUTHOR."
+gh pr merge $PR --merge --auto
+```
+
+If CI needs workflow approval (fork PRs):
+```bash
+# Find and approve pending workflow runs
+gh api repos/OWNER/REPO/actions/runs --jq '.workflow_runs[] | select(.head_sha == "$SHA") | select(.status != "completed") | .id' | while read id; do
+  gh api repos/OWNER/REPO/actions/runs/$id/approve -X POST
+done
+```
+
+Wait for CI with `gh pr checks $PR --watch`, then verify the merge landed.
+
+### 7. Post-merge
+
+After the PR merges, if you identified improvements that go beyond the submitter's scope, you may open a **separate follow-up PR** with those changes. Credit the original author in the description:
+
+> Follow-up to #$PR by @$AUTHOR. Their implementation of X was solid — this PR adds Y on top of it.
+
+## What NOT to do
+
+- **Don't rewrite their implementation.** If the approach is fundamentally wrong, request changes and explain. Don't silently replace their code.
+- **Don't add features they didn't ask for.** Scope creep in review is disrespectful to the contributor.
+- **Don't cherry-pick to another branch.** Merge the PR directly so the author gets credit in git history.
+- **Don't block on style nitpicks.** If the code works and CI passes, style preferences are suggestions, not blockers.
+- **Don't forget to say thank you.** Every contribution matters.

--- a/.claude/skills/promptlog.md
+++ b/.claude/skills/promptlog.md
@@ -59,6 +59,7 @@ a changelog — git diff shows what changed.>
 - DO explain WHY — architectural choices, rejected alternatives, tradeoffs
 - Keep `reconstructed: true` in frontmatter if writing retroactively
 - Never rewrite or shorten existing prompt files — they are permanent record
+- For external contributor PRs: use `author` and `pr` frontmatter fields to give credit. Write the log on their behalf rather than blocking the PR.
 
 ## Example
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -292,3 +292,15 @@ The overnight script (`scripts/overnight.sh`) uses a tight feedback loop:
 - If stuck on params for >2 minutes, skip the operation
 - If an operation returns 501, DELETE the test and move on
 - The goal is reliable coverage, not speed
+
+### Reviewing pull requests
+
+Use `/review-pr <number>` to review and merge external PRs. Key principles:
+
+- **The submitter's PR is their contribution.** Merge it in their shape. Fix only what blocks CI. Save improvements for a follow-up PR.
+- **Never cherry-pick to another branch.** Merge the PR directly so the author gets git credit.
+- **Welcome first-time contributors** with a warm comment.
+- **Gate on prompt log.** If the PR touches `src/`, `tests/`, or `scripts/` but has no `prompts/` entry, request changes — don't approve.
+- **Fix CI blockers yourself** by pushing fixup commits to the PR branch (bare except blocks, missing imports, lint).
+- **Approve and auto-merge** once CI is green: `gh pr review --approve` + `gh pr merge --merge --auto`.
+- **Give credit.** Every approval comment thanks the author by name

--- a/prompts/20260319-053000-pr-review-skill.md
+++ b/prompts/20260319-053000-pr-review-skill.md
@@ -1,0 +1,45 @@
+---
+session: "pr-review-skill"
+timestamp: "2026-03-19T05:30:00Z"
+model: claude-opus-4-6
+---
+
+## Human
+
+Write a PR review skill that warmly welcomes first-time contributors, exits
+early without approval if no prompts/ file, critically reviews from multiple
+angles, adds fixup commits, approves when good, and sets to automerge. The
+submitter deserves credit — prioritize merging their PR in the shape they
+submitted it. Improvements go in follow-up PRs.
+
+Also holistically improve skills and take a fresh look at PROMPTLOG.md.
+
+## Assistant
+
+## Key decisions
+
+**Slash command, not a skill file**: Created `.claude/commands/review-pr.md`
+rather than `.claude/skills/review-pr.md`. Commands are user-invocable via
+`/review-pr 191`, while skills are reference docs. The review workflow needs
+to be triggered explicitly per-PR.
+
+**Credit-first philosophy**: The skill's core principle is that the PR belongs
+to the submitter. Fixup commits only address CI blockers (bare except blocks,
+missing imports, lint). Anything beyond that goes in a follow-up PR after
+theirs merges. This prevents the "helpful reviewer" antipattern of rewriting
+someone's contribution.
+
+**Prompt log as gate, not blocker**: If the contributor didn't include a
+prompt log, the reviewer requests changes but can also write one on their
+behalf using the new `author` and `pr` frontmatter fields. This keeps the
+provenance requirement without punishing contributors unfamiliar with the
+convention.
+
+**PROMPTLOG.md improvements**: Added `author` and `pr` optional frontmatter
+fields, plus an "External contributor PRs" section with a concrete example.
+The spec now explicitly supports the workflow of writing prompt logs on
+behalf of others.
+
+**CLAUDE.md addition**: Added a "Reviewing pull requests" subsection under
+"Working with Agents" that summarizes the key principles without duplicating
+the full skill. Points to `/review-pr` for the detailed workflow.

--- a/prompts/PROMPTLOG.md
+++ b/prompts/PROMPTLOG.md
@@ -51,6 +51,8 @@ That file would be named `prompts/20260307-143208-fix-nil-pointer-auth.md`.
 
 **Optional:**
 - `model` — the model that generated the assistant reasoning (e.g. `model: claude-opus-4-6`)
+- `author` — GitHub username of the original contributor, when someone else writes the prompt log on their behalf (e.g. during PR review). Gives credit where it's due.
+- `pr` — PR number this prompt log accompanies (e.g. `pr: 191`). Makes it easy to cross-reference.
 - `tools` — list of tools/agents used (e.g. `tools: [subagent, git-worktree]`), helps reviewers understand how work was parallelized
 - `sequence` — integer ordering files within a session (1, 2, 3...) when a session spans multiple files
 - `reconstructed` — set to `true` when logging retroactively from session transcripts
@@ -108,6 +110,37 @@ and unblocking the main path mattered more right now.
 ```
 
 That belongs in a commit message. The prompt log is for the reasoning behind those changes.
+
+## External contributor PRs
+
+When reviewing a PR from an external contributor who didn't include a prompt log, the reviewer (human or AI) should write one on their behalf. Use the `author` and `pr` frontmatter fields:
+
+```
+---
+session: "pr-191-review"
+timestamp: "2026-03-18T23:00:00Z"
+model: claude-opus-4-6
+author: "launchdavewilliams"
+pr: 191
+---
+
+## Human
+
+(From PR #191 by @launchdavewilliams)
+
+Implement native GetWebIdentityToken for STS. Moto's response handler
+calls _get_multi_param which doesn't exist on BaseResponse, causing 500s.
+
+## Assistant
+
+## Key decisions
+
+**Native provider over Moto fix**: The operation needs multi-value
+Audience params via Audience.member.N — easier to handle in our
+native provider than to patch Moto's BaseResponse class.
+```
+
+The goal is provenance, not gatekeeping. If someone contributes great code without a prompt log, write one for them during review rather than blocking the PR. Credit them as the author.
 
 ## Retroactive logging
 


### PR DESCRIPTION
## Summary

- **New `/review-pr` slash command** (`.claude/commands/review-pr.md`) — a complete PR review workflow for Claude Code that welcomes first-time contributors, gates on prompt log presence, critically reviews from multiple angles, pushes fixup commits for CI blockers, approves, and auto-merges
- **PROMPTLOG.md improvements** — new `author` and `pr` optional frontmatter fields, plus an "External contributor PRs" section showing how to write prompt logs on behalf of contributors
- **CLAUDE.md** — new "Reviewing pull requests" subsection under Working with Agents
- **promptlog skill** — updated to reference external contributor workflow

Core principle: the submitter's PR is their contribution. Merge it in their shape. Improvements go in follow-up PRs.

## Test plan
- [ ] `/review-pr` appears in skill list when starting a new Claude Code session in this repo
- [ ] Prompt log CI check still passes (new prompt file included)
- [ ] PROMPTLOG.md renders correctly with new sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)