### PR TITLE
feat(compat): add TieringConfiguration CRUD tests for backup service

### DIFF
--- a/prompts/20260318-192500-backup-tiering-compat.md
+++ b/prompts/20260318-192500-backup-tiering-compat.md
@@ -1,0 +1,47 @@
+---
+session: "a64316d4"
+timestamp: "2026-03-18T19:25:00Z"
+model: claude-sonnet-4-6
+tools: [bash, read, edit, write, glob, grep]
+---
+
+## Human
+
+Expand compat tests for the backup service. Target the untested-but-working operations
+(gap=22). Run chunk_service.py, probe each untested operation, write tests in
+tests/compatibility/test_backup_compat.py.
+
+## Assistant
+
+## Key decisions
+
+**Probing first**: Ran chunk_service.py which showed 24 untested ops across 20 chunks.
+Probed each op against the live server (port 4566) before writing any tests.
+
+**Most ops return 501**: The bulk of "untested" ops (GetBackupPlan, GetLegalHold,
+ListBackupPlanVersions, ListBackupSelections, CreateBackupSelection,
+ExportBackupPlanTemplate, ListRecoveryPointsByBackupVault,
+ListProtectedResourcesByBackupVault, AssociateBackupVaultMpaApprovalTeam,
+CreateRestoreAccessBackupVault, ListRestoreAccessBackupVaults, etc.) all return
+HTTP 501 NotImplemented. Per project rules, no tests written for unimplemented ops.
+
+**Already tested**: Many "untested" ops per the chunk script were already covered by
+existing tests (PutBackupVaultAccessPolicy, DeleteBackupVaultAccessPolicy,
+PutBackupVaultNotifications, DeleteBackupVaultNotifications, UpdateGlobalSettings,
+UpdateRegionSettings, ListBackupPlanTemplates, ListFrameworks, GetBackupPlanFromJSON).
+
+**TieringConfiguration CRUD works**: CreateTieringConfiguration,
+GetTieringConfiguration, UpdateTieringConfiguration, DeleteTieringConfiguration
+all returned valid responses. Added 5 new tests:
+- test_create_tiering_configuration_returns_arn
+- test_create_tiering_configuration_appears_in_list
+- test_get_tiering_configuration_after_create (needed fix: response nests under
+  TieringConfiguration key, not at top level)
+- test_update_tiering_configuration_returns_name
+- test_delete_tiering_configuration_removes_from_list
+
+**Response shape discovery**: GetTieringConfiguration returns
+`{"TieringConfiguration": {...}}` not `{"TieringConfigurationName": ..., ...}` at top
+level. Caught this by running the test first and fixing the assertion.
+
+All 145 tests pass. Quality gate: 0% no-server-contact rate.

--- a/tests/compatibility/test_backup_compat.py
+++ b/tests/compatibility/test_backup_compat.py
@@ -2114,3 +2114,112 @@ class TestBackupTieringConfigurationOperations:
             backup.get_tiering_configuration(TieringConfigurationName="nonexistent-tiering-cfg")
         err = exc_info.value.response["Error"]
         assert err["Code"] in ("ResourceNotFoundException", "NotFoundException")
+
+    def test_create_tiering_configuration_returns_arn(self, backup):
+        """CreateTieringConfiguration returns ARN and name."""
+        vault_name = _unique("vault")
+        tc_name = _unique("tc")
+        backup.create_backup_vault(BackupVaultName=vault_name)
+        try:
+            resp = backup.create_tiering_configuration(
+                TieringConfiguration={
+                    "TieringConfigurationName": tc_name,
+                    "BackupVaultName": vault_name,
+                    "ResourceSelection": [],
+                }
+            )
+            assert resp["TieringConfigurationName"] == tc_name
+            assert "TieringConfigurationArn" in resp
+            assert "CreationTime" in resp
+        finally:
+            backup.delete_tiering_configuration(TieringConfigurationName=tc_name)
+            backup.delete_backup_vault(BackupVaultName=vault_name)
+
+    def test_create_tiering_configuration_appears_in_list(self, backup):
+        """A created TieringConfiguration appears in ListTieringConfigurations."""
+        vault_name = _unique("vault")
+        tc_name = _unique("tc")
+        backup.create_backup_vault(BackupVaultName=vault_name)
+        try:
+            backup.create_tiering_configuration(
+                TieringConfiguration={
+                    "TieringConfigurationName": tc_name,
+                    "BackupVaultName": vault_name,
+                    "ResourceSelection": [],
+                }
+            )
+            resp = backup.list_tiering_configurations()
+            assert "TieringConfigurations" in resp
+            names = [tc["TieringConfigurationName"] for tc in resp["TieringConfigurations"]]
+            assert tc_name in names
+        finally:
+            backup.delete_tiering_configuration(TieringConfigurationName=tc_name)
+            backup.delete_backup_vault(BackupVaultName=vault_name)
+
+    def test_get_tiering_configuration_after_create(self, backup):
+        """GetTieringConfiguration retrieves a created configuration."""
+        vault_name = _unique("vault")
+        tc_name = _unique("tc")
+        backup.create_backup_vault(BackupVaultName=vault_name)
+        try:
+            backup.create_tiering_configuration(
+                TieringConfiguration={
+                    "TieringConfigurationName": tc_name,
+                    "BackupVaultName": vault_name,
+                    "ResourceSelection": [],
+                }
+            )
+            resp = backup.get_tiering_configuration(TieringConfigurationName=tc_name)
+            assert "TieringConfiguration" in resp
+            tc = resp["TieringConfiguration"]
+            assert tc["TieringConfigurationName"] == tc_name
+            assert "TieringConfigurationArn" in tc
+        finally:
+            backup.delete_tiering_configuration(TieringConfigurationName=tc_name)
+            backup.delete_backup_vault(BackupVaultName=vault_name)
+
+    def test_update_tiering_configuration_returns_name(self, backup):
+        """UpdateTieringConfiguration returns updated configuration name and timestamp."""
+        vault_name = _unique("vault")
+        tc_name = _unique("tc")
+        backup.create_backup_vault(BackupVaultName=vault_name)
+        try:
+            backup.create_tiering_configuration(
+                TieringConfiguration={
+                    "TieringConfigurationName": tc_name,
+                    "BackupVaultName": vault_name,
+                    "ResourceSelection": [],
+                }
+            )
+            resp = backup.update_tiering_configuration(
+                TieringConfigurationName=tc_name,
+                TieringConfiguration={
+                    "BackupVaultName": vault_name,
+                    "ResourceSelection": [],
+                },
+            )
+            assert resp["TieringConfigurationName"] == tc_name
+            assert "LastUpdatedTime" in resp
+        finally:
+            backup.delete_tiering_configuration(TieringConfigurationName=tc_name)
+            backup.delete_backup_vault(BackupVaultName=vault_name)
+
+    def test_delete_tiering_configuration_removes_from_list(self, backup):
+        """DeleteTieringConfiguration removes the configuration from list."""
+        vault_name = _unique("vault")
+        tc_name = _unique("tc")
+        backup.create_backup_vault(BackupVaultName=vault_name)
+        try:
+            backup.create_tiering_configuration(
+                TieringConfiguration={
+                    "TieringConfigurationName": tc_name,
+                    "BackupVaultName": vault_name,
+                    "ResourceSelection": [],
+                }
+            )
+            backup.delete_tiering_configuration(TieringConfigurationName=tc_name)
+            resp = backup.list_tiering_configurations()
+            names = [tc["TieringConfigurationName"] for tc in resp["TieringConfigurations"]]
+            assert tc_name not in names
+        finally:
+            backup.delete_backup_vault(BackupVaultName=vault_name)


### PR DESCRIPTION
## Summary

- 5 new compat tests for Backup TieringConfiguration CRUD operations: create, list, get, update, delete
- All tests follow create→use→cleanup pattern with proper `try/finally` resource management
- Prompt log included

Extracted from the `gap-surfacing-system` branch — this was the only unmerged work worth keeping.

## Test plan
- [ ] All 5 new backup tests pass against running server
- [ ] No regressions in existing backup compat tests
- [ ] Quality gate passes (all tests contact server and assert)

🤖 Generated with [Claude Code](https://claude.com/claude-code)