### PR TITLE
feat: add probe/chunk data for 102 services

### DIFF
--- a/chunks/account.json
+++ b/chunks/account.json
@@ -1,0 +1,164 @@
+[
+  {
+    "noun": "AccountInformation",
+    "operations": [
+      "GetAccountInformation"
+    ],
+    "tested": [],
+    "untested": [
+      "GetAccountInformation"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetAccountInformation": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "AccountName",
+    "operations": [
+      "PutAccountName"
+    ],
+    "tested": [],
+    "untested": [
+      "PutAccountName"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "PutAccountName": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ContactInformation",
+    "operations": [
+      "GetContactInformation",
+      "PutContactInformation"
+    ],
+    "tested": [],
+    "untested": [
+      "GetContactInformation",
+      "PutContactInformation"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "GetContactInformation": "not_implemented",
+      "PutContactInformation": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "GovCloudAccountInformation",
+    "operations": [
+      "GetGovCloudAccountInformation"
+    ],
+    "tested": [],
+    "untested": [
+      "GetGovCloudAccountInformation"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetGovCloudAccountInformation": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "PrimaryEmail",
+    "operations": [
+      "GetPrimaryEmail"
+    ],
+    "tested": [],
+    "untested": [
+      "GetPrimaryEmail"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetPrimaryEmail": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "PrimaryEmailUpdate",
+    "operations": [
+      "AcceptPrimaryEmailUpdate",
+      "StartPrimaryEmailUpdate"
+    ],
+    "tested": [],
+    "untested": [
+      "AcceptPrimaryEmailUpdate",
+      "StartPrimaryEmailUpdate"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "AcceptPrimaryEmailUpdate": "not_implemented",
+      "StartPrimaryEmailUpdate": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Region",
+    "operations": [
+      "DisableRegion",
+      "EnableRegion"
+    ],
+    "tested": [],
+    "untested": [
+      "DisableRegion",
+      "EnableRegion"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "DisableRegion": "not_implemented",
+      "EnableRegion": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "RegionOptStatus",
+    "operations": [
+      "GetRegionOptStatus"
+    ],
+    "tested": [],
+    "untested": [
+      "GetRegionOptStatus"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetRegionOptStatus": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Regions",
+    "operations": [
+      "ListRegions"
+    ],
+    "tested": [],
+    "untested": [
+      "ListRegions"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListRegions": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/acm.json
+++ b/chunks/acm.json
@@ -1,0 +1,55 @@
+[
+  {
+    "noun": "Certificate",
+    "operations": [
+      "DeleteCertificate",
+      "DescribeCertificate",
+      "ExportCertificate",
+      "GetCertificate",
+      "ImportCertificate",
+      "RequestCertificate",
+      "RevokeCertificate"
+    ],
+    "tested": [
+      "DeleteCertificate",
+      "DescribeCertificate",
+      "ExportCertificate",
+      "GetCertificate",
+      "ImportCertificate",
+      "RequestCertificate"
+    ],
+    "untested": [
+      "RevokeCertificate"
+    ],
+    "size": 7,
+    "untested_count": 1,
+    "probe_status": {
+      "DeleteCertificate": "working",
+      "DescribeCertificate": "working",
+      "ExportCertificate": "working",
+      "GetCertificate": "working",
+      "ImportCertificate": "working",
+      "RequestCertificate": "working",
+      "RevokeCertificate": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "RenewCertificate",
+    "operations": [
+      "RenewCertificate"
+    ],
+    "tested": [],
+    "untested": [
+      "RenewCertificate"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "RenewCertificate": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/amp.json
+++ b/chunks/amp.json
@@ -1,0 +1,82 @@
+[
+  {
+    "noun": "AnomalyDetector",
+    "operations": [
+      "CreateAnomalyDetector",
+      "DeleteAnomalyDetector",
+      "DescribeAnomalyDetector",
+      "PutAnomalyDetector"
+    ],
+    "tested": [
+      "DeleteAnomalyDetector"
+    ],
+    "untested": [
+      "CreateAnomalyDetector",
+      "DescribeAnomalyDetector",
+      "PutAnomalyDetector"
+    ],
+    "size": 4,
+    "untested_count": 3,
+    "probe_status": {
+      "CreateAnomalyDetector": "needs_params",
+      "DeleteAnomalyDetector": "working",
+      "DescribeAnomalyDetector": "working",
+      "PutAnomalyDetector": "needs_params"
+    },
+    "working_untested": [
+      "DescribeAnomalyDetector"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "QueryLoggingConfiguration",
+    "operations": [
+      "CreateQueryLoggingConfiguration",
+      "DeleteQueryLoggingConfiguration",
+      "DescribeQueryLoggingConfiguration",
+      "UpdateQueryLoggingConfiguration"
+    ],
+    "tested": [
+      "DeleteQueryLoggingConfiguration",
+      "DescribeQueryLoggingConfiguration"
+    ],
+    "untested": [
+      "CreateQueryLoggingConfiguration",
+      "UpdateQueryLoggingConfiguration"
+    ],
+    "size": 4,
+    "untested_count": 2,
+    "probe_status": {
+      "CreateQueryLoggingConfiguration": "needs_params",
+      "DeleteQueryLoggingConfiguration": "working",
+      "DescribeQueryLoggingConfiguration": "working",
+      "UpdateQueryLoggingConfiguration": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ScraperLoggingConfiguration",
+    "operations": [
+      "DeleteScraperLoggingConfiguration",
+      "DescribeScraperLoggingConfiguration",
+      "UpdateScraperLoggingConfiguration"
+    ],
+    "tested": [
+      "DeleteScraperLoggingConfiguration",
+      "DescribeScraperLoggingConfiguration"
+    ],
+    "untested": [
+      "UpdateScraperLoggingConfiguration"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "DeleteScraperLoggingConfiguration": "working",
+      "DescribeScraperLoggingConfiguration": "working",
+      "UpdateScraperLoggingConfiguration": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/apigateway.json
+++ b/chunks/apigateway.json
@@ -1,0 +1,402 @@
+[
+  {
+    "noun": "ApiKeys",
+    "operations": [
+      "GetApiKeys",
+      "ImportApiKeys"
+    ],
+    "tested": [
+      "GetApiKeys"
+    ],
+    "untested": [
+      "ImportApiKeys"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "GetApiKeys": "working",
+      "ImportApiKeys": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Deployment",
+    "operations": [
+      "CreateDeployment",
+      "DeleteDeployment",
+      "GetDeployment",
+      "UpdateDeployment"
+    ],
+    "tested": [
+      "CreateDeployment",
+      "DeleteDeployment",
+      "GetDeployment"
+    ],
+    "untested": [
+      "UpdateDeployment"
+    ],
+    "size": 4,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateDeployment": "working",
+      "DeleteDeployment": "working",
+      "GetDeployment": "working",
+      "UpdateDeployment": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DocumentationParts",
+    "operations": [
+      "GetDocumentationParts",
+      "ImportDocumentationParts"
+    ],
+    "tested": [
+      "GetDocumentationParts"
+    ],
+    "untested": [
+      "ImportDocumentationParts"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "GetDocumentationParts": "working",
+      "ImportDocumentationParts": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DomainName",
+    "operations": [
+      "CreateDomainName",
+      "DeleteDomainName",
+      "GetDomainName",
+      "UpdateDomainName"
+    ],
+    "tested": [
+      "CreateDomainName",
+      "DeleteDomainName",
+      "GetDomainName"
+    ],
+    "untested": [
+      "UpdateDomainName"
+    ],
+    "size": 4,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateDomainName": "working",
+      "DeleteDomainName": "working",
+      "GetDomainName": "working",
+      "UpdateDomainName": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DomainNameAccessAssociation",
+    "operations": [
+      "CreateDomainNameAccessAssociation",
+      "DeleteDomainNameAccessAssociation",
+      "RejectDomainNameAccessAssociation"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateDomainNameAccessAssociation",
+      "DeleteDomainNameAccessAssociation",
+      "RejectDomainNameAccessAssociation"
+    ],
+    "size": 3,
+    "untested_count": 3,
+    "probe_status": {
+      "CreateDomainNameAccessAssociation": "not_implemented",
+      "DeleteDomainNameAccessAssociation": "not_implemented",
+      "RejectDomainNameAccessAssociation": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DomainNameAccessAssociations",
+    "operations": [
+      "GetDomainNameAccessAssociations"
+    ],
+    "tested": [],
+    "untested": [
+      "GetDomainNameAccessAssociations"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetDomainNameAccessAssociations": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "IntegrationResponse",
+    "operations": [
+      "DeleteIntegrationResponse",
+      "GetIntegrationResponse",
+      "PutIntegrationResponse",
+      "UpdateIntegrationResponse"
+    ],
+    "tested": [
+      "DeleteIntegrationResponse",
+      "GetIntegrationResponse",
+      "PutIntegrationResponse"
+    ],
+    "untested": [
+      "UpdateIntegrationResponse"
+    ],
+    "size": 4,
+    "untested_count": 1,
+    "probe_status": {
+      "DeleteIntegrationResponse": "not_implemented",
+      "GetIntegrationResponse": "not_implemented",
+      "PutIntegrationResponse": "not_implemented",
+      "UpdateIntegrationResponse": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "MethodResponse",
+    "operations": [
+      "DeleteMethodResponse",
+      "GetMethodResponse",
+      "PutMethodResponse",
+      "UpdateMethodResponse"
+    ],
+    "tested": [
+      "DeleteMethodResponse",
+      "GetMethodResponse",
+      "PutMethodResponse"
+    ],
+    "untested": [
+      "UpdateMethodResponse"
+    ],
+    "size": 4,
+    "untested_count": 1,
+    "probe_status": {
+      "DeleteMethodResponse": "not_implemented",
+      "GetMethodResponse": "not_implemented",
+      "PutMethodResponse": "not_implemented",
+      "UpdateMethodResponse": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Model",
+    "operations": [
+      "CreateModel",
+      "DeleteModel",
+      "GetModel",
+      "UpdateModel"
+    ],
+    "tested": [
+      "CreateModel",
+      "DeleteModel",
+      "GetModel"
+    ],
+    "untested": [
+      "UpdateModel"
+    ],
+    "size": 4,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateModel": "working",
+      "DeleteModel": "working",
+      "GetModel": "working",
+      "UpdateModel": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ModelTemplate",
+    "operations": [
+      "GetModelTemplate"
+    ],
+    "tested": [],
+    "untested": [
+      "GetModelTemplate"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetModelTemplate": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Resource",
+    "operations": [
+      "CreateResource",
+      "DeleteResource",
+      "GetResource",
+      "TagResource",
+      "UntagResource",
+      "UpdateResource"
+    ],
+    "tested": [
+      "CreateResource",
+      "DeleteResource",
+      "GetResource",
+      "TagResource",
+      "UntagResource"
+    ],
+    "untested": [
+      "UpdateResource"
+    ],
+    "size": 6,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateResource": "working",
+      "DeleteResource": "working",
+      "GetResource": "working",
+      "TagResource": "working",
+      "UntagResource": "working",
+      "UpdateResource": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Sdk",
+    "operations": [
+      "GetSdk"
+    ],
+    "tested": [],
+    "untested": [
+      "GetSdk"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetSdk": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SdkType",
+    "operations": [
+      "GetSdkType"
+    ],
+    "tested": [],
+    "untested": [
+      "GetSdkType"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetSdkType": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SdkTypes",
+    "operations": [
+      "GetSdkTypes"
+    ],
+    "tested": [],
+    "untested": [
+      "GetSdkTypes"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetSdkTypes": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TestInvokeAuthorizer",
+    "operations": [
+      "TestInvokeAuthorizer"
+    ],
+    "tested": [],
+    "untested": [
+      "TestInvokeAuthorizer"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "TestInvokeAuthorizer": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TestInvokeMethod",
+    "operations": [
+      "TestInvokeMethod"
+    ],
+    "tested": [],
+    "untested": [
+      "TestInvokeMethod"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "TestInvokeMethod": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Usage",
+    "operations": [
+      "GetUsage",
+      "UpdateUsage"
+    ],
+    "tested": [
+      "GetUsage"
+    ],
+    "untested": [
+      "UpdateUsage"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "GetUsage": "working",
+      "UpdateUsage": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "VpcLink",
+    "operations": [
+      "CreateVpcLink",
+      "DeleteVpcLink",
+      "GetVpcLink",
+      "UpdateVpcLink"
+    ],
+    "tested": [
+      "CreateVpcLink",
+      "DeleteVpcLink",
+      "GetVpcLink"
+    ],
+    "untested": [
+      "UpdateVpcLink"
+    ],
+    "size": 4,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateVpcLink": "working",
+      "DeleteVpcLink": "working",
+      "GetVpcLink": "working",
+      "UpdateVpcLink": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/appmesh.json
+++ b/chunks/appmesh.json
@@ -1,0 +1,152 @@
+[
+  {
+    "noun": "GatewayRoute",
+    "operations": [
+      "CreateGatewayRoute",
+      "DeleteGatewayRoute",
+      "DescribeGatewayRoute",
+      "UpdateGatewayRoute"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateGatewayRoute",
+      "DeleteGatewayRoute",
+      "DescribeGatewayRoute",
+      "UpdateGatewayRoute"
+    ],
+    "size": 4,
+    "untested_count": 4,
+    "probe_status": {
+      "CreateGatewayRoute": "not_implemented",
+      "DeleteGatewayRoute": "not_implemented",
+      "DescribeGatewayRoute": "not_implemented",
+      "UpdateGatewayRoute": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "GatewayRoutes",
+    "operations": [
+      "ListGatewayRoutes"
+    ],
+    "tested": [],
+    "untested": [
+      "ListGatewayRoutes"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListGatewayRoutes": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Resource",
+    "operations": [
+      "TagResource",
+      "UntagResource"
+    ],
+    "tested": [
+      "TagResource"
+    ],
+    "untested": [
+      "UntagResource"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "TagResource": "working",
+      "UntagResource": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "VirtualGateway",
+    "operations": [
+      "CreateVirtualGateway",
+      "DeleteVirtualGateway",
+      "DescribeVirtualGateway",
+      "UpdateVirtualGateway"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateVirtualGateway",
+      "DeleteVirtualGateway",
+      "DescribeVirtualGateway",
+      "UpdateVirtualGateway"
+    ],
+    "size": 4,
+    "untested_count": 4,
+    "probe_status": {
+      "CreateVirtualGateway": "not_implemented",
+      "DeleteVirtualGateway": "not_implemented",
+      "DescribeVirtualGateway": "not_implemented",
+      "UpdateVirtualGateway": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "VirtualGateways",
+    "operations": [
+      "ListVirtualGateways"
+    ],
+    "tested": [],
+    "untested": [
+      "ListVirtualGateways"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListVirtualGateways": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "VirtualService",
+    "operations": [
+      "CreateVirtualService",
+      "DeleteVirtualService",
+      "DescribeVirtualService",
+      "UpdateVirtualService"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateVirtualService",
+      "DeleteVirtualService",
+      "DescribeVirtualService",
+      "UpdateVirtualService"
+    ],
+    "size": 4,
+    "untested_count": 4,
+    "probe_status": {
+      "CreateVirtualService": "not_implemented",
+      "DeleteVirtualService": "not_implemented",
+      "DescribeVirtualService": "not_implemented",
+      "UpdateVirtualService": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "VirtualServices",
+    "operations": [
+      "ListVirtualServices"
+    ],
+    "tested": [],
+    "untested": [
+      "ListVirtualServices"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListVirtualServices": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/appsync.json
+++ b/chunks/appsync.json
@@ -1,0 +1,25 @@
+[
+  {
+    "noun": "SourceApiAssociation",
+    "operations": [
+      "GetSourceApiAssociation",
+      "UpdateSourceApiAssociation"
+    ],
+    "tested": [
+      "GetSourceApiAssociation"
+    ],
+    "untested": [
+      "UpdateSourceApiAssociation"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "GetSourceApiAssociation": "working",
+      "UpdateSourceApiAssociation": "working"
+    },
+    "working_untested": [
+      "UpdateSourceApiAssociation"
+    ],
+    "working_untested_count": 1
+  }
+]

--- a/chunks/athena.json
+++ b/chunks/athena.json
@@ -1,0 +1,51 @@
+[
+  {
+    "noun": "ApplicationDPUSizes",
+    "operations": [
+      "ListApplicationDPUSizes"
+    ],
+    "tested": [],
+    "untested": [
+      "ListApplicationDPUSizes"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListApplicationDPUSizes": "working"
+    },
+    "working_untested": [
+      "ListApplicationDPUSizes"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "CapacityReservation",
+    "operations": [
+      "CancelCapacityReservation",
+      "CreateCapacityReservation",
+      "DeleteCapacityReservation",
+      "GetCapacityReservation",
+      "UpdateCapacityReservation"
+    ],
+    "tested": [
+      "CancelCapacityReservation",
+      "DeleteCapacityReservation",
+      "GetCapacityReservation"
+    ],
+    "untested": [
+      "CreateCapacityReservation",
+      "UpdateCapacityReservation"
+    ],
+    "size": 5,
+    "untested_count": 2,
+    "probe_status": {
+      "CancelCapacityReservation": "working",
+      "CreateCapacityReservation": "needs_params",
+      "DeleteCapacityReservation": "working",
+      "GetCapacityReservation": "working",
+      "UpdateCapacityReservation": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/autoscaling.json
+++ b/chunks/autoscaling.json
@@ -1,0 +1,131 @@
+[
+  {
+    "noun": "CompleteLifecycleAction",
+    "operations": [
+      "CompleteLifecycleAction"
+    ],
+    "tested": [],
+    "untested": [
+      "CompleteLifecycleAction"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "CompleteLifecycleAction": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "LaunchInstances",
+    "operations": [
+      "LaunchInstances"
+    ],
+    "tested": [],
+    "untested": [
+      "LaunchInstances"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "LaunchInstances": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "MetricsCollection",
+    "operations": [
+      "DisableMetricsCollection",
+      "EnableMetricsCollection"
+    ],
+    "tested": [
+      "EnableMetricsCollection"
+    ],
+    "untested": [
+      "DisableMetricsCollection"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "DisableMetricsCollection": "not_implemented",
+      "EnableMetricsCollection": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "PredictiveScalingForecast",
+    "operations": [
+      "GetPredictiveScalingForecast"
+    ],
+    "tested": [],
+    "untested": [
+      "GetPredictiveScalingForecast"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetPredictiveScalingForecast": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "RecordLifecycleActionHeartbeat",
+    "operations": [
+      "RecordLifecycleActionHeartbeat"
+    ],
+    "tested": [],
+    "untested": [
+      "RecordLifecycleActionHeartbeat"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "RecordLifecycleActionHeartbeat": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "RollbackInstanceRefresh",
+    "operations": [
+      "RollbackInstanceRefresh"
+    ],
+    "tested": [],
+    "untested": [
+      "RollbackInstanceRefresh"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "RollbackInstanceRefresh": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TrafficSources",
+    "operations": [
+      "AttachTrafficSources",
+      "DescribeTrafficSources",
+      "DetachTrafficSources"
+    ],
+    "tested": [],
+    "untested": [
+      "AttachTrafficSources",
+      "DescribeTrafficSources",
+      "DetachTrafficSources"
+    ],
+    "size": 3,
+    "untested_count": 3,
+    "probe_status": {
+      "AttachTrafficSources": "not_implemented",
+      "DescribeTrafficSources": "not_implemented",
+      "DetachTrafficSources": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/backup.json
+++ b/chunks/backup.json
@@ -1,0 +1,422 @@
+[
+  {
+    "noun": "BackupPlan",
+    "operations": [
+      "CreateBackupPlan",
+      "DeleteBackupPlan",
+      "GetBackupPlan",
+      "UpdateBackupPlan"
+    ],
+    "tested": [
+      "CreateBackupPlan",
+      "DeleteBackupPlan",
+      "UpdateBackupPlan"
+    ],
+    "untested": [
+      "GetBackupPlan"
+    ],
+    "size": 4,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateBackupPlan": "working",
+      "DeleteBackupPlan": "working",
+      "GetBackupPlan": "not_implemented",
+      "UpdateBackupPlan": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "BackupPlanFromJSON",
+    "operations": [
+      "GetBackupPlanFromJSON"
+    ],
+    "tested": [],
+    "untested": [
+      "GetBackupPlanFromJSON"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetBackupPlanFromJSON": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "BackupPlanTemplate",
+    "operations": [
+      "ExportBackupPlanTemplate"
+    ],
+    "tested": [],
+    "untested": [
+      "ExportBackupPlanTemplate"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ExportBackupPlanTemplate": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "BackupPlanVersions",
+    "operations": [
+      "ListBackupPlanVersions"
+    ],
+    "tested": [],
+    "untested": [
+      "ListBackupPlanVersions"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListBackupPlanVersions": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "BackupSelection",
+    "operations": [
+      "CreateBackupSelection",
+      "DeleteBackupSelection",
+      "GetBackupSelection"
+    ],
+    "tested": [
+      "DeleteBackupSelection",
+      "GetBackupSelection"
+    ],
+    "untested": [
+      "CreateBackupSelection"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateBackupSelection": "not_implemented",
+      "DeleteBackupSelection": "working",
+      "GetBackupSelection": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "BackupSelections",
+    "operations": [
+      "ListBackupSelections"
+    ],
+    "tested": [],
+    "untested": [
+      "ListBackupSelections"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListBackupSelections": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "BackupVaultMpaApprovalTeam",
+    "operations": [
+      "AssociateBackupVaultMpaApprovalTeam",
+      "DisassociateBackupVaultMpaApprovalTeam"
+    ],
+    "tested": [],
+    "untested": [
+      "AssociateBackupVaultMpaApprovalTeam",
+      "DisassociateBackupVaultMpaApprovalTeam"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "AssociateBackupVaultMpaApprovalTeam": "not_implemented",
+      "DisassociateBackupVaultMpaApprovalTeam": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "IndexedRecoveryPoints",
+    "operations": [
+      "ListIndexedRecoveryPoints"
+    ],
+    "tested": [],
+    "untested": [
+      "ListIndexedRecoveryPoints"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListIndexedRecoveryPoints": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "LegalHold",
+    "operations": [
+      "CancelLegalHold",
+      "CreateLegalHold",
+      "GetLegalHold"
+    ],
+    "tested": [
+      "CancelLegalHold",
+      "CreateLegalHold"
+    ],
+    "untested": [
+      "GetLegalHold"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "CancelLegalHold": "working",
+      "CreateLegalHold": "working",
+      "GetLegalHold": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ProtectedResourcesByBackupVault",
+    "operations": [
+      "ListProtectedResourcesByBackupVault"
+    ],
+    "tested": [],
+    "untested": [
+      "ListProtectedResourcesByBackupVault"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListProtectedResourcesByBackupVault": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "RecoveryPointIndexDetails",
+    "operations": [
+      "GetRecoveryPointIndexDetails"
+    ],
+    "tested": [],
+    "untested": [
+      "GetRecoveryPointIndexDetails"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetRecoveryPointIndexDetails": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "RecoveryPointIndexSettings",
+    "operations": [
+      "UpdateRecoveryPointIndexSettings"
+    ],
+    "tested": [],
+    "untested": [
+      "UpdateRecoveryPointIndexSettings"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "UpdateRecoveryPointIndexSettings": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "RecoveryPointsByBackupVault",
+    "operations": [
+      "ListRecoveryPointsByBackupVault"
+    ],
+    "tested": [],
+    "untested": [
+      "ListRecoveryPointsByBackupVault"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListRecoveryPointsByBackupVault": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ReportJob",
+    "operations": [
+      "DescribeReportJob",
+      "StartReportJob"
+    ],
+    "tested": [
+      "DescribeReportJob"
+    ],
+    "untested": [
+      "StartReportJob"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeReportJob": "working",
+      "StartReportJob": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "RestoreAccessBackupVault",
+    "operations": [
+      "CreateRestoreAccessBackupVault",
+      "RevokeRestoreAccessBackupVault"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateRestoreAccessBackupVault",
+      "RevokeRestoreAccessBackupVault"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "CreateRestoreAccessBackupVault": "not_implemented",
+      "RevokeRestoreAccessBackupVault": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "RestoreAccessBackupVaults",
+    "operations": [
+      "ListRestoreAccessBackupVaults"
+    ],
+    "tested": [],
+    "untested": [
+      "ListRestoreAccessBackupVaults"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListRestoreAccessBackupVaults": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "RestoreTestingInferredMetadata",
+    "operations": [
+      "GetRestoreTestingInferredMetadata"
+    ],
+    "tested": [],
+    "untested": [
+      "GetRestoreTestingInferredMetadata"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetRestoreTestingInferredMetadata": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ScanJob",
+    "operations": [
+      "DescribeScanJob",
+      "StartScanJob"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeScanJob",
+      "StartScanJob"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "DescribeScanJob": "not_implemented",
+      "StartScanJob": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ScanJobSummaries",
+    "operations": [
+      "ListScanJobSummaries"
+    ],
+    "tested": [],
+    "untested": [
+      "ListScanJobSummaries"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListScanJobSummaries": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ScanJobs",
+    "operations": [
+      "ListScanJobs"
+    ],
+    "tested": [],
+    "untested": [
+      "ListScanJobs"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListScanJobs": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TieringConfiguration",
+    "operations": [
+      "CreateTieringConfiguration",
+      "DeleteTieringConfiguration",
+      "GetTieringConfiguration",
+      "UpdateTieringConfiguration"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateTieringConfiguration",
+      "DeleteTieringConfiguration",
+      "GetTieringConfiguration",
+      "UpdateTieringConfiguration"
+    ],
+    "size": 4,
+    "untested_count": 4,
+    "probe_status": {
+      "CreateTieringConfiguration": "not_implemented",
+      "DeleteTieringConfiguration": "not_implemented",
+      "GetTieringConfiguration": "not_implemented",
+      "UpdateTieringConfiguration": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TieringConfigurations",
+    "operations": [
+      "ListTieringConfigurations"
+    ],
+    "tested": [],
+    "untested": [
+      "ListTieringConfigurations"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListTieringConfigurations": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/bedrock.json
+++ b/chunks/bedrock.json
@@ -1,0 +1,235 @@
+[
+  {
+    "noun": "AutomatedReasoningPolicyAnnotations",
+    "operations": [
+      "GetAutomatedReasoningPolicyAnnotations",
+      "UpdateAutomatedReasoningPolicyAnnotations"
+    ],
+    "tested": [
+      "GetAutomatedReasoningPolicyAnnotations"
+    ],
+    "untested": [
+      "UpdateAutomatedReasoningPolicyAnnotations"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "GetAutomatedReasoningPolicyAnnotations": "working",
+      "UpdateAutomatedReasoningPolicyAnnotations": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "AutomatedReasoningPolicyVersion",
+    "operations": [
+      "CreateAutomatedReasoningPolicyVersion",
+      "ExportAutomatedReasoningPolicyVersion"
+    ],
+    "tested": [
+      "ExportAutomatedReasoningPolicyVersion"
+    ],
+    "untested": [
+      "CreateAutomatedReasoningPolicyVersion"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateAutomatedReasoningPolicyVersion": "needs_params",
+      "ExportAutomatedReasoningPolicyVersion": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "CustomModel",
+    "operations": [
+      "CreateCustomModel",
+      "DeleteCustomModel",
+      "GetCustomModel"
+    ],
+    "tested": [
+      "DeleteCustomModel",
+      "GetCustomModel"
+    ],
+    "untested": [
+      "CreateCustomModel"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateCustomModel": "needs_params",
+      "DeleteCustomModel": "working",
+      "GetCustomModel": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DeleteEvaluationJob",
+    "operations": [
+      "BatchDeleteEvaluationJob"
+    ],
+    "tested": [],
+    "untested": [
+      "BatchDeleteEvaluationJob"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "BatchDeleteEvaluationJob": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "EvaluationJob",
+    "operations": [
+      "CreateEvaluationJob",
+      "GetEvaluationJob",
+      "StopEvaluationJob"
+    ],
+    "tested": [
+      "GetEvaluationJob",
+      "StopEvaluationJob"
+    ],
+    "untested": [
+      "CreateEvaluationJob"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateEvaluationJob": "needs_params",
+      "GetEvaluationJob": "working",
+      "StopEvaluationJob": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "InferenceProfile",
+    "operations": [
+      "CreateInferenceProfile",
+      "DeleteInferenceProfile",
+      "GetInferenceProfile"
+    ],
+    "tested": [
+      "DeleteInferenceProfile",
+      "GetInferenceProfile"
+    ],
+    "untested": [
+      "CreateInferenceProfile"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateInferenceProfile": "needs_params",
+      "DeleteInferenceProfile": "working",
+      "GetInferenceProfile": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "MarketplaceModelEndpoint",
+    "operations": [
+      "CreateMarketplaceModelEndpoint",
+      "DeleteMarketplaceModelEndpoint",
+      "DeregisterMarketplaceModelEndpoint",
+      "GetMarketplaceModelEndpoint",
+      "RegisterMarketplaceModelEndpoint",
+      "UpdateMarketplaceModelEndpoint"
+    ],
+    "tested": [
+      "DeleteMarketplaceModelEndpoint",
+      "DeregisterMarketplaceModelEndpoint",
+      "GetMarketplaceModelEndpoint",
+      "RegisterMarketplaceModelEndpoint"
+    ],
+    "untested": [
+      "CreateMarketplaceModelEndpoint",
+      "UpdateMarketplaceModelEndpoint"
+    ],
+    "size": 6,
+    "untested_count": 2,
+    "probe_status": {
+      "CreateMarketplaceModelEndpoint": "needs_params",
+      "DeleteMarketplaceModelEndpoint": "working",
+      "DeregisterMarketplaceModelEndpoint": "working",
+      "GetMarketplaceModelEndpoint": "working",
+      "RegisterMarketplaceModelEndpoint": "working",
+      "UpdateMarketplaceModelEndpoint": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ModelImportJob",
+    "operations": [
+      "CreateModelImportJob",
+      "GetModelImportJob"
+    ],
+    "tested": [
+      "GetModelImportJob"
+    ],
+    "untested": [
+      "CreateModelImportJob"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateModelImportJob": "needs_params",
+      "GetModelImportJob": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ModelInvocationJob",
+    "operations": [
+      "CreateModelInvocationJob",
+      "GetModelInvocationJob",
+      "StopModelInvocationJob"
+    ],
+    "tested": [
+      "GetModelInvocationJob",
+      "StopModelInvocationJob"
+    ],
+    "untested": [
+      "CreateModelInvocationJob"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateModelInvocationJob": "needs_params",
+      "GetModelInvocationJob": "working",
+      "StopModelInvocationJob": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "PromptRouter",
+    "operations": [
+      "CreatePromptRouter",
+      "DeletePromptRouter",
+      "GetPromptRouter"
+    ],
+    "tested": [
+      "DeletePromptRouter",
+      "GetPromptRouter"
+    ],
+    "untested": [
+      "CreatePromptRouter"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "CreatePromptRouter": "needs_params",
+      "DeletePromptRouter": "working",
+      "GetPromptRouter": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/budgets.json
+++ b/chunks/budgets.json
@@ -1,0 +1,36 @@
+[
+  {
+    "noun": "BudgetActionHistories",
+    "operations": [
+      "DescribeBudgetActionHistories"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeBudgetActionHistories"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeBudgetActionHistories": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SubscribersForNotification",
+    "operations": [
+      "DescribeSubscribersForNotification"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeSubscribersForNotification"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeSubscribersForNotification": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/ce.json
+++ b/chunks/ce.json
@@ -1,0 +1,74 @@
+[
+  {
+    "noun": "CommitmentPurchaseAnalysis",
+    "operations": [
+      "GetCommitmentPurchaseAnalysis",
+      "StartCommitmentPurchaseAnalysis"
+    ],
+    "tested": [
+      "StartCommitmentPurchaseAnalysis"
+    ],
+    "untested": [
+      "GetCommitmentPurchaseAnalysis"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "GetCommitmentPurchaseAnalysis": "needs_params",
+      "StartCommitmentPurchaseAnalysis": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "CostAllocationTagBackfill",
+    "operations": [
+      "StartCostAllocationTagBackfill"
+    ],
+    "tested": [],
+    "untested": [
+      "StartCostAllocationTagBackfill"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "StartCostAllocationTagBackfill": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "CostAllocationTagsStatus",
+    "operations": [
+      "UpdateCostAllocationTagsStatus"
+    ],
+    "tested": [],
+    "untested": [
+      "UpdateCostAllocationTagsStatus"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "UpdateCostAllocationTagsStatus": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SavingsPlanPurchaseRecommendationDetails",
+    "operations": [
+      "GetSavingsPlanPurchaseRecommendationDetails"
+    ],
+    "tested": [],
+    "untested": [
+      "GetSavingsPlanPurchaseRecommendationDetails"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetSavingsPlanPurchaseRecommendationDetails": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/cloudformation.json
+++ b/chunks/cloudformation.json
@@ -1,0 +1,103 @@
+[
+  {
+    "noun": "DescribeTypeConfigurations",
+    "operations": [
+      "BatchDescribeTypeConfigurations"
+    ],
+    "tested": [],
+    "untested": [
+      "BatchDescribeTypeConfigurations"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "BatchDescribeTypeConfigurations": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Type",
+    "operations": [
+      "ActivateType",
+      "DeactivateType",
+      "DeregisterType",
+      "DescribeType",
+      "PublishType",
+      "RegisterType"
+    ],
+    "tested": [
+      "ActivateType",
+      "DeactivateType",
+      "DeregisterType",
+      "DescribeType",
+      "PublishType"
+    ],
+    "untested": [
+      "RegisterType"
+    ],
+    "size": 6,
+    "untested_count": 1,
+    "probe_status": {
+      "ActivateType": "working",
+      "DeactivateType": "working",
+      "DeregisterType": "working",
+      "DescribeType": "working",
+      "PublishType": "working",
+      "RegisterType": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TypeConfiguration",
+    "operations": [
+      "SetTypeConfiguration"
+    ],
+    "tested": [],
+    "untested": [
+      "SetTypeConfiguration"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "SetTypeConfiguration": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TypeRegistration",
+    "operations": [
+      "DescribeTypeRegistration"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeTypeRegistration"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeTypeRegistration": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "UpdateStack",
+    "operations": [
+      "CancelUpdateStack"
+    ],
+    "tested": [],
+    "untested": [
+      "CancelUpdateStack"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "CancelUpdateStack": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/cloudfront.json
+++ b/chunks/cloudfront.json
@@ -1,0 +1,534 @@
+[
+  {
+    "noun": "DistributionTenantWebACL",
+    "operations": [
+      "AssociateDistributionTenantWebACL",
+      "DisassociateDistributionTenantWebACL"
+    ],
+    "tested": [],
+    "untested": [
+      "AssociateDistributionTenantWebACL",
+      "DisassociateDistributionTenantWebACL"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "AssociateDistributionTenantWebACL": "working",
+      "DisassociateDistributionTenantWebACL": "working"
+    },
+    "working_untested": [
+      "AssociateDistributionTenantWebACL",
+      "DisassociateDistributionTenantWebACL"
+    ],
+    "working_untested_count": 2
+  },
+  {
+    "noun": "DistributionWebACL",
+    "operations": [
+      "AssociateDistributionWebACL",
+      "DisassociateDistributionWebACL"
+    ],
+    "tested": [],
+    "untested": [
+      "AssociateDistributionWebACL",
+      "DisassociateDistributionWebACL"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "AssociateDistributionWebACL": "working",
+      "DisassociateDistributionWebACL": "working"
+    },
+    "working_untested": [
+      "AssociateDistributionWebACL",
+      "DisassociateDistributionWebACL"
+    ],
+    "working_untested_count": 2
+  },
+  {
+    "noun": "DistributionsByWebACLId",
+    "operations": [
+      "ListDistributionsByWebACLId"
+    ],
+    "tested": [],
+    "untested": [
+      "ListDistributionsByWebACLId"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListDistributionsByWebACLId": "working"
+    },
+    "working_untested": [
+      "ListDistributionsByWebACLId"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "AnycastIpList",
+    "operations": [
+      "CreateAnycastIpList",
+      "DeleteAnycastIpList",
+      "GetAnycastIpList",
+      "UpdateAnycastIpList"
+    ],
+    "tested": [
+      "DeleteAnycastIpList",
+      "GetAnycastIpList",
+      "UpdateAnycastIpList"
+    ],
+    "untested": [
+      "CreateAnycastIpList"
+    ],
+    "size": 4,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateAnycastIpList": "500_error",
+      "DeleteAnycastIpList": "working",
+      "GetAnycastIpList": "working",
+      "UpdateAnycastIpList": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "AnycastIpLists",
+    "operations": [
+      "ListAnycastIpLists"
+    ],
+    "tested": [],
+    "untested": [
+      "ListAnycastIpLists"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListAnycastIpLists": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ConnectionFunction",
+    "operations": [
+      "CreateConnectionFunction",
+      "DeleteConnectionFunction",
+      "DescribeConnectionFunction",
+      "GetConnectionFunction",
+      "PublishConnectionFunction",
+      "UpdateConnectionFunction"
+    ],
+    "tested": [
+      "DeleteConnectionFunction",
+      "GetConnectionFunction"
+    ],
+    "untested": [
+      "CreateConnectionFunction",
+      "DescribeConnectionFunction",
+      "PublishConnectionFunction",
+      "UpdateConnectionFunction"
+    ],
+    "size": 6,
+    "untested_count": 4,
+    "probe_status": {
+      "CreateConnectionFunction": "500_error",
+      "DeleteConnectionFunction": "working",
+      "DescribeConnectionFunction": "500_error",
+      "GetConnectionFunction": "working",
+      "PublishConnectionFunction": "500_error",
+      "UpdateConnectionFunction": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ConnectionFunctions",
+    "operations": [
+      "ListConnectionFunctions"
+    ],
+    "tested": [],
+    "untested": [
+      "ListConnectionFunctions"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListConnectionFunctions": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ConnectionGroup",
+    "operations": [
+      "CreateConnectionGroup",
+      "DeleteConnectionGroup",
+      "GetConnectionGroup",
+      "UpdateConnectionGroup"
+    ],
+    "tested": [
+      "DeleteConnectionGroup"
+    ],
+    "untested": [
+      "CreateConnectionGroup",
+      "GetConnectionGroup",
+      "UpdateConnectionGroup"
+    ],
+    "size": 4,
+    "untested_count": 3,
+    "probe_status": {
+      "CreateConnectionGroup": "500_error",
+      "DeleteConnectionGroup": "working",
+      "GetConnectionGroup": "500_error",
+      "UpdateConnectionGroup": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ConnectionGroupByRoutingEndpoint",
+    "operations": [
+      "GetConnectionGroupByRoutingEndpoint"
+    ],
+    "tested": [],
+    "untested": [
+      "GetConnectionGroupByRoutingEndpoint"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetConnectionGroupByRoutingEndpoint": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ConnectionGroups",
+    "operations": [
+      "ListConnectionGroups"
+    ],
+    "tested": [],
+    "untested": [
+      "ListConnectionGroups"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListConnectionGroups": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DistributionTenant",
+    "operations": [
+      "CreateDistributionTenant",
+      "DeleteDistributionTenant",
+      "GetDistributionTenant",
+      "UpdateDistributionTenant"
+    ],
+    "tested": [
+      "DeleteDistributionTenant"
+    ],
+    "untested": [
+      "CreateDistributionTenant",
+      "GetDistributionTenant",
+      "UpdateDistributionTenant"
+    ],
+    "size": 4,
+    "untested_count": 3,
+    "probe_status": {
+      "CreateDistributionTenant": "500_error",
+      "DeleteDistributionTenant": "working",
+      "GetDistributionTenant": "500_error",
+      "UpdateDistributionTenant": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DistributionTenantByDomain",
+    "operations": [
+      "GetDistributionTenantByDomain"
+    ],
+    "tested": [],
+    "untested": [
+      "GetDistributionTenantByDomain"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetDistributionTenantByDomain": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DistributionTenants",
+    "operations": [
+      "ListDistributionTenants"
+    ],
+    "tested": [],
+    "untested": [
+      "ListDistributionTenants"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListDistributionTenants": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DistributionTenantsByCustomization",
+    "operations": [
+      "ListDistributionTenantsByCustomization"
+    ],
+    "tested": [],
+    "untested": [
+      "ListDistributionTenantsByCustomization"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListDistributionTenantsByCustomization": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DistributionsByOwnedResource",
+    "operations": [
+      "ListDistributionsByOwnedResource"
+    ],
+    "tested": [],
+    "untested": [
+      "ListDistributionsByOwnedResource"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListDistributionsByOwnedResource": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DnsConfiguration",
+    "operations": [
+      "VerifyDnsConfiguration"
+    ],
+    "tested": [],
+    "untested": [
+      "VerifyDnsConfiguration"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "VerifyDnsConfiguration": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DomainConflicts",
+    "operations": [
+      "ListDomainConflicts"
+    ],
+    "tested": [],
+    "untested": [
+      "ListDomainConflicts"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListDomainConflicts": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "InvalidationForDistributionTenant",
+    "operations": [
+      "CreateInvalidationForDistributionTenant",
+      "GetInvalidationForDistributionTenant"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateInvalidationForDistributionTenant",
+      "GetInvalidationForDistributionTenant"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "CreateInvalidationForDistributionTenant": "500_error",
+      "GetInvalidationForDistributionTenant": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "InvalidationsForDistributionTenant",
+    "operations": [
+      "ListInvalidationsForDistributionTenant"
+    ],
+    "tested": [],
+    "untested": [
+      "ListInvalidationsForDistributionTenant"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListInvalidationsForDistributionTenant": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ManagedCertificateDetails",
+    "operations": [
+      "GetManagedCertificateDetails"
+    ],
+    "tested": [],
+    "untested": [
+      "GetManagedCertificateDetails"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetManagedCertificateDetails": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ResourcePolicy",
+    "operations": [
+      "DeleteResourcePolicy",
+      "GetResourcePolicy",
+      "PutResourcePolicy"
+    ],
+    "tested": [
+      "DeleteResourcePolicy"
+    ],
+    "untested": [
+      "GetResourcePolicy",
+      "PutResourcePolicy"
+    ],
+    "size": 3,
+    "untested_count": 2,
+    "probe_status": {
+      "DeleteResourcePolicy": "working",
+      "GetResourcePolicy": "500_error",
+      "PutResourcePolicy": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TestConnectionFunction",
+    "operations": [
+      "TestConnectionFunction"
+    ],
+    "tested": [],
+    "untested": [
+      "TestConnectionFunction"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "TestConnectionFunction": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TrustStore",
+    "operations": [
+      "CreateTrustStore",
+      "DeleteTrustStore",
+      "GetTrustStore",
+      "UpdateTrustStore"
+    ],
+    "tested": [
+      "DeleteTrustStore"
+    ],
+    "untested": [
+      "CreateTrustStore",
+      "GetTrustStore",
+      "UpdateTrustStore"
+    ],
+    "size": 4,
+    "untested_count": 3,
+    "probe_status": {
+      "CreateTrustStore": "needs_params",
+      "DeleteTrustStore": "working",
+      "GetTrustStore": "500_error",
+      "UpdateTrustStore": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TrustStores",
+    "operations": [
+      "ListTrustStores"
+    ],
+    "tested": [],
+    "untested": [
+      "ListTrustStores"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListTrustStores": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "VpcOrigin",
+    "operations": [
+      "CreateVpcOrigin",
+      "DeleteVpcOrigin",
+      "GetVpcOrigin",
+      "UpdateVpcOrigin"
+    ],
+    "tested": [
+      "DeleteVpcOrigin",
+      "GetVpcOrigin"
+    ],
+    "untested": [
+      "CreateVpcOrigin",
+      "UpdateVpcOrigin"
+    ],
+    "size": 4,
+    "untested_count": 2,
+    "probe_status": {
+      "CreateVpcOrigin": "500_error",
+      "DeleteVpcOrigin": "working",
+      "GetVpcOrigin": "working",
+      "UpdateVpcOrigin": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "VpcOrigins",
+    "operations": [
+      "ListVpcOrigins"
+    ],
+    "tested": [],
+    "untested": [
+      "ListVpcOrigins"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListVpcOrigins": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/cloudtrail.json
+++ b/chunks/cloudtrail.json
@@ -1,0 +1,247 @@
+[
+  {
+    "noun": "Dashboard",
+    "operations": [
+      "CreateDashboard",
+      "DeleteDashboard",
+      "GetDashboard",
+      "UpdateDashboard"
+    ],
+    "tested": [
+      "GetDashboard"
+    ],
+    "untested": [
+      "CreateDashboard",
+      "DeleteDashboard",
+      "UpdateDashboard"
+    ],
+    "size": 4,
+    "untested_count": 3,
+    "probe_status": {
+      "CreateDashboard": "not_implemented",
+      "DeleteDashboard": "not_implemented",
+      "GetDashboard": "working",
+      "UpdateDashboard": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DashboardRefresh",
+    "operations": [
+      "StartDashboardRefresh"
+    ],
+    "tested": [],
+    "untested": [
+      "StartDashboardRefresh"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "StartDashboardRefresh": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Dashboards",
+    "operations": [
+      "ListDashboards"
+    ],
+    "tested": [],
+    "untested": [
+      "ListDashboards"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListDashboards": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "EventConfiguration",
+    "operations": [
+      "GetEventConfiguration",
+      "PutEventConfiguration"
+    ],
+    "tested": [
+      "GetEventConfiguration"
+    ],
+    "untested": [
+      "PutEventConfiguration"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "GetEventConfiguration": "working",
+      "PutEventConfiguration": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "EventDataStoreIngestion",
+    "operations": [
+      "StartEventDataStoreIngestion",
+      "StopEventDataStoreIngestion"
+    ],
+    "tested": [],
+    "untested": [
+      "StartEventDataStoreIngestion",
+      "StopEventDataStoreIngestion"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "StartEventDataStoreIngestion": "not_implemented",
+      "StopEventDataStoreIngestion": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "GenerateQuery",
+    "operations": [
+      "GenerateQuery"
+    ],
+    "tested": [],
+    "untested": [
+      "GenerateQuery"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GenerateQuery": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ImportFailures",
+    "operations": [
+      "ListImportFailures"
+    ],
+    "tested": [],
+    "untested": [
+      "ListImportFailures"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListImportFailures": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "InsightsData",
+    "operations": [
+      "ListInsightsData"
+    ],
+    "tested": [],
+    "untested": [
+      "ListInsightsData"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListInsightsData": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "InsightsMetricData",
+    "operations": [
+      "ListInsightsMetricData"
+    ],
+    "tested": [],
+    "untested": [
+      "ListInsightsMetricData"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListInsightsMetricData": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "LookupEvents",
+    "operations": [
+      "LookupEvents"
+    ],
+    "tested": [],
+    "untested": [
+      "LookupEvents"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "LookupEvents": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "PublicKeys",
+    "operations": [
+      "ListPublicKeys"
+    ],
+    "tested": [],
+    "untested": [
+      "ListPublicKeys"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListPublicKeys": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ResourcePolicy",
+    "operations": [
+      "DeleteResourcePolicy",
+      "GetResourcePolicy",
+      "PutResourcePolicy"
+    ],
+    "tested": [
+      "GetResourcePolicy",
+      "PutResourcePolicy"
+    ],
+    "untested": [
+      "DeleteResourcePolicy"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "DeleteResourcePolicy": "not_implemented",
+      "GetResourcePolicy": "working",
+      "PutResourcePolicy": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SearchSampleQueries",
+    "operations": [
+      "SearchSampleQueries"
+    ],
+    "tested": [],
+    "untested": [
+      "SearchSampleQueries"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "SearchSampleQueries": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/cloudwatch.json
+++ b/chunks/cloudwatch.json
@@ -1,0 +1,144 @@
+[
+  {
+    "noun": "AlarmContributors",
+    "operations": [
+      "DescribeAlarmContributors"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeAlarmContributors"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeAlarmContributors": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "AlarmMuteRule",
+    "operations": [
+      "DeleteAlarmMuteRule",
+      "GetAlarmMuteRule",
+      "PutAlarmMuteRule"
+    ],
+    "tested": [],
+    "untested": [
+      "DeleteAlarmMuteRule",
+      "GetAlarmMuteRule",
+      "PutAlarmMuteRule"
+    ],
+    "size": 3,
+    "untested_count": 3,
+    "probe_status": {
+      "DeleteAlarmMuteRule": "not_implemented",
+      "GetAlarmMuteRule": "not_implemented",
+      "PutAlarmMuteRule": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "InsightRuleReport",
+    "operations": [
+      "GetInsightRuleReport"
+    ],
+    "tested": [],
+    "untested": [
+      "GetInsightRuleReport"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetInsightRuleReport": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ManagedInsightRules",
+    "operations": [
+      "ListManagedInsightRules",
+      "PutManagedInsightRules"
+    ],
+    "tested": [
+      "ListManagedInsightRules"
+    ],
+    "untested": [
+      "PutManagedInsightRules"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "ListManagedInsightRules": "working",
+      "PutManagedInsightRules": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "MetricStream",
+    "operations": [
+      "DeleteMetricStream",
+      "GetMetricStream",
+      "PutMetricStream"
+    ],
+    "tested": [],
+    "untested": [
+      "DeleteMetricStream",
+      "GetMetricStream",
+      "PutMetricStream"
+    ],
+    "size": 3,
+    "untested_count": 3,
+    "probe_status": {
+      "DeleteMetricStream": "not_implemented",
+      "GetMetricStream": "not_implemented",
+      "PutMetricStream": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "MetricStreams",
+    "operations": [
+      "ListMetricStreams",
+      "StartMetricStreams",
+      "StopMetricStreams"
+    ],
+    "tested": [
+      "ListMetricStreams"
+    ],
+    "untested": [
+      "StartMetricStreams",
+      "StopMetricStreams"
+    ],
+    "size": 3,
+    "untested_count": 2,
+    "probe_status": {
+      "ListMetricStreams": "working",
+      "StartMetricStreams": "not_implemented",
+      "StopMetricStreams": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "MetricWidgetImage",
+    "operations": [
+      "GetMetricWidgetImage"
+    ],
+    "tested": [],
+    "untested": [
+      "GetMetricWidgetImage"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetMetricWidgetImage": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/codepipeline.json
+++ b/chunks/codepipeline.json
@@ -1,0 +1,57 @@
+[
+  {
+    "noun": "ActionRevision",
+    "operations": [
+      "PutActionRevision"
+    ],
+    "tested": [],
+    "untested": [
+      "PutActionRevision"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "PutActionRevision": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ActionType",
+    "operations": [
+      "GetActionType",
+      "UpdateActionType"
+    ],
+    "tested": [
+      "GetActionType"
+    ],
+    "untested": [
+      "UpdateActionType"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "GetActionType": "working",
+      "UpdateActionType": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DeployActionExecutionTargets",
+    "operations": [
+      "ListDeployActionExecutionTargets"
+    ],
+    "tested": [],
+    "untested": [
+      "ListDeployActionExecutionTargets"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListDeployActionExecutionTargets": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/comprehend.json
+++ b/chunks/comprehend.json
@@ -1,0 +1,169 @@
+[
+  {
+    "noun": "DetectDominantLanguage",
+    "operations": [
+      "BatchDetectDominantLanguage",
+      "DetectDominantLanguage"
+    ],
+    "tested": [
+      "DetectDominantLanguage"
+    ],
+    "untested": [
+      "BatchDetectDominantLanguage"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "BatchDetectDominantLanguage": "needs_params",
+      "DetectDominantLanguage": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DetectEntities",
+    "operations": [
+      "BatchDetectEntities",
+      "DetectEntities"
+    ],
+    "tested": [
+      "DetectEntities"
+    ],
+    "untested": [
+      "BatchDetectEntities"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "BatchDetectEntities": "needs_params",
+      "DetectEntities": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DetectKeyPhrases",
+    "operations": [
+      "BatchDetectKeyPhrases",
+      "DetectKeyPhrases"
+    ],
+    "tested": [
+      "DetectKeyPhrases"
+    ],
+    "untested": [
+      "BatchDetectKeyPhrases"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "BatchDetectKeyPhrases": "needs_params",
+      "DetectKeyPhrases": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DetectSentiment",
+    "operations": [
+      "BatchDetectSentiment",
+      "DetectSentiment"
+    ],
+    "tested": [
+      "DetectSentiment"
+    ],
+    "untested": [
+      "BatchDetectSentiment"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "BatchDetectSentiment": "needs_params",
+      "DetectSentiment": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DetectSyntax",
+    "operations": [
+      "BatchDetectSyntax",
+      "DetectSyntax"
+    ],
+    "tested": [
+      "DetectSyntax"
+    ],
+    "untested": [
+      "BatchDetectSyntax"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "BatchDetectSyntax": "needs_params",
+      "DetectSyntax": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DetectTargetedSentiment",
+    "operations": [
+      "BatchDetectTargetedSentiment",
+      "DetectTargetedSentiment"
+    ],
+    "tested": [
+      "DetectTargetedSentiment"
+    ],
+    "untested": [
+      "BatchDetectTargetedSentiment"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "BatchDetectTargetedSentiment": "needs_params",
+      "DetectTargetedSentiment": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DetectToxicContent",
+    "operations": [
+      "DetectToxicContent"
+    ],
+    "tested": [],
+    "untested": [
+      "DetectToxicContent"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DetectToxicContent": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "EventsDetectionJob",
+    "operations": [
+      "DescribeEventsDetectionJob",
+      "StartEventsDetectionJob",
+      "StopEventsDetectionJob"
+    ],
+    "tested": [
+      "DescribeEventsDetectionJob",
+      "StopEventsDetectionJob"
+    ],
+    "untested": [
+      "StartEventsDetectionJob"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeEventsDetectionJob": "working",
+      "StartEventsDetectionJob": "needs_params",
+      "StopEventsDetectionJob": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/config.json
+++ b/chunks/config.json
@@ -1,0 +1,223 @@
+[
+  {
+    "noun": "AggregateResourceConfig",
+    "operations": [
+      "GetAggregateResourceConfig"
+    ],
+    "tested": [],
+    "untested": [
+      "GetAggregateResourceConfig"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetAggregateResourceConfig": "working"
+    },
+    "working_untested": [
+      "GetAggregateResourceConfig"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "OrganizationConfigRuleDetailedStatus",
+    "operations": [
+      "GetOrganizationConfigRuleDetailedStatus"
+    ],
+    "tested": [],
+    "untested": [
+      "GetOrganizationConfigRuleDetailedStatus"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetOrganizationConfigRuleDetailedStatus": "working"
+    },
+    "working_untested": [
+      "GetOrganizationConfigRuleDetailedStatus"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "ConfigurationAggregatorSourcesStatus",
+    "operations": [
+      "DescribeConfigurationAggregatorSourcesStatus"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeConfigurationAggregatorSourcesStatus"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeConfigurationAggregatorSourcesStatus": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ConformancePackComplianceSummary",
+    "operations": [
+      "GetConformancePackComplianceSummary"
+    ],
+    "tested": [],
+    "untested": [
+      "GetConformancePackComplianceSummary"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetConformancePackComplianceSummary": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DeliverConfigSnapshot",
+    "operations": [
+      "DeliverConfigSnapshot"
+    ],
+    "tested": [],
+    "untested": [
+      "DeliverConfigSnapshot"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DeliverConfigSnapshot": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "OrganizationCustomRulePolicy",
+    "operations": [
+      "GetOrganizationCustomRulePolicy"
+    ],
+    "tested": [],
+    "untested": [
+      "GetOrganizationCustomRulePolicy"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetOrganizationCustomRulePolicy": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "PendingAggregationRequest",
+    "operations": [
+      "DeletePendingAggregationRequest"
+    ],
+    "tested": [],
+    "untested": [
+      "DeletePendingAggregationRequest"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DeletePendingAggregationRequest": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "RemediationExceptions",
+    "operations": [
+      "DeleteRemediationExceptions",
+      "DescribeRemediationExceptions",
+      "PutRemediationExceptions"
+    ],
+    "tested": [
+      "DescribeRemediationExceptions"
+    ],
+    "untested": [
+      "DeleteRemediationExceptions",
+      "PutRemediationExceptions"
+    ],
+    "size": 3,
+    "untested_count": 2,
+    "probe_status": {
+      "DeleteRemediationExceptions": "needs_params",
+      "DescribeRemediationExceptions": "working",
+      "PutRemediationExceptions": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "RemediationExecution",
+    "operations": [
+      "StartRemediationExecution"
+    ],
+    "tested": [],
+    "untested": [
+      "StartRemediationExecution"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "StartRemediationExecution": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ResourceTypes",
+    "operations": [
+      "AssociateResourceTypes",
+      "DisassociateResourceTypes"
+    ],
+    "tested": [],
+    "untested": [
+      "AssociateResourceTypes",
+      "DisassociateResourceTypes"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "AssociateResourceTypes": "not_implemented",
+      "DisassociateResourceTypes": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SelectAggregateResourceConfig",
+    "operations": [
+      "SelectAggregateResourceConfig"
+    ],
+    "tested": [],
+    "untested": [
+      "SelectAggregateResourceConfig"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "SelectAggregateResourceConfig": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ServiceLinkedConfigurationRecorder",
+    "operations": [
+      "DeleteServiceLinkedConfigurationRecorder",
+      "PutServiceLinkedConfigurationRecorder"
+    ],
+    "tested": [],
+    "untested": [
+      "DeleteServiceLinkedConfigurationRecorder",
+      "PutServiceLinkedConfigurationRecorder"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "DeleteServiceLinkedConfigurationRecorder": "not_implemented",
+      "PutServiceLinkedConfigurationRecorder": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/connect.json
+++ b/chunks/connect.json
@@ -1,0 +1,2413 @@
+[
+  {
+    "noun": "AnalyticsDataLakeDataSets",
+    "operations": [
+      "ListAnalyticsDataLakeDataSets"
+    ],
+    "tested": [],
+    "untested": [
+      "ListAnalyticsDataLakeDataSets"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListAnalyticsDataLakeDataSets": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "AssociateAnalyticsDataSet",
+    "operations": [
+      "BatchAssociateAnalyticsDataSet"
+    ],
+    "tested": [],
+    "untested": [
+      "BatchAssociateAnalyticsDataSet"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "BatchAssociateAnalyticsDataSet": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "AssociatedContacts",
+    "operations": [
+      "ListAssociatedContacts"
+    ],
+    "tested": [],
+    "untested": [
+      "ListAssociatedContacts"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListAssociatedContacts": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "AttachedFile",
+    "operations": [
+      "DeleteAttachedFile",
+      "GetAttachedFile"
+    ],
+    "tested": [],
+    "untested": [
+      "DeleteAttachedFile",
+      "GetAttachedFile"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "DeleteAttachedFile": "not_implemented",
+      "GetAttachedFile": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "AttachedFileUpload",
+    "operations": [
+      "StartAttachedFileUpload"
+    ],
+    "tested": [],
+    "untested": [
+      "StartAttachedFileUpload"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "StartAttachedFileUpload": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "AuthenticationProfile",
+    "operations": [
+      "DescribeAuthenticationProfile",
+      "UpdateAuthenticationProfile"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeAuthenticationProfile",
+      "UpdateAuthenticationProfile"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "DescribeAuthenticationProfile": "not_implemented",
+      "UpdateAuthenticationProfile": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "AuthenticationProfiles",
+    "operations": [
+      "ListAuthenticationProfiles"
+    ],
+    "tested": [],
+    "untested": [
+      "ListAuthenticationProfiles"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListAuthenticationProfiles": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ChatContact",
+    "operations": [
+      "StartChatContact"
+    ],
+    "tested": [],
+    "untested": [
+      "StartChatContact"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "StartChatContact": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ChatIntegrationEvent",
+    "operations": [
+      "SendChatIntegrationEvent"
+    ],
+    "tested": [],
+    "untested": [
+      "SendChatIntegrationEvent"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "SendChatIntegrationEvent": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ChildHoursOfOperations",
+    "operations": [
+      "ListChildHoursOfOperations"
+    ],
+    "tested": [],
+    "untested": [
+      "ListChildHoursOfOperations"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListChildHoursOfOperations": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "CompleteAttachedFileUpload",
+    "operations": [
+      "CompleteAttachedFileUpload"
+    ],
+    "tested": [],
+    "untested": [
+      "CompleteAttachedFileUpload"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "CompleteAttachedFileUpload": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Contact",
+    "operations": [
+      "CreateContact",
+      "DescribeContact",
+      "MonitorContact",
+      "StopContact",
+      "TagContact",
+      "UntagContact",
+      "UpdateContact"
+    ],
+    "tested": [
+      "CreateContact",
+      "DescribeContact",
+      "StopContact",
+      "UpdateContact"
+    ],
+    "untested": [
+      "MonitorContact",
+      "TagContact",
+      "UntagContact"
+    ],
+    "size": 7,
+    "untested_count": 3,
+    "probe_status": {
+      "CreateContact": "working",
+      "DescribeContact": "working",
+      "MonitorContact": "not_implemented",
+      "StopContact": "working",
+      "TagContact": "not_implemented",
+      "UntagContact": "needs_params",
+      "UpdateContact": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ContactEvaluation",
+    "operations": [
+      "DeleteContactEvaluation",
+      "DescribeContactEvaluation",
+      "StartContactEvaluation",
+      "UpdateContactEvaluation"
+    ],
+    "tested": [],
+    "untested": [
+      "DeleteContactEvaluation",
+      "DescribeContactEvaluation",
+      "StartContactEvaluation",
+      "UpdateContactEvaluation"
+    ],
+    "size": 4,
+    "untested_count": 4,
+    "probe_status": {
+      "DeleteContactEvaluation": "not_implemented",
+      "DescribeContactEvaluation": "not_implemented",
+      "StartContactEvaluation": "not_implemented",
+      "UpdateContactEvaluation": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ContactFlowModuleAlias",
+    "operations": [
+      "CreateContactFlowModuleAlias",
+      "DeleteContactFlowModuleAlias",
+      "DescribeContactFlowModuleAlias",
+      "UpdateContactFlowModuleAlias"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateContactFlowModuleAlias",
+      "DeleteContactFlowModuleAlias",
+      "DescribeContactFlowModuleAlias",
+      "UpdateContactFlowModuleAlias"
+    ],
+    "size": 4,
+    "untested_count": 4,
+    "probe_status": {
+      "CreateContactFlowModuleAlias": "not_implemented",
+      "DeleteContactFlowModuleAlias": "not_implemented",
+      "DescribeContactFlowModuleAlias": "not_implemented",
+      "UpdateContactFlowModuleAlias": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ContactFlowModuleAliases",
+    "operations": [
+      "ListContactFlowModuleAliases"
+    ],
+    "tested": [],
+    "untested": [
+      "ListContactFlowModuleAliases"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListContactFlowModuleAliases": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ContactFlowModuleVersion",
+    "operations": [
+      "CreateContactFlowModuleVersion",
+      "DeleteContactFlowModuleVersion"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateContactFlowModuleVersion",
+      "DeleteContactFlowModuleVersion"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "CreateContactFlowModuleVersion": "not_implemented",
+      "DeleteContactFlowModuleVersion": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ContactFlowModuleVersions",
+    "operations": [
+      "ListContactFlowModuleVersions"
+    ],
+    "tested": [],
+    "untested": [
+      "ListContactFlowModuleVersions"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListContactFlowModuleVersions": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ContactFlowVersion",
+    "operations": [
+      "CreateContactFlowVersion",
+      "DeleteContactFlowVersion"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateContactFlowVersion",
+      "DeleteContactFlowVersion"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "CreateContactFlowVersion": "not_implemented",
+      "DeleteContactFlowVersion": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ContactMediaProcessing",
+    "operations": [
+      "StartContactMediaProcessing",
+      "StopContactMediaProcessing"
+    ],
+    "tested": [],
+    "untested": [
+      "StartContactMediaProcessing",
+      "StopContactMediaProcessing"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "StartContactMediaProcessing": "not_implemented",
+      "StopContactMediaProcessing": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ContactMetrics",
+    "operations": [
+      "GetContactMetrics"
+    ],
+    "tested": [],
+    "untested": [
+      "GetContactMetrics"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetContactMetrics": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ContactRecording",
+    "operations": [
+      "StartContactRecording",
+      "StopContactRecording"
+    ],
+    "tested": [],
+    "untested": [
+      "StartContactRecording",
+      "StopContactRecording"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "StartContactRecording": "not_implemented",
+      "StopContactRecording": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ContactRoutingData",
+    "operations": [
+      "UpdateContactRoutingData"
+    ],
+    "tested": [],
+    "untested": [
+      "UpdateContactRoutingData"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "UpdateContactRoutingData": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ContactSchedule",
+    "operations": [
+      "UpdateContactSchedule"
+    ],
+    "tested": [],
+    "untested": [
+      "UpdateContactSchedule"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "UpdateContactSchedule": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ContactStreaming",
+    "operations": [
+      "StartContactStreaming",
+      "StopContactStreaming"
+    ],
+    "tested": [],
+    "untested": [
+      "StartContactStreaming",
+      "StopContactStreaming"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "StartContactStreaming": "not_implemented",
+      "StopContactStreaming": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ContactWithUser",
+    "operations": [
+      "AssociateContactWithUser"
+    ],
+    "tested": [],
+    "untested": [
+      "AssociateContactWithUser"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "AssociateContactWithUser": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "CreateDataTableValue",
+    "operations": [
+      "BatchCreateDataTableValue"
+    ],
+    "tested": [],
+    "untested": [
+      "BatchCreateDataTableValue"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "BatchCreateDataTableValue": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "CurrentMetricData",
+    "operations": [
+      "GetCurrentMetricData"
+    ],
+    "tested": [],
+    "untested": [
+      "GetCurrentMetricData"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetCurrentMetricData": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "CurrentUserData",
+    "operations": [
+      "GetCurrentUserData"
+    ],
+    "tested": [],
+    "untested": [
+      "GetCurrentUserData"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetCurrentUserData": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DataTable",
+    "operations": [
+      "CreateDataTable",
+      "DeleteDataTable",
+      "DescribeDataTable"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateDataTable",
+      "DeleteDataTable",
+      "DescribeDataTable"
+    ],
+    "size": 3,
+    "untested_count": 3,
+    "probe_status": {
+      "CreateDataTable": "not_implemented",
+      "DeleteDataTable": "not_implemented",
+      "DescribeDataTable": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DataTableAttribute",
+    "operations": [
+      "CreateDataTableAttribute",
+      "DeleteDataTableAttribute",
+      "DescribeDataTableAttribute",
+      "UpdateDataTableAttribute"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateDataTableAttribute",
+      "DeleteDataTableAttribute",
+      "DescribeDataTableAttribute",
+      "UpdateDataTableAttribute"
+    ],
+    "size": 4,
+    "untested_count": 4,
+    "probe_status": {
+      "CreateDataTableAttribute": "not_implemented",
+      "DeleteDataTableAttribute": "not_implemented",
+      "DescribeDataTableAttribute": "not_implemented",
+      "UpdateDataTableAttribute": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DataTableAttributes",
+    "operations": [
+      "ListDataTableAttributes"
+    ],
+    "tested": [],
+    "untested": [
+      "ListDataTableAttributes"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListDataTableAttributes": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DataTableMetadata",
+    "operations": [
+      "UpdateDataTableMetadata"
+    ],
+    "tested": [],
+    "untested": [
+      "UpdateDataTableMetadata"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "UpdateDataTableMetadata": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DataTablePrimaryValues",
+    "operations": [
+      "ListDataTablePrimaryValues",
+      "UpdateDataTablePrimaryValues"
+    ],
+    "tested": [],
+    "untested": [
+      "ListDataTablePrimaryValues",
+      "UpdateDataTablePrimaryValues"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "ListDataTablePrimaryValues": "not_implemented",
+      "UpdateDataTablePrimaryValues": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DataTableValues",
+    "operations": [
+      "ListDataTableValues"
+    ],
+    "tested": [],
+    "untested": [
+      "ListDataTableValues"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListDataTableValues": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DataTables",
+    "operations": [
+      "ListDataTables"
+    ],
+    "tested": [],
+    "untested": [
+      "ListDataTables"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListDataTables": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DefaultVocabulary",
+    "operations": [
+      "AssociateDefaultVocabulary"
+    ],
+    "tested": [],
+    "untested": [
+      "AssociateDefaultVocabulary"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "AssociateDefaultVocabulary": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DeleteDataTableValue",
+    "operations": [
+      "BatchDeleteDataTableValue"
+    ],
+    "tested": [],
+    "untested": [
+      "BatchDeleteDataTableValue"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "BatchDeleteDataTableValue": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DescribeDataTableValue",
+    "operations": [
+      "BatchDescribeDataTableValue"
+    ],
+    "tested": [],
+    "untested": [
+      "BatchDescribeDataTableValue"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "BatchDescribeDataTableValue": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DisassociateAnalyticsDataSet",
+    "operations": [
+      "BatchDisassociateAnalyticsDataSet"
+    ],
+    "tested": [],
+    "untested": [
+      "BatchDisassociateAnalyticsDataSet"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "BatchDisassociateAnalyticsDataSet": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DismissUserContact",
+    "operations": [
+      "DismissUserContact"
+    ],
+    "tested": [],
+    "untested": [
+      "DismissUserContact"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DismissUserContact": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "EffectiveHoursOfOperations",
+    "operations": [
+      "GetEffectiveHoursOfOperations"
+    ],
+    "tested": [],
+    "untested": [
+      "GetEffectiveHoursOfOperations"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetEffectiveHoursOfOperations": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "EmailAddress",
+    "operations": [
+      "CreateEmailAddress",
+      "DeleteEmailAddress",
+      "DescribeEmailAddress"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateEmailAddress",
+      "DeleteEmailAddress",
+      "DescribeEmailAddress"
+    ],
+    "size": 3,
+    "untested_count": 3,
+    "probe_status": {
+      "CreateEmailAddress": "not_implemented",
+      "DeleteEmailAddress": "not_implemented",
+      "DescribeEmailAddress": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "EmailAddressAlias",
+    "operations": [
+      "AssociateEmailAddressAlias",
+      "DisassociateEmailAddressAlias"
+    ],
+    "tested": [],
+    "untested": [
+      "AssociateEmailAddressAlias",
+      "DisassociateEmailAddressAlias"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "AssociateEmailAddressAlias": "not_implemented",
+      "DisassociateEmailAddressAlias": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "EmailAddressMetadata",
+    "operations": [
+      "UpdateEmailAddressMetadata"
+    ],
+    "tested": [],
+    "untested": [
+      "UpdateEmailAddressMetadata"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "UpdateEmailAddressMetadata": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "EmailContact",
+    "operations": [
+      "StartEmailContact"
+    ],
+    "tested": [],
+    "untested": [
+      "StartEmailContact"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "StartEmailContact": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "EntitySecurityProfiles",
+    "operations": [
+      "ListEntitySecurityProfiles"
+    ],
+    "tested": [],
+    "untested": [
+      "ListEntitySecurityProfiles"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListEntitySecurityProfiles": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "EvaluateDataTableValues",
+    "operations": [
+      "EvaluateDataTableValues"
+    ],
+    "tested": [],
+    "untested": [
+      "EvaluateDataTableValues"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "EvaluateDataTableValues": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "FederationToken",
+    "operations": [
+      "GetFederationToken"
+    ],
+    "tested": [],
+    "untested": [
+      "GetFederationToken"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetFederationToken": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Flow",
+    "operations": [
+      "AssociateFlow",
+      "DisassociateFlow"
+    ],
+    "tested": [],
+    "untested": [
+      "AssociateFlow",
+      "DisassociateFlow"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "AssociateFlow": "not_implemented",
+      "DisassociateFlow": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "FlowAssociation",
+    "operations": [
+      "GetFlowAssociation"
+    ],
+    "tested": [],
+    "untested": [
+      "GetFlowAssociation"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetFlowAssociation": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "GetAttachedFileMetadata",
+    "operations": [
+      "BatchGetAttachedFileMetadata"
+    ],
+    "tested": [],
+    "untested": [
+      "BatchGetAttachedFileMetadata"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "BatchGetAttachedFileMetadata": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "GetFlowAssociation",
+    "operations": [
+      "BatchGetFlowAssociation"
+    ],
+    "tested": [],
+    "untested": [
+      "BatchGetFlowAssociation"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "BatchGetFlowAssociation": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "HoursOfOperations",
+    "operations": [
+      "AssociateHoursOfOperations",
+      "DisassociateHoursOfOperations",
+      "ListHoursOfOperations"
+    ],
+    "tested": [
+      "ListHoursOfOperations"
+    ],
+    "untested": [
+      "AssociateHoursOfOperations",
+      "DisassociateHoursOfOperations"
+    ],
+    "size": 3,
+    "untested_count": 2,
+    "probe_status": {
+      "AssociateHoursOfOperations": "not_implemented",
+      "DisassociateHoursOfOperations": "needs_params",
+      "ListHoursOfOperations": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "InstanceStorageConfig",
+    "operations": [
+      "AssociateInstanceStorageConfig",
+      "DescribeInstanceStorageConfig",
+      "DisassociateInstanceStorageConfig",
+      "UpdateInstanceStorageConfig"
+    ],
+    "tested": [
+      "AssociateInstanceStorageConfig",
+      "DisassociateInstanceStorageConfig"
+    ],
+    "untested": [
+      "DescribeInstanceStorageConfig",
+      "UpdateInstanceStorageConfig"
+    ],
+    "size": 4,
+    "untested_count": 2,
+    "probe_status": {
+      "AssociateInstanceStorageConfig": "working",
+      "DescribeInstanceStorageConfig": "not_implemented",
+      "DisassociateInstanceStorageConfig": "working",
+      "UpdateInstanceStorageConfig": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "IntegrationAssociation",
+    "operations": [
+      "CreateIntegrationAssociation",
+      "DeleteIntegrationAssociation"
+    ],
+    "tested": [
+      "CreateIntegrationAssociation"
+    ],
+    "untested": [
+      "DeleteIntegrationAssociation"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateIntegrationAssociation": "working",
+      "DeleteIntegrationAssociation": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "LexBot",
+    "operations": [
+      "AssociateLexBot",
+      "DisassociateLexBot"
+    ],
+    "tested": [],
+    "untested": [
+      "AssociateLexBot",
+      "DisassociateLexBot"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "AssociateLexBot": "not_implemented",
+      "DisassociateLexBot": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "LexBots",
+    "operations": [
+      "ListLexBots"
+    ],
+    "tested": [],
+    "untested": [
+      "ListLexBots"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListLexBots": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "MetricData",
+    "operations": [
+      "GetMetricData"
+    ],
+    "tested": [],
+    "untested": [
+      "GetMetricData"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetMetricData": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "MetricDataV2",
+    "operations": [
+      "GetMetricDataV2"
+    ],
+    "tested": [],
+    "untested": [
+      "GetMetricDataV2"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetMetricDataV2": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Notification",
+    "operations": [
+      "CreateNotification",
+      "DeleteNotification",
+      "DescribeNotification"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateNotification",
+      "DeleteNotification",
+      "DescribeNotification"
+    ],
+    "size": 3,
+    "untested_count": 3,
+    "probe_status": {
+      "CreateNotification": "not_implemented",
+      "DeleteNotification": "not_implemented",
+      "DescribeNotification": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "NotificationContent",
+    "operations": [
+      "UpdateNotificationContent"
+    ],
+    "tested": [],
+    "untested": [
+      "UpdateNotificationContent"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "UpdateNotificationContent": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Notifications",
+    "operations": [
+      "ListNotifications"
+    ],
+    "tested": [],
+    "untested": [
+      "ListNotifications"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListNotifications": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "OutboundChatContact",
+    "operations": [
+      "StartOutboundChatContact"
+    ],
+    "tested": [],
+    "untested": [
+      "StartOutboundChatContact"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "StartOutboundChatContact": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "OutboundEmail",
+    "operations": [
+      "SendOutboundEmail"
+    ],
+    "tested": [],
+    "untested": [
+      "SendOutboundEmail"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "SendOutboundEmail": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "OutboundEmailContact",
+    "operations": [
+      "StartOutboundEmailContact"
+    ],
+    "tested": [],
+    "untested": [
+      "StartOutboundEmailContact"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "StartOutboundEmailContact": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "OutboundVoiceContact",
+    "operations": [
+      "StartOutboundVoiceContact"
+    ],
+    "tested": [],
+    "untested": [
+      "StartOutboundVoiceContact"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "StartOutboundVoiceContact": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Participant",
+    "operations": [
+      "CreateParticipant"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateParticipant"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateParticipant": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ParticipantAuthentication",
+    "operations": [
+      "UpdateParticipantAuthentication"
+    ],
+    "tested": [],
+    "untested": [
+      "UpdateParticipantAuthentication"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "UpdateParticipantAuthentication": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ParticipantRoleConfig",
+    "operations": [
+      "UpdateParticipantRoleConfig"
+    ],
+    "tested": [],
+    "untested": [
+      "UpdateParticipantRoleConfig"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "UpdateParticipantRoleConfig": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "PauseContact",
+    "operations": [
+      "PauseContact"
+    ],
+    "tested": [],
+    "untested": [
+      "PauseContact"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "PauseContact": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "PersistentContactAssociation",
+    "operations": [
+      "CreatePersistentContactAssociation"
+    ],
+    "tested": [],
+    "untested": [
+      "CreatePersistentContactAssociation"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "CreatePersistentContactAssociation": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "PhoneNumber",
+    "operations": [
+      "DescribePhoneNumber",
+      "ImportPhoneNumber",
+      "ReleasePhoneNumber",
+      "UpdatePhoneNumber"
+    ],
+    "tested": [
+      "DescribePhoneNumber",
+      "ReleasePhoneNumber",
+      "UpdatePhoneNumber"
+    ],
+    "untested": [
+      "ImportPhoneNumber"
+    ],
+    "size": 4,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribePhoneNumber": "working",
+      "ImportPhoneNumber": "not_implemented",
+      "ReleasePhoneNumber": "working",
+      "UpdatePhoneNumber": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "PhoneNumberContactFlow",
+    "operations": [
+      "AssociatePhoneNumberContactFlow",
+      "DisassociatePhoneNumberContactFlow"
+    ],
+    "tested": [],
+    "untested": [
+      "AssociatePhoneNumberContactFlow",
+      "DisassociatePhoneNumberContactFlow"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "AssociatePhoneNumberContactFlow": "not_implemented",
+      "DisassociatePhoneNumberContactFlow": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "PhoneNumberMetadata",
+    "operations": [
+      "UpdatePhoneNumberMetadata"
+    ],
+    "tested": [],
+    "untested": [
+      "UpdatePhoneNumberMetadata"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "UpdatePhoneNumberMetadata": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "PromptFile",
+    "operations": [
+      "GetPromptFile"
+    ],
+    "tested": [],
+    "untested": [
+      "GetPromptFile"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetPromptFile": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "PushNotificationRegistration",
+    "operations": [
+      "CreatePushNotificationRegistration",
+      "DeletePushNotificationRegistration"
+    ],
+    "tested": [],
+    "untested": [
+      "CreatePushNotificationRegistration",
+      "DeletePushNotificationRegistration"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "CreatePushNotificationRegistration": "not_implemented",
+      "DeletePushNotificationRegistration": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "PutContact",
+    "operations": [
+      "BatchPutContact"
+    ],
+    "tested": [],
+    "untested": [
+      "BatchPutContact"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "BatchPutContact": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "QueueEmailAddresses",
+    "operations": [
+      "AssociateQueueEmailAddresses",
+      "DisassociateQueueEmailAddresses",
+      "ListQueueEmailAddresses"
+    ],
+    "tested": [],
+    "untested": [
+      "AssociateQueueEmailAddresses",
+      "DisassociateQueueEmailAddresses",
+      "ListQueueEmailAddresses"
+    ],
+    "size": 3,
+    "untested_count": 3,
+    "probe_status": {
+      "AssociateQueueEmailAddresses": "needs_params",
+      "DisassociateQueueEmailAddresses": "needs_params",
+      "ListQueueEmailAddresses": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "QueueOutboundEmailConfig",
+    "operations": [
+      "UpdateQueueOutboundEmailConfig"
+    ],
+    "tested": [],
+    "untested": [
+      "UpdateQueueOutboundEmailConfig"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "UpdateQueueOutboundEmailConfig": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "RealtimeContactAnalysisSegmentsV2",
+    "operations": [
+      "ListRealtimeContactAnalysisSegmentsV2"
+    ],
+    "tested": [],
+    "untested": [
+      "ListRealtimeContactAnalysisSegmentsV2"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListRealtimeContactAnalysisSegmentsV2": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ReplicateInstance",
+    "operations": [
+      "ReplicateInstance"
+    ],
+    "tested": [],
+    "untested": [
+      "ReplicateInstance"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ReplicateInstance": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ResumeContact",
+    "operations": [
+      "ResumeContact"
+    ],
+    "tested": [],
+    "untested": [
+      "ResumeContact"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ResumeContact": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ResumeContactRecording",
+    "operations": [
+      "ResumeContactRecording"
+    ],
+    "tested": [],
+    "untested": [
+      "ResumeContactRecording"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ResumeContactRecording": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "RoutingProfileAgentAvailabilityTimer",
+    "operations": [
+      "UpdateRoutingProfileAgentAvailabilityTimer"
+    ],
+    "tested": [],
+    "untested": [
+      "UpdateRoutingProfileAgentAvailabilityTimer"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "UpdateRoutingProfileAgentAvailabilityTimer": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "RoutingProfileManualAssignmentQueues",
+    "operations": [
+      "ListRoutingProfileManualAssignmentQueues"
+    ],
+    "tested": [],
+    "untested": [
+      "ListRoutingProfileManualAssignmentQueues"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListRoutingProfileManualAssignmentQueues": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ScreenSharing",
+    "operations": [
+      "StartScreenSharing"
+    ],
+    "tested": [],
+    "untested": [
+      "StartScreenSharing"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "StartScreenSharing": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SearchContactEvaluations",
+    "operations": [
+      "SearchContactEvaluations"
+    ],
+    "tested": [],
+    "untested": [
+      "SearchContactEvaluations"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "SearchContactEvaluations": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SearchContacts",
+    "operations": [
+      "SearchContacts"
+    ],
+    "tested": [],
+    "untested": [
+      "SearchContacts"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "SearchContacts": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SearchDataTables",
+    "operations": [
+      "SearchDataTables"
+    ],
+    "tested": [],
+    "untested": [
+      "SearchDataTables"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "SearchDataTables": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SearchEmailAddresses",
+    "operations": [
+      "SearchEmailAddresses"
+    ],
+    "tested": [],
+    "untested": [
+      "SearchEmailAddresses"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "SearchEmailAddresses": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SearchEvaluationForms",
+    "operations": [
+      "SearchEvaluationForms"
+    ],
+    "tested": [],
+    "untested": [
+      "SearchEvaluationForms"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "SearchEvaluationForms": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SearchHoursOfOperationOverrides",
+    "operations": [
+      "SearchHoursOfOperationOverrides"
+    ],
+    "tested": [],
+    "untested": [
+      "SearchHoursOfOperationOverrides"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "SearchHoursOfOperationOverrides": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SearchNotifications",
+    "operations": [
+      "SearchNotifications"
+    ],
+    "tested": [],
+    "untested": [
+      "SearchNotifications"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "SearchNotifications": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SearchResourceTags",
+    "operations": [
+      "SearchResourceTags"
+    ],
+    "tested": [],
+    "untested": [
+      "SearchResourceTags"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "SearchResourceTags": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SearchTestCases",
+    "operations": [
+      "SearchTestCases"
+    ],
+    "tested": [],
+    "untested": [
+      "SearchTestCases"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "SearchTestCases": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SearchViews",
+    "operations": [
+      "SearchViews"
+    ],
+    "tested": [],
+    "untested": [
+      "SearchViews"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "SearchViews": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SearchWorkspaceAssociations",
+    "operations": [
+      "SearchWorkspaceAssociations"
+    ],
+    "tested": [],
+    "untested": [
+      "SearchWorkspaceAssociations"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "SearchWorkspaceAssociations": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SearchWorkspaces",
+    "operations": [
+      "SearchWorkspaces"
+    ],
+    "tested": [],
+    "untested": [
+      "SearchWorkspaces"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "SearchWorkspaces": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SecurityProfileFlowModules",
+    "operations": [
+      "ListSecurityProfileFlowModules"
+    ],
+    "tested": [],
+    "untested": [
+      "ListSecurityProfileFlowModules"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListSecurityProfileFlowModules": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SecurityProfiles",
+    "operations": [
+      "AssociateSecurityProfiles",
+      "DisassociateSecurityProfiles",
+      "ListSecurityProfiles"
+    ],
+    "tested": [
+      "ListSecurityProfiles"
+    ],
+    "untested": [
+      "AssociateSecurityProfiles",
+      "DisassociateSecurityProfiles"
+    ],
+    "size": 3,
+    "untested_count": 2,
+    "probe_status": {
+      "AssociateSecurityProfiles": "needs_params",
+      "DisassociateSecurityProfiles": "needs_params",
+      "ListSecurityProfiles": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SubmitContactEvaluation",
+    "operations": [
+      "SubmitContactEvaluation"
+    ],
+    "tested": [],
+    "untested": [
+      "SubmitContactEvaluation"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "SubmitContactEvaluation": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SuspendContactRecording",
+    "operations": [
+      "SuspendContactRecording"
+    ],
+    "tested": [],
+    "untested": [
+      "SuspendContactRecording"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "SuspendContactRecording": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TaskContact",
+    "operations": [
+      "StartTaskContact"
+    ],
+    "tested": [],
+    "untested": [
+      "StartTaskContact"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "StartTaskContact": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TestCase",
+    "operations": [
+      "CreateTestCase",
+      "DeleteTestCase",
+      "DescribeTestCase",
+      "UpdateTestCase"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateTestCase",
+      "DeleteTestCase",
+      "DescribeTestCase",
+      "UpdateTestCase"
+    ],
+    "size": 4,
+    "untested_count": 4,
+    "probe_status": {
+      "CreateTestCase": "not_implemented",
+      "DeleteTestCase": "not_implemented",
+      "DescribeTestCase": "not_implemented",
+      "UpdateTestCase": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TestCaseExecution",
+    "operations": [
+      "StartTestCaseExecution",
+      "StopTestCaseExecution"
+    ],
+    "tested": [],
+    "untested": [
+      "StartTestCaseExecution",
+      "StopTestCaseExecution"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "StartTestCaseExecution": "not_implemented",
+      "StopTestCaseExecution": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TestCaseExecutionRecords",
+    "operations": [
+      "ListTestCaseExecutionRecords"
+    ],
+    "tested": [],
+    "untested": [
+      "ListTestCaseExecutionRecords"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListTestCaseExecutionRecords": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TestCaseExecutionSummary",
+    "operations": [
+      "GetTestCaseExecutionSummary"
+    ],
+    "tested": [],
+    "untested": [
+      "GetTestCaseExecutionSummary"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetTestCaseExecutionSummary": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TestCaseExecutions",
+    "operations": [
+      "ListTestCaseExecutions"
+    ],
+    "tested": [],
+    "untested": [
+      "ListTestCaseExecutions"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListTestCaseExecutions": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TestCases",
+    "operations": [
+      "ListTestCases"
+    ],
+    "tested": [],
+    "untested": [
+      "ListTestCases"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListTestCases": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TrafficDistribution",
+    "operations": [
+      "GetTrafficDistribution",
+      "UpdateTrafficDistribution"
+    ],
+    "tested": [],
+    "untested": [
+      "GetTrafficDistribution",
+      "UpdateTrafficDistribution"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "GetTrafficDistribution": "not_implemented",
+      "UpdateTrafficDistribution": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TrafficDistributionGroupUser",
+    "operations": [
+      "AssociateTrafficDistributionGroupUser",
+      "DisassociateTrafficDistributionGroupUser"
+    ],
+    "tested": [],
+    "untested": [
+      "AssociateTrafficDistributionGroupUser",
+      "DisassociateTrafficDistributionGroupUser"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "AssociateTrafficDistributionGroupUser": "not_implemented",
+      "DisassociateTrafficDistributionGroupUser": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TrafficDistributionGroupUsers",
+    "operations": [
+      "ListTrafficDistributionGroupUsers"
+    ],
+    "tested": [],
+    "untested": [
+      "ListTrafficDistributionGroupUsers"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListTrafficDistributionGroupUsers": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TransferContact",
+    "operations": [
+      "TransferContact"
+    ],
+    "tested": [],
+    "untested": [
+      "TransferContact"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "TransferContact": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "UpdateDataTableValue",
+    "operations": [
+      "BatchUpdateDataTableValue"
+    ],
+    "tested": [],
+    "untested": [
+      "BatchUpdateDataTableValue"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "BatchUpdateDataTableValue": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "UserConfig",
+    "operations": [
+      "UpdateUserConfig"
+    ],
+    "tested": [],
+    "untested": [
+      "UpdateUserConfig"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "UpdateUserConfig": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "UserNotificationStatus",
+    "operations": [
+      "UpdateUserNotificationStatus"
+    ],
+    "tested": [],
+    "untested": [
+      "UpdateUserNotificationStatus"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "UpdateUserNotificationStatus": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "UserNotifications",
+    "operations": [
+      "ListUserNotifications"
+    ],
+    "tested": [],
+    "untested": [
+      "ListUserNotifications"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListUserNotifications": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "UserProficiencies",
+    "operations": [
+      "AssociateUserProficiencies",
+      "DisassociateUserProficiencies",
+      "ListUserProficiencies",
+      "UpdateUserProficiencies"
+    ],
+    "tested": [],
+    "untested": [
+      "AssociateUserProficiencies",
+      "DisassociateUserProficiencies",
+      "ListUserProficiencies",
+      "UpdateUserProficiencies"
+    ],
+    "size": 4,
+    "untested_count": 4,
+    "probe_status": {
+      "AssociateUserProficiencies": "not_implemented",
+      "DisassociateUserProficiencies": "not_implemented",
+      "ListUserProficiencies": "not_implemented",
+      "UpdateUserProficiencies": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "UserStatus",
+    "operations": [
+      "PutUserStatus"
+    ],
+    "tested": [],
+    "untested": [
+      "PutUserStatus"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "PutUserStatus": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ViewVersion",
+    "operations": [
+      "CreateViewVersion",
+      "DeleteViewVersion"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateViewVersion",
+      "DeleteViewVersion"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "CreateViewVersion": "not_implemented",
+      "DeleteViewVersion": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ViewVersions",
+    "operations": [
+      "ListViewVersions"
+    ],
+    "tested": [],
+    "untested": [
+      "ListViewVersions"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListViewVersions": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "WebRTCContact",
+    "operations": [
+      "StartWebRTCContact"
+    ],
+    "tested": [],
+    "untested": [
+      "StartWebRTCContact"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "StartWebRTCContact": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Workspace",
+    "operations": [
+      "AssociateWorkspace",
+      "CreateWorkspace",
+      "DeleteWorkspace",
+      "DescribeWorkspace",
+      "DisassociateWorkspace"
+    ],
+    "tested": [],
+    "untested": [
+      "AssociateWorkspace",
+      "CreateWorkspace",
+      "DeleteWorkspace",
+      "DescribeWorkspace",
+      "DisassociateWorkspace"
+    ],
+    "size": 5,
+    "untested_count": 5,
+    "probe_status": {
+      "AssociateWorkspace": "needs_params",
+      "CreateWorkspace": "not_implemented",
+      "DeleteWorkspace": "not_implemented",
+      "DescribeWorkspace": "not_implemented",
+      "DisassociateWorkspace": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "WorkspaceMedia",
+    "operations": [
+      "DeleteWorkspaceMedia",
+      "ImportWorkspaceMedia",
+      "ListWorkspaceMedia"
+    ],
+    "tested": [],
+    "untested": [
+      "DeleteWorkspaceMedia",
+      "ImportWorkspaceMedia",
+      "ListWorkspaceMedia"
+    ],
+    "size": 3,
+    "untested_count": 3,
+    "probe_status": {
+      "DeleteWorkspaceMedia": "not_implemented",
+      "ImportWorkspaceMedia": "not_implemented",
+      "ListWorkspaceMedia": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "WorkspaceMetadata",
+    "operations": [
+      "UpdateWorkspaceMetadata"
+    ],
+    "tested": [],
+    "untested": [
+      "UpdateWorkspaceMetadata"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "UpdateWorkspaceMetadata": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "WorkspacePage",
+    "operations": [
+      "CreateWorkspacePage",
+      "DeleteWorkspacePage",
+      "UpdateWorkspacePage"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateWorkspacePage",
+      "DeleteWorkspacePage",
+      "UpdateWorkspacePage"
+    ],
+    "size": 3,
+    "untested_count": 3,
+    "probe_status": {
+      "CreateWorkspacePage": "not_implemented",
+      "DeleteWorkspacePage": "not_implemented",
+      "UpdateWorkspacePage": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "WorkspacePages",
+    "operations": [
+      "ListWorkspacePages"
+    ],
+    "tested": [],
+    "untested": [
+      "ListWorkspacePages"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListWorkspacePages": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "WorkspaceTheme",
+    "operations": [
+      "UpdateWorkspaceTheme"
+    ],
+    "tested": [],
+    "untested": [
+      "UpdateWorkspaceTheme"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "UpdateWorkspaceTheme": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "WorkspaceVisibility",
+    "operations": [
+      "UpdateWorkspaceVisibility"
+    ],
+    "tested": [],
+    "untested": [
+      "UpdateWorkspaceVisibility"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "UpdateWorkspaceVisibility": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Workspaces",
+    "operations": [
+      "ListWorkspaces"
+    ],
+    "tested": [],
+    "untested": [
+      "ListWorkspaces"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListWorkspaces": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/connectcampaigns.json
+++ b/chunks/connectcampaigns.json
@@ -1,0 +1,146 @@
+[
+  {
+    "noun": "CampaignDialerConfig",
+    "operations": [
+      "UpdateCampaignDialerConfig"
+    ],
+    "tested": [],
+    "untested": [
+      "UpdateCampaignDialerConfig"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "UpdateCampaignDialerConfig": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "CampaignName",
+    "operations": [
+      "UpdateCampaignName"
+    ],
+    "tested": [],
+    "untested": [
+      "UpdateCampaignName"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "UpdateCampaignName": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "CampaignOutboundCallConfig",
+    "operations": [
+      "UpdateCampaignOutboundCallConfig"
+    ],
+    "tested": [],
+    "untested": [
+      "UpdateCampaignOutboundCallConfig"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "UpdateCampaignOutboundCallConfig": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "CampaignStateBatch",
+    "operations": [
+      "GetCampaignStateBatch"
+    ],
+    "tested": [],
+    "untested": [
+      "GetCampaignStateBatch"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetCampaignStateBatch": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ConnectInstanceConfig",
+    "operations": [
+      "DeleteConnectInstanceConfig",
+      "GetConnectInstanceConfig"
+    ],
+    "tested": [
+      "GetConnectInstanceConfig"
+    ],
+    "untested": [
+      "DeleteConnectInstanceConfig"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "DeleteConnectInstanceConfig": "not_implemented",
+      "GetConnectInstanceConfig": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DialRequestBatch",
+    "operations": [
+      "PutDialRequestBatch"
+    ],
+    "tested": [],
+    "untested": [
+      "PutDialRequestBatch"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "PutDialRequestBatch": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "InstanceOnboardingJob",
+    "operations": [
+      "DeleteInstanceOnboardingJob",
+      "StartInstanceOnboardingJob"
+    ],
+    "tested": [
+      "StartInstanceOnboardingJob"
+    ],
+    "untested": [
+      "DeleteInstanceOnboardingJob"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "DeleteInstanceOnboardingJob": "not_implemented",
+      "StartInstanceOnboardingJob": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "InstanceOnboardingJobStatus",
+    "operations": [
+      "GetInstanceOnboardingJobStatus"
+    ],
+    "tested": [],
+    "untested": [
+      "GetInstanceOnboardingJobStatus"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetInstanceOnboardingJobStatus": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/databrew.json
+++ b/chunks/databrew.json
@@ -1,0 +1,216 @@
+[
+  {
+    "noun": "DeleteRecipeVersion",
+    "operations": [
+      "BatchDeleteRecipeVersion"
+    ],
+    "tested": [],
+    "untested": [
+      "BatchDeleteRecipeVersion"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "BatchDeleteRecipeVersion": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "JobRun",
+    "operations": [
+      "DescribeJobRun",
+      "StartJobRun",
+      "StopJobRun"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeJobRun",
+      "StartJobRun",
+      "StopJobRun"
+    ],
+    "size": 3,
+    "untested_count": 3,
+    "probe_status": {
+      "DescribeJobRun": "not_implemented",
+      "StartJobRun": "not_implemented",
+      "StopJobRun": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "JobRuns",
+    "operations": [
+      "ListJobRuns"
+    ],
+    "tested": [],
+    "untested": [
+      "ListJobRuns"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListJobRuns": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Project",
+    "operations": [
+      "CreateProject",
+      "DeleteProject",
+      "DescribeProject",
+      "UpdateProject"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateProject",
+      "DeleteProject",
+      "DescribeProject",
+      "UpdateProject"
+    ],
+    "size": 4,
+    "untested_count": 4,
+    "probe_status": {
+      "CreateProject": "not_implemented",
+      "DeleteProject": "not_implemented",
+      "DescribeProject": "not_implemented",
+      "UpdateProject": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ProjectSession",
+    "operations": [
+      "StartProjectSession"
+    ],
+    "tested": [],
+    "untested": [
+      "StartProjectSession"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "StartProjectSession": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ProjectSessionAction",
+    "operations": [
+      "SendProjectSessionAction"
+    ],
+    "tested": [],
+    "untested": [
+      "SendProjectSessionAction"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "SendProjectSessionAction": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Projects",
+    "operations": [
+      "ListProjects"
+    ],
+    "tested": [],
+    "untested": [
+      "ListProjects"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListProjects": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Resource",
+    "operations": [
+      "TagResource",
+      "UntagResource"
+    ],
+    "tested": [],
+    "untested": [
+      "TagResource",
+      "UntagResource"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "TagResource": "not_implemented",
+      "UntagResource": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Schedule",
+    "operations": [
+      "CreateSchedule",
+      "DeleteSchedule",
+      "DescribeSchedule",
+      "UpdateSchedule"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateSchedule",
+      "DeleteSchedule",
+      "DescribeSchedule",
+      "UpdateSchedule"
+    ],
+    "size": 4,
+    "untested_count": 4,
+    "probe_status": {
+      "CreateSchedule": "not_implemented",
+      "DeleteSchedule": "not_implemented",
+      "DescribeSchedule": "not_implemented",
+      "UpdateSchedule": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Schedules",
+    "operations": [
+      "ListSchedules"
+    ],
+    "tested": [],
+    "untested": [
+      "ListSchedules"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListSchedules": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TagsForResource",
+    "operations": [
+      "ListTagsForResource"
+    ],
+    "tested": [],
+    "untested": [
+      "ListTagsForResource"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListTagsForResource": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/datapipeline.json
+++ b/chunks/datapipeline.json
@@ -1,0 +1,117 @@
+[
+  {
+    "noun": "EvaluateExpression",
+    "operations": [
+      "EvaluateExpression"
+    ],
+    "tested": [],
+    "untested": [
+      "EvaluateExpression"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "EvaluateExpression": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Pipeline",
+    "operations": [
+      "ActivatePipeline",
+      "CreatePipeline",
+      "DeactivatePipeline",
+      "DeletePipeline"
+    ],
+    "tested": [
+      "ActivatePipeline",
+      "CreatePipeline",
+      "DeletePipeline"
+    ],
+    "untested": [
+      "DeactivatePipeline"
+    ],
+    "size": 4,
+    "untested_count": 1,
+    "probe_status": {
+      "ActivatePipeline": "500_error",
+      "CreatePipeline": "working",
+      "DeactivatePipeline": "500_error",
+      "DeletePipeline": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "QueryObjects",
+    "operations": [
+      "QueryObjects"
+    ],
+    "tested": [],
+    "untested": [
+      "QueryObjects"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "QueryObjects": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Status",
+    "operations": [
+      "SetStatus"
+    ],
+    "tested": [],
+    "untested": [
+      "SetStatus"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "SetStatus": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Tags",
+    "operations": [
+      "AddTags",
+      "RemoveTags"
+    ],
+    "tested": [],
+    "untested": [
+      "AddTags",
+      "RemoveTags"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "AddTags": "500_error",
+      "RemoveTags": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ValidatePipelineDefinition",
+    "operations": [
+      "ValidatePipelineDefinition"
+    ],
+    "tested": [],
+    "untested": [
+      "ValidatePipelineDefinition"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ValidatePipelineDefinition": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/datasync.json
+++ b/chunks/datasync.json
@@ -1,0 +1,374 @@
+[
+  {
+    "noun": "Agent",
+    "operations": [
+      "CreateAgent",
+      "DeleteAgent",
+      "DescribeAgent",
+      "UpdateAgent"
+    ],
+    "tested": [
+      "CreateAgent",
+      "DescribeAgent"
+    ],
+    "untested": [
+      "DeleteAgent",
+      "UpdateAgent"
+    ],
+    "size": 4,
+    "untested_count": 2,
+    "probe_status": {
+      "CreateAgent": "working",
+      "DeleteAgent": "not_implemented",
+      "DescribeAgent": "working",
+      "UpdateAgent": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "LocationAzureBlob",
+    "operations": [
+      "CreateLocationAzureBlob",
+      "DescribeLocationAzureBlob",
+      "UpdateLocationAzureBlob"
+    ],
+    "tested": [
+      "CreateLocationAzureBlob",
+      "DescribeLocationAzureBlob"
+    ],
+    "untested": [
+      "UpdateLocationAzureBlob"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateLocationAzureBlob": "working",
+      "DescribeLocationAzureBlob": "working",
+      "UpdateLocationAzureBlob": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "LocationEfs",
+    "operations": [
+      "CreateLocationEfs",
+      "DescribeLocationEfs",
+      "UpdateLocationEfs"
+    ],
+    "tested": [
+      "CreateLocationEfs",
+      "DescribeLocationEfs"
+    ],
+    "untested": [
+      "UpdateLocationEfs"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateLocationEfs": "needs_params",
+      "DescribeLocationEfs": "working",
+      "UpdateLocationEfs": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "LocationFsxLustre",
+    "operations": [
+      "CreateLocationFsxLustre",
+      "DescribeLocationFsxLustre",
+      "UpdateLocationFsxLustre"
+    ],
+    "tested": [
+      "CreateLocationFsxLustre",
+      "DescribeLocationFsxLustre"
+    ],
+    "untested": [
+      "UpdateLocationFsxLustre"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateLocationFsxLustre": "needs_params",
+      "DescribeLocationFsxLustre": "working",
+      "UpdateLocationFsxLustre": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "LocationFsxOntap",
+    "operations": [
+      "CreateLocationFsxOntap",
+      "DescribeLocationFsxOntap",
+      "UpdateLocationFsxOntap"
+    ],
+    "tested": [
+      "CreateLocationFsxOntap",
+      "DescribeLocationFsxOntap"
+    ],
+    "untested": [
+      "UpdateLocationFsxOntap"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateLocationFsxOntap": "needs_params",
+      "DescribeLocationFsxOntap": "working",
+      "UpdateLocationFsxOntap": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "LocationFsxOpenZfs",
+    "operations": [
+      "CreateLocationFsxOpenZfs",
+      "DescribeLocationFsxOpenZfs",
+      "UpdateLocationFsxOpenZfs"
+    ],
+    "tested": [
+      "CreateLocationFsxOpenZfs",
+      "DescribeLocationFsxOpenZfs"
+    ],
+    "untested": [
+      "UpdateLocationFsxOpenZfs"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateLocationFsxOpenZfs": "needs_params",
+      "DescribeLocationFsxOpenZfs": "working",
+      "UpdateLocationFsxOpenZfs": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "LocationFsxWindows",
+    "operations": [
+      "CreateLocationFsxWindows",
+      "DescribeLocationFsxWindows",
+      "UpdateLocationFsxWindows"
+    ],
+    "tested": [
+      "CreateLocationFsxWindows",
+      "DescribeLocationFsxWindows"
+    ],
+    "untested": [
+      "UpdateLocationFsxWindows"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateLocationFsxWindows": "needs_params",
+      "DescribeLocationFsxWindows": "working",
+      "UpdateLocationFsxWindows": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "LocationHdfs",
+    "operations": [
+      "CreateLocationHdfs",
+      "DescribeLocationHdfs",
+      "UpdateLocationHdfs"
+    ],
+    "tested": [
+      "CreateLocationHdfs",
+      "DescribeLocationHdfs"
+    ],
+    "untested": [
+      "UpdateLocationHdfs"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateLocationHdfs": "needs_params",
+      "DescribeLocationHdfs": "working",
+      "UpdateLocationHdfs": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "LocationNfs",
+    "operations": [
+      "CreateLocationNfs",
+      "DescribeLocationNfs",
+      "UpdateLocationNfs"
+    ],
+    "tested": [
+      "CreateLocationNfs",
+      "DescribeLocationNfs"
+    ],
+    "untested": [
+      "UpdateLocationNfs"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateLocationNfs": "needs_params",
+      "DescribeLocationNfs": "working",
+      "UpdateLocationNfs": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "LocationObjectStorage",
+    "operations": [
+      "CreateLocationObjectStorage",
+      "DescribeLocationObjectStorage",
+      "UpdateLocationObjectStorage"
+    ],
+    "tested": [
+      "CreateLocationObjectStorage",
+      "DescribeLocationObjectStorage"
+    ],
+    "untested": [
+      "UpdateLocationObjectStorage"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateLocationObjectStorage": "working",
+      "DescribeLocationObjectStorage": "working",
+      "UpdateLocationObjectStorage": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "LocationS3",
+    "operations": [
+      "CreateLocationS3",
+      "DescribeLocationS3",
+      "UpdateLocationS3"
+    ],
+    "tested": [
+      "CreateLocationS3",
+      "DescribeLocationS3"
+    ],
+    "untested": [
+      "UpdateLocationS3"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateLocationS3": "working",
+      "DescribeLocationS3": "working",
+      "UpdateLocationS3": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "LocationSmb",
+    "operations": [
+      "CreateLocationSmb",
+      "DescribeLocationSmb",
+      "UpdateLocationSmb"
+    ],
+    "tested": [
+      "CreateLocationSmb",
+      "DescribeLocationSmb"
+    ],
+    "untested": [
+      "UpdateLocationSmb"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateLocationSmb": "needs_params",
+      "DescribeLocationSmb": "working",
+      "UpdateLocationSmb": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Resource",
+    "operations": [
+      "TagResource",
+      "UntagResource"
+    ],
+    "tested": [],
+    "untested": [
+      "TagResource",
+      "UntagResource"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "TagResource": "not_implemented",
+      "UntagResource": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TagsForResource",
+    "operations": [
+      "ListTagsForResource"
+    ],
+    "tested": [],
+    "untested": [
+      "ListTagsForResource"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListTagsForResource": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TaskExecution",
+    "operations": [
+      "CancelTaskExecution",
+      "DescribeTaskExecution",
+      "StartTaskExecution",
+      "UpdateTaskExecution"
+    ],
+    "tested": [
+      "CancelTaskExecution",
+      "DescribeTaskExecution",
+      "StartTaskExecution"
+    ],
+    "untested": [
+      "UpdateTaskExecution"
+    ],
+    "size": 4,
+    "untested_count": 1,
+    "probe_status": {
+      "CancelTaskExecution": "working",
+      "DescribeTaskExecution": "working",
+      "StartTaskExecution": "working",
+      "UpdateTaskExecution": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TaskExecutions",
+    "operations": [
+      "ListTaskExecutions"
+    ],
+    "tested": [],
+    "untested": [
+      "ListTaskExecutions"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListTaskExecutions": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/dms.json
+++ b/chunks/dms.json
@@ -1,0 +1,63 @@
+[
+  {
+    "noun": "Replication",
+    "operations": [
+      "StartReplication",
+      "StopReplication"
+    ],
+    "tested": [
+      "StartReplication"
+    ],
+    "untested": [
+      "StopReplication"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "StartReplication": "working",
+      "StopReplication": "working"
+    },
+    "working_untested": [
+      "StopReplication"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "EngineVersions",
+    "operations": [
+      "DescribeEngineVersions"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeEngineVersions"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeEngineVersions": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "MetadataModelCreation",
+    "operations": [
+      "CancelMetadataModelCreation",
+      "StartMetadataModelCreation"
+    ],
+    "tested": [
+      "CancelMetadataModelCreation"
+    ],
+    "untested": [
+      "StartMetadataModelCreation"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "CancelMetadataModelCreation": "working",
+      "StartMetadataModelCreation": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/ds.json
+++ b/chunks/ds.json
@@ -1,0 +1,346 @@
+[
+  {
+    "noun": "CAEnrollmentPolicy",
+    "operations": [
+      "DescribeCAEnrollmentPolicy",
+      "DisableCAEnrollmentPolicy",
+      "EnableCAEnrollmentPolicy"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeCAEnrollmentPolicy",
+      "DisableCAEnrollmentPolicy",
+      "EnableCAEnrollmentPolicy"
+    ],
+    "size": 3,
+    "untested_count": 3,
+    "probe_status": {
+      "DescribeCAEnrollmentPolicy": "working",
+      "DisableCAEnrollmentPolicy": "working",
+      "EnableCAEnrollmentPolicy": "working"
+    },
+    "working_untested": [
+      "DescribeCAEnrollmentPolicy",
+      "DisableCAEnrollmentPolicy",
+      "EnableCAEnrollmentPolicy"
+    ],
+    "working_untested_count": 3
+  },
+  {
+    "noun": "DirectoryDataAccess",
+    "operations": [
+      "DescribeDirectoryDataAccess",
+      "DisableDirectoryDataAccess",
+      "EnableDirectoryDataAccess"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeDirectoryDataAccess",
+      "DisableDirectoryDataAccess",
+      "EnableDirectoryDataAccess"
+    ],
+    "size": 3,
+    "untested_count": 3,
+    "probe_status": {
+      "DescribeDirectoryDataAccess": "working",
+      "DisableDirectoryDataAccess": "working",
+      "EnableDirectoryDataAccess": "working"
+    },
+    "working_untested": [
+      "DescribeDirectoryDataAccess",
+      "DisableDirectoryDataAccess",
+      "EnableDirectoryDataAccess"
+    ],
+    "working_untested_count": 3
+  },
+  {
+    "noun": "ADAssessment",
+    "operations": [
+      "DeleteADAssessment",
+      "DescribeADAssessment",
+      "StartADAssessment"
+    ],
+    "tested": [],
+    "untested": [
+      "DeleteADAssessment",
+      "DescribeADAssessment",
+      "StartADAssessment"
+    ],
+    "size": 3,
+    "untested_count": 3,
+    "probe_status": {
+      "DeleteADAssessment": "working",
+      "DescribeADAssessment": "working",
+      "StartADAssessment": "500_error"
+    },
+    "working_untested": [
+      "DeleteADAssessment",
+      "DescribeADAssessment"
+    ],
+    "working_untested_count": 2
+  },
+  {
+    "noun": "LDAPS",
+    "operations": [
+      "DisableLDAPS",
+      "EnableLDAPS"
+    ],
+    "tested": [],
+    "untested": [
+      "DisableLDAPS",
+      "EnableLDAPS"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "DisableLDAPS": "working",
+      "EnableLDAPS": "working"
+    },
+    "working_untested": [
+      "DisableLDAPS",
+      "EnableLDAPS"
+    ],
+    "working_untested_count": 2
+  },
+  {
+    "noun": "Region",
+    "operations": [
+      "AddRegion",
+      "RemoveRegion"
+    ],
+    "tested": [],
+    "untested": [
+      "AddRegion",
+      "RemoveRegion"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "AddRegion": "working",
+      "RemoveRegion": "working"
+    },
+    "working_untested": [
+      "AddRegion",
+      "RemoveRegion"
+    ],
+    "working_untested_count": 2
+  },
+  {
+    "noun": "SharedDirectory",
+    "operations": [
+      "AcceptSharedDirectory",
+      "RejectSharedDirectory"
+    ],
+    "tested": [],
+    "untested": [
+      "AcceptSharedDirectory",
+      "RejectSharedDirectory"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "AcceptSharedDirectory": "working",
+      "RejectSharedDirectory": "working"
+    },
+    "working_untested": [
+      "AcceptSharedDirectory",
+      "RejectSharedDirectory"
+    ],
+    "working_untested_count": 2
+  },
+  {
+    "noun": "ADAssessments",
+    "operations": [
+      "ListADAssessments"
+    ],
+    "tested": [],
+    "untested": [
+      "ListADAssessments"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListADAssessments": "working"
+    },
+    "working_untested": [
+      "ListADAssessments"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "DirectorySetup",
+    "operations": [
+      "UpdateDirectorySetup"
+    ],
+    "tested": [],
+    "untested": [
+      "UpdateDirectorySetup"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "UpdateDirectorySetup": "working"
+    },
+    "working_untested": [
+      "UpdateDirectorySetup"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "LDAPSSettings",
+    "operations": [
+      "DescribeLDAPSSettings"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeLDAPSSettings"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeLDAPSSettings": "working"
+    },
+    "working_untested": [
+      "DescribeLDAPSSettings"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "MicrosoftAD",
+    "operations": [
+      "CreateMicrosoftAD"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateMicrosoftAD"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateMicrosoftAD": "working"
+    },
+    "working_untested": [
+      "CreateMicrosoftAD"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "ShareDirectory",
+    "operations": [
+      "ShareDirectory"
+    ],
+    "tested": [],
+    "untested": [
+      "ShareDirectory"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ShareDirectory": "working"
+    },
+    "working_untested": [
+      "ShareDirectory"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "UnshareDirectory",
+    "operations": [
+      "UnshareDirectory"
+    ],
+    "tested": [],
+    "untested": [
+      "UnshareDirectory"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "UnshareDirectory": "working"
+    },
+    "working_untested": [
+      "UnshareDirectory"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "HybridAD",
+    "operations": [
+      "CreateHybridAD",
+      "UpdateHybridAD"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateHybridAD",
+      "UpdateHybridAD"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "CreateHybridAD": "not_implemented",
+      "UpdateHybridAD": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "HybridADUpdate",
+    "operations": [
+      "DescribeHybridADUpdate"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeHybridADUpdate"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeHybridADUpdate": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "NumberOfDomainControllers",
+    "operations": [
+      "UpdateNumberOfDomainControllers"
+    ],
+    "tested": [],
+    "untested": [
+      "UpdateNumberOfDomainControllers"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "UpdateNumberOfDomainControllers": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Trust",
+    "operations": [
+      "CreateTrust",
+      "DeleteTrust",
+      "UpdateTrust",
+      "VerifyTrust"
+    ],
+    "tested": [
+      "CreateTrust",
+      "DeleteTrust"
+    ],
+    "untested": [
+      "UpdateTrust",
+      "VerifyTrust"
+    ],
+    "size": 4,
+    "untested_count": 2,
+    "probe_status": {
+      "CreateTrust": "working",
+      "DeleteTrust": "working",
+      "UpdateTrust": "not_implemented",
+      "VerifyTrust": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/dsql.json
+++ b/chunks/dsql.json
@@ -1,0 +1,89 @@
+[
+  {
+    "noun": "Cluster",
+    "operations": [
+      "CreateCluster",
+      "DeleteCluster",
+      "GetCluster",
+      "UpdateCluster"
+    ],
+    "tested": [
+      "CreateCluster",
+      "DeleteCluster",
+      "GetCluster"
+    ],
+    "untested": [
+      "UpdateCluster"
+    ],
+    "size": 4,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateCluster": "working",
+      "DeleteCluster": "unknown",
+      "GetCluster": "working",
+      "UpdateCluster": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ClusterPolicy",
+    "operations": [
+      "DeleteClusterPolicy",
+      "GetClusterPolicy",
+      "PutClusterPolicy"
+    ],
+    "tested": [],
+    "untested": [
+      "DeleteClusterPolicy",
+      "GetClusterPolicy",
+      "PutClusterPolicy"
+    ],
+    "size": 3,
+    "untested_count": 3,
+    "probe_status": {
+      "DeleteClusterPolicy": "not_implemented",
+      "GetClusterPolicy": "not_implemented",
+      "PutClusterPolicy": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Clusters",
+    "operations": [
+      "ListClusters"
+    ],
+    "tested": [],
+    "untested": [
+      "ListClusters"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListClusters": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Resource",
+    "operations": [
+      "TagResource",
+      "UntagResource"
+    ],
+    "tested": [],
+    "untested": [
+      "TagResource",
+      "UntagResource"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "TagResource": "not_implemented",
+      "UntagResource": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/dynamodb.json
+++ b/chunks/dynamodb.json
@@ -1,0 +1,136 @@
+[
+  {
+    "noun": "GlobalTable",
+    "operations": [
+      "CreateGlobalTable",
+      "DescribeGlobalTable",
+      "UpdateGlobalTable"
+    ],
+    "tested": [
+      "CreateGlobalTable",
+      "DescribeGlobalTable"
+    ],
+    "untested": [
+      "UpdateGlobalTable"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateGlobalTable": "working",
+      "DescribeGlobalTable": "working",
+      "UpdateGlobalTable": "working"
+    },
+    "working_untested": [
+      "UpdateGlobalTable"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "ContributorInsights",
+    "operations": [
+      "DescribeContributorInsights",
+      "ListContributorInsights",
+      "UpdateContributorInsights"
+    ],
+    "tested": [
+      "ListContributorInsights"
+    ],
+    "untested": [
+      "DescribeContributorInsights",
+      "UpdateContributorInsights"
+    ],
+    "size": 3,
+    "untested_count": 2,
+    "probe_status": {
+      "DescribeContributorInsights": "not_implemented",
+      "ListContributorInsights": "working",
+      "UpdateContributorInsights": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "GlobalTableSettings",
+    "operations": [
+      "DescribeGlobalTableSettings",
+      "UpdateGlobalTableSettings"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeGlobalTableSettings",
+      "UpdateGlobalTableSettings"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "DescribeGlobalTableSettings": "not_implemented",
+      "UpdateGlobalTableSettings": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Import",
+    "operations": [
+      "DescribeImport"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeImport"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeImport": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "KinesisStreamingDestination",
+    "operations": [
+      "DescribeKinesisStreamingDestination",
+      "DisableKinesisStreamingDestination",
+      "EnableKinesisStreamingDestination",
+      "UpdateKinesisStreamingDestination"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeKinesisStreamingDestination",
+      "DisableKinesisStreamingDestination",
+      "EnableKinesisStreamingDestination",
+      "UpdateKinesisStreamingDestination"
+    ],
+    "size": 4,
+    "untested_count": 4,
+    "probe_status": {
+      "DescribeKinesisStreamingDestination": "not_implemented",
+      "DisableKinesisStreamingDestination": "not_implemented",
+      "EnableKinesisStreamingDestination": "not_implemented",
+      "UpdateKinesisStreamingDestination": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TableReplicaAutoScaling",
+    "operations": [
+      "DescribeTableReplicaAutoScaling",
+      "UpdateTableReplicaAutoScaling"
+    ],
+    "tested": [
+      "DescribeTableReplicaAutoScaling"
+    ],
+    "untested": [
+      "UpdateTableReplicaAutoScaling"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeTableReplicaAutoScaling": "working",
+      "UpdateTableReplicaAutoScaling": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/ec2.json
+++ b/chunks/ec2.json
@@ -1,0 +1,3819 @@
+[
+  {
+    "noun": "ActiveVpnTunnelStatus",
+    "operations": [
+      "GetActiveVpnTunnelStatus"
+    ],
+    "tested": [],
+    "untested": [
+      "GetActiveVpnTunnelStatus"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetActiveVpnTunnelStatus": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "AddressAttribute",
+    "operations": [
+      "ModifyAddressAttribute",
+      "ResetAddressAttribute"
+    ],
+    "tested": [],
+    "untested": [
+      "ModifyAddressAttribute",
+      "ResetAddressAttribute"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "ModifyAddressAttribute": "not_implemented",
+      "ResetAddressAttribute": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "AddressToClassic",
+    "operations": [
+      "RestoreAddressToClassic"
+    ],
+    "tested": [],
+    "untested": [
+      "RestoreAddressToClassic"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "RestoreAddressToClassic": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "AddressToVpc",
+    "operations": [
+      "MoveAddressToVpc"
+    ],
+    "tested": [],
+    "untested": [
+      "MoveAddressToVpc"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "MoveAddressToVpc": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "AddressTransfer",
+    "operations": [
+      "AcceptAddressTransfer",
+      "DisableAddressTransfer",
+      "EnableAddressTransfer"
+    ],
+    "tested": [],
+    "untested": [
+      "AcceptAddressTransfer",
+      "DisableAddressTransfer",
+      "EnableAddressTransfer"
+    ],
+    "size": 3,
+    "untested_count": 3,
+    "probe_status": {
+      "AcceptAddressTransfer": "not_implemented",
+      "DisableAddressTransfer": "not_implemented",
+      "EnableAddressTransfer": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "AllowedImagesSettings",
+    "operations": [
+      "DisableAllowedImagesSettings",
+      "EnableAllowedImagesSettings",
+      "GetAllowedImagesSettings"
+    ],
+    "tested": [
+      "DisableAllowedImagesSettings",
+      "GetAllowedImagesSettings"
+    ],
+    "untested": [
+      "EnableAllowedImagesSettings"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "DisableAllowedImagesSettings": "working",
+      "EnableAllowedImagesSettings": "not_implemented",
+      "GetAllowedImagesSettings": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "AssociatedEnclaveCertificateIamRoles",
+    "operations": [
+      "GetAssociatedEnclaveCertificateIamRoles"
+    ],
+    "tested": [],
+    "untested": [
+      "GetAssociatedEnclaveCertificateIamRoles"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetAssociatedEnclaveCertificateIamRoles": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "AssociatedIpv6PoolCidrs",
+    "operations": [
+      "GetAssociatedIpv6PoolCidrs"
+    ],
+    "tested": [],
+    "untested": [
+      "GetAssociatedIpv6PoolCidrs"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetAssociatedIpv6PoolCidrs": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "AvailabilityZoneGroup",
+    "operations": [
+      "ModifyAvailabilityZoneGroup"
+    ],
+    "tested": [],
+    "untested": [
+      "ModifyAvailabilityZoneGroup"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ModifyAvailabilityZoneGroup": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "BundleTask",
+    "operations": [
+      "CancelBundleTask"
+    ],
+    "tested": [],
+    "untested": [
+      "CancelBundleTask"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "CancelBundleTask": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ByoipCidr",
+    "operations": [
+      "AdvertiseByoipCidr",
+      "WithdrawByoipCidr"
+    ],
+    "tested": [],
+    "untested": [
+      "AdvertiseByoipCidr",
+      "WithdrawByoipCidr"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "AdvertiseByoipCidr": "not_implemented",
+      "WithdrawByoipCidr": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ByoipCidrToIpam",
+    "operations": [
+      "MoveByoipCidrToIpam"
+    ],
+    "tested": [],
+    "untested": [
+      "MoveByoipCidrToIpam"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "MoveByoipCidrToIpam": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "CapacityBlockExtensionOfferings",
+    "operations": [
+      "DescribeCapacityBlockExtensionOfferings"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeCapacityBlockExtensionOfferings"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeCapacityBlockExtensionOfferings": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "CapacityManagerDataExport",
+    "operations": [
+      "CreateCapacityManagerDataExport",
+      "DeleteCapacityManagerDataExport"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateCapacityManagerDataExport",
+      "DeleteCapacityManagerDataExport"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "CreateCapacityManagerDataExport": "not_implemented",
+      "DeleteCapacityManagerDataExport": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "CapacityManagerMetricData",
+    "operations": [
+      "GetCapacityManagerMetricData"
+    ],
+    "tested": [],
+    "untested": [
+      "GetCapacityManagerMetricData"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetCapacityManagerMetricData": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "CapacityManagerMetricDimensions",
+    "operations": [
+      "GetCapacityManagerMetricDimensions"
+    ],
+    "tested": [],
+    "untested": [
+      "GetCapacityManagerMetricDimensions"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetCapacityManagerMetricDimensions": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "CapacityManagerOrganizationsAccess",
+    "operations": [
+      "UpdateCapacityManagerOrganizationsAccess"
+    ],
+    "tested": [],
+    "untested": [
+      "UpdateCapacityManagerOrganizationsAccess"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "UpdateCapacityManagerOrganizationsAccess": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "CapacityReservationBillingOwner",
+    "operations": [
+      "AssociateCapacityReservationBillingOwner",
+      "DisassociateCapacityReservationBillingOwner"
+    ],
+    "tested": [],
+    "untested": [
+      "AssociateCapacityReservationBillingOwner",
+      "DisassociateCapacityReservationBillingOwner"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "AssociateCapacityReservationBillingOwner": "not_implemented",
+      "DisassociateCapacityReservationBillingOwner": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "CapacityReservationBillingOwnership",
+    "operations": [
+      "AcceptCapacityReservationBillingOwnership",
+      "RejectCapacityReservationBillingOwnership"
+    ],
+    "tested": [],
+    "untested": [
+      "AcceptCapacityReservationBillingOwnership",
+      "RejectCapacityReservationBillingOwnership"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "AcceptCapacityReservationBillingOwnership": "not_implemented",
+      "RejectCapacityReservationBillingOwnership": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "CapacityReservationBillingRequests",
+    "operations": [
+      "DescribeCapacityReservationBillingRequests"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeCapacityReservationBillingRequests"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeCapacityReservationBillingRequests": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "CapacityReservationBySplitting",
+    "operations": [
+      "CreateCapacityReservationBySplitting"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateCapacityReservationBySplitting"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateCapacityReservationBySplitting": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "CapacityReservationInstances",
+    "operations": [
+      "MoveCapacityReservationInstances"
+    ],
+    "tested": [],
+    "untested": [
+      "MoveCapacityReservationInstances"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "MoveCapacityReservationInstances": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "CapacityReservationUsage",
+    "operations": [
+      "GetCapacityReservationUsage"
+    ],
+    "tested": [],
+    "untested": [
+      "GetCapacityReservationUsage"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetCapacityReservationUsage": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ClassicLinkVpc",
+    "operations": [
+      "AttachClassicLinkVpc",
+      "DetachClassicLinkVpc"
+    ],
+    "tested": [],
+    "untested": [
+      "AttachClassicLinkVpc",
+      "DetachClassicLinkVpc"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "AttachClassicLinkVpc": "not_implemented",
+      "DetachClassicLinkVpc": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ClientVpnClientCertificateRevocationList",
+    "operations": [
+      "ExportClientVpnClientCertificateRevocationList",
+      "ImportClientVpnClientCertificateRevocationList"
+    ],
+    "tested": [],
+    "untested": [
+      "ExportClientVpnClientCertificateRevocationList",
+      "ImportClientVpnClientCertificateRevocationList"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "ExportClientVpnClientCertificateRevocationList": "not_implemented",
+      "ImportClientVpnClientCertificateRevocationList": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ClientVpnClientConfiguration",
+    "operations": [
+      "ExportClientVpnClientConfiguration"
+    ],
+    "tested": [],
+    "untested": [
+      "ExportClientVpnClientConfiguration"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ExportClientVpnClientConfiguration": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ClientVpnConnections",
+    "operations": [
+      "DescribeClientVpnConnections",
+      "TerminateClientVpnConnections"
+    ],
+    "tested": [
+      "DescribeClientVpnConnections"
+    ],
+    "untested": [
+      "TerminateClientVpnConnections"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeClientVpnConnections": "working",
+      "TerminateClientVpnConnections": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ClientVpnIngress",
+    "operations": [
+      "AuthorizeClientVpnIngress",
+      "RevokeClientVpnIngress"
+    ],
+    "tested": [],
+    "untested": [
+      "AuthorizeClientVpnIngress",
+      "RevokeClientVpnIngress"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "AuthorizeClientVpnIngress": "not_implemented",
+      "RevokeClientVpnIngress": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ClientVpnRoute",
+    "operations": [
+      "CreateClientVpnRoute",
+      "DeleteClientVpnRoute"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateClientVpnRoute",
+      "DeleteClientVpnRoute"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "CreateClientVpnRoute": "not_implemented",
+      "DeleteClientVpnRoute": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ClientVpnTargetNetwork",
+    "operations": [
+      "AssociateClientVpnTargetNetwork",
+      "DisassociateClientVpnTargetNetwork"
+    ],
+    "tested": [],
+    "untested": [
+      "AssociateClientVpnTargetNetwork",
+      "DisassociateClientVpnTargetNetwork"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "AssociateClientVpnTargetNetwork": "not_implemented",
+      "DisassociateClientVpnTargetNetwork": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ConsoleScreenshot",
+    "operations": [
+      "GetConsoleScreenshot"
+    ],
+    "tested": [],
+    "untested": [
+      "GetConsoleScreenshot"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetConsoleScreenshot": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ConversionTask",
+    "operations": [
+      "CancelConversionTask"
+    ],
+    "tested": [],
+    "untested": [
+      "CancelConversionTask"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "CancelConversionTask": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DeclarativePoliciesReport",
+    "operations": [
+      "CancelDeclarativePoliciesReport",
+      "StartDeclarativePoliciesReport"
+    ],
+    "tested": [],
+    "untested": [
+      "CancelDeclarativePoliciesReport",
+      "StartDeclarativePoliciesReport"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "CancelDeclarativePoliciesReport": "not_implemented",
+      "StartDeclarativePoliciesReport": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DefaultCreditSpecification",
+    "operations": [
+      "GetDefaultCreditSpecification",
+      "ModifyDefaultCreditSpecification"
+    ],
+    "tested": [],
+    "untested": [
+      "GetDefaultCreditSpecification",
+      "ModifyDefaultCreditSpecification"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "GetDefaultCreditSpecification": "not_implemented",
+      "ModifyDefaultCreditSpecification": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DelegateMacVolumeOwnershipTask",
+    "operations": [
+      "CreateDelegateMacVolumeOwnershipTask"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateDelegateMacVolumeOwnershipTask"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateDelegateMacVolumeOwnershipTask": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DeprovisionByoipCidr",
+    "operations": [
+      "DeprovisionByoipCidr"
+    ],
+    "tested": [],
+    "untested": [
+      "DeprovisionByoipCidr"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DeprovisionByoipCidr": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DeprovisionIpamByoasn",
+    "operations": [
+      "DeprovisionIpamByoasn"
+    ],
+    "tested": [],
+    "untested": [
+      "DeprovisionIpamByoasn"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DeprovisionIpamByoasn": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DiagnosticInterrupt",
+    "operations": [
+      "SendDiagnosticInterrupt"
+    ],
+    "tested": [],
+    "untested": [
+      "SendDiagnosticInterrupt"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "SendDiagnosticInterrupt": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "EnclaveCertificateIamRole",
+    "operations": [
+      "AssociateEnclaveCertificateIamRole",
+      "DisassociateEnclaveCertificateIamRole"
+    ],
+    "tested": [],
+    "untested": [
+      "AssociateEnclaveCertificateIamRole",
+      "DisassociateEnclaveCertificateIamRole"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "AssociateEnclaveCertificateIamRole": "not_implemented",
+      "DisassociateEnclaveCertificateIamRole": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ExportTask",
+    "operations": [
+      "CancelExportTask"
+    ],
+    "tested": [],
+    "untested": [
+      "CancelExportTask"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "CancelExportTask": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "FastSnapshotRestores",
+    "operations": [
+      "DescribeFastSnapshotRestores",
+      "DisableFastSnapshotRestores",
+      "EnableFastSnapshotRestores"
+    ],
+    "tested": [
+      "DescribeFastSnapshotRestores"
+    ],
+    "untested": [
+      "DisableFastSnapshotRestores",
+      "EnableFastSnapshotRestores"
+    ],
+    "size": 3,
+    "untested_count": 2,
+    "probe_status": {
+      "DescribeFastSnapshotRestores": "working",
+      "DisableFastSnapshotRestores": "not_implemented",
+      "EnableFastSnapshotRestores": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "FlowLogsIntegrationTemplate",
+    "operations": [
+      "GetFlowLogsIntegrationTemplate"
+    ],
+    "tested": [],
+    "untested": [
+      "GetFlowLogsIntegrationTemplate"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetFlowLogsIntegrationTemplate": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "FpgaImage",
+    "operations": [
+      "CopyFpgaImage",
+      "CreateFpgaImage",
+      "DeleteFpgaImage"
+    ],
+    "tested": [],
+    "untested": [
+      "CopyFpgaImage",
+      "CreateFpgaImage",
+      "DeleteFpgaImage"
+    ],
+    "size": 3,
+    "untested_count": 3,
+    "probe_status": {
+      "CopyFpgaImage": "not_implemented",
+      "CreateFpgaImage": "not_implemented",
+      "DeleteFpgaImage": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "FpgaImageAttribute",
+    "operations": [
+      "DescribeFpgaImageAttribute",
+      "ModifyFpgaImageAttribute",
+      "ResetFpgaImageAttribute"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeFpgaImageAttribute",
+      "ModifyFpgaImageAttribute",
+      "ResetFpgaImageAttribute"
+    ],
+    "size": 3,
+    "untested_count": 3,
+    "probe_status": {
+      "DescribeFpgaImageAttribute": "not_implemented",
+      "ModifyFpgaImageAttribute": "not_implemented",
+      "ResetFpgaImageAttribute": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "GroupsForCapacityReservation",
+    "operations": [
+      "GetGroupsForCapacityReservation"
+    ],
+    "tested": [],
+    "untested": [
+      "GetGroupsForCapacityReservation"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetGroupsForCapacityReservation": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "IdFormat",
+    "operations": [
+      "DescribeIdFormat",
+      "ModifyIdFormat"
+    ],
+    "tested": [
+      "DescribeIdFormat"
+    ],
+    "untested": [
+      "ModifyIdFormat"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeIdFormat": "working",
+      "ModifyIdFormat": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "IdentityIdFormat",
+    "operations": [
+      "DescribeIdentityIdFormat",
+      "ModifyIdentityIdFormat"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeIdentityIdFormat",
+      "ModifyIdentityIdFormat"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "DescribeIdentityIdFormat": "not_implemented",
+      "ModifyIdentityIdFormat": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Image",
+    "operations": [
+      "CopyImage",
+      "CreateImage",
+      "DeregisterImage",
+      "DisableImage",
+      "EnableImage",
+      "ExportImage",
+      "ImportImage",
+      "RegisterImage"
+    ],
+    "tested": [
+      "CopyImage",
+      "CreateImage",
+      "DeregisterImage",
+      "ImportImage",
+      "RegisterImage"
+    ],
+    "untested": [
+      "DisableImage",
+      "EnableImage",
+      "ExportImage"
+    ],
+    "size": 8,
+    "untested_count": 3,
+    "probe_status": {
+      "CopyImage": "working",
+      "CreateImage": "working",
+      "DeregisterImage": "working",
+      "DisableImage": "not_implemented",
+      "EnableImage": "not_implemented",
+      "ExportImage": "not_implemented",
+      "ImportImage": "working",
+      "RegisterImage": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ImageAncestry",
+    "operations": [
+      "GetImageAncestry"
+    ],
+    "tested": [],
+    "untested": [
+      "GetImageAncestry"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetImageAncestry": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ImageAttribute",
+    "operations": [
+      "DescribeImageAttribute",
+      "ModifyImageAttribute",
+      "ResetImageAttribute"
+    ],
+    "tested": [
+      "DescribeImageAttribute",
+      "ModifyImageAttribute"
+    ],
+    "untested": [
+      "ResetImageAttribute"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeImageAttribute": "working",
+      "ModifyImageAttribute": "working",
+      "ResetImageAttribute": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ImageBlockPublicAccess",
+    "operations": [
+      "DisableImageBlockPublicAccess",
+      "EnableImageBlockPublicAccess"
+    ],
+    "tested": [
+      "DisableImageBlockPublicAccess"
+    ],
+    "untested": [
+      "EnableImageBlockPublicAccess"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "DisableImageBlockPublicAccess": "working",
+      "EnableImageBlockPublicAccess": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ImageDeprecation",
+    "operations": [
+      "DisableImageDeprecation",
+      "EnableImageDeprecation"
+    ],
+    "tested": [],
+    "untested": [
+      "DisableImageDeprecation",
+      "EnableImageDeprecation"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "DisableImageDeprecation": "not_implemented",
+      "EnableImageDeprecation": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ImageDeregistrationProtection",
+    "operations": [
+      "DisableImageDeregistrationProtection",
+      "EnableImageDeregistrationProtection"
+    ],
+    "tested": [],
+    "untested": [
+      "DisableImageDeregistrationProtection",
+      "EnableImageDeregistrationProtection"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "DisableImageDeregistrationProtection": "not_implemented",
+      "EnableImageDeregistrationProtection": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ImageFromRecycleBin",
+    "operations": [
+      "RestoreImageFromRecycleBin"
+    ],
+    "tested": [],
+    "untested": [
+      "RestoreImageFromRecycleBin"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "RestoreImageFromRecycleBin": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ImageLaunchPermission",
+    "operations": [
+      "CancelImageLaunchPermission"
+    ],
+    "tested": [],
+    "untested": [
+      "CancelImageLaunchPermission"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "CancelImageLaunchPermission": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ImageReferences",
+    "operations": [
+      "DescribeImageReferences"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeImageReferences"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeImageReferences": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ImageUsageReport",
+    "operations": [
+      "CreateImageUsageReport",
+      "DeleteImageUsageReport"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateImageUsageReport",
+      "DeleteImageUsageReport"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "CreateImageUsageReport": "not_implemented",
+      "DeleteImageUsageReport": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Instance",
+    "operations": [
+      "BundleInstance",
+      "ImportInstance"
+    ],
+    "tested": [],
+    "untested": [
+      "BundleInstance",
+      "ImportInstance"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "BundleInstance": "not_implemented",
+      "ImportInstance": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "InstanceAttribute",
+    "operations": [
+      "DescribeInstanceAttribute",
+      "ModifyInstanceAttribute",
+      "ResetInstanceAttribute"
+    ],
+    "tested": [
+      "DescribeInstanceAttribute",
+      "ModifyInstanceAttribute"
+    ],
+    "untested": [
+      "ResetInstanceAttribute"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeInstanceAttribute": "working",
+      "ModifyInstanceAttribute": "working",
+      "ResetInstanceAttribute": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "InstanceCapacityReservationAttributes",
+    "operations": [
+      "ModifyInstanceCapacityReservationAttributes"
+    ],
+    "tested": [],
+    "untested": [
+      "ModifyInstanceCapacityReservationAttributes"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ModifyInstanceCapacityReservationAttributes": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "InstanceConnectEndpoint",
+    "operations": [
+      "CreateInstanceConnectEndpoint",
+      "DeleteInstanceConnectEndpoint",
+      "ModifyInstanceConnectEndpoint"
+    ],
+    "tested": [
+      "CreateInstanceConnectEndpoint",
+      "DeleteInstanceConnectEndpoint"
+    ],
+    "untested": [
+      "ModifyInstanceConnectEndpoint"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateInstanceConnectEndpoint": "working",
+      "DeleteInstanceConnectEndpoint": "working",
+      "ModifyInstanceConnectEndpoint": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "InstanceCpuOptions",
+    "operations": [
+      "ModifyInstanceCpuOptions"
+    ],
+    "tested": [],
+    "untested": [
+      "ModifyInstanceCpuOptions"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ModifyInstanceCpuOptions": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "InstanceCreditSpecification",
+    "operations": [
+      "ModifyInstanceCreditSpecification"
+    ],
+    "tested": [],
+    "untested": [
+      "ModifyInstanceCreditSpecification"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ModifyInstanceCreditSpecification": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "InstanceEventNotificationAttributes",
+    "operations": [
+      "DeregisterInstanceEventNotificationAttributes",
+      "DescribeInstanceEventNotificationAttributes",
+      "RegisterInstanceEventNotificationAttributes"
+    ],
+    "tested": [
+      "DescribeInstanceEventNotificationAttributes"
+    ],
+    "untested": [
+      "DeregisterInstanceEventNotificationAttributes",
+      "RegisterInstanceEventNotificationAttributes"
+    ],
+    "size": 3,
+    "untested_count": 2,
+    "probe_status": {
+      "DeregisterInstanceEventNotificationAttributes": "not_implemented",
+      "DescribeInstanceEventNotificationAttributes": "working",
+      "RegisterInstanceEventNotificationAttributes": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "InstanceEventStartTime",
+    "operations": [
+      "ModifyInstanceEventStartTime"
+    ],
+    "tested": [],
+    "untested": [
+      "ModifyInstanceEventStartTime"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ModifyInstanceEventStartTime": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "InstanceExportTask",
+    "operations": [
+      "CreateInstanceExportTask"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateInstanceExportTask"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateInstanceExportTask": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "InstanceMaintenanceOptions",
+    "operations": [
+      "ModifyInstanceMaintenanceOptions"
+    ],
+    "tested": [],
+    "untested": [
+      "ModifyInstanceMaintenanceOptions"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ModifyInstanceMaintenanceOptions": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "InstanceNetworkPerformanceOptions",
+    "operations": [
+      "ModifyInstanceNetworkPerformanceOptions"
+    ],
+    "tested": [],
+    "untested": [
+      "ModifyInstanceNetworkPerformanceOptions"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ModifyInstanceNetworkPerformanceOptions": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "InstancePlacement",
+    "operations": [
+      "ModifyInstancePlacement"
+    ],
+    "tested": [],
+    "untested": [
+      "ModifyInstancePlacement"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ModifyInstancePlacement": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "InstanceSqlHaStandbyDetections",
+    "operations": [
+      "DisableInstanceSqlHaStandbyDetections",
+      "EnableInstanceSqlHaStandbyDetections"
+    ],
+    "tested": [],
+    "untested": [
+      "DisableInstanceSqlHaStandbyDetections",
+      "EnableInstanceSqlHaStandbyDetections"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "DisableInstanceSqlHaStandbyDetections": "needs_params",
+      "EnableInstanceSqlHaStandbyDetections": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "InstanceTpmEkPub",
+    "operations": [
+      "GetInstanceTpmEkPub"
+    ],
+    "tested": [],
+    "untested": [
+      "GetInstanceTpmEkPub"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetInstanceTpmEkPub": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "InstanceTypesFromInstanceRequirements",
+    "operations": [
+      "GetInstanceTypesFromInstanceRequirements"
+    ],
+    "tested": [],
+    "untested": [
+      "GetInstanceTypesFromInstanceRequirements"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetInstanceTypesFromInstanceRequirements": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Instances",
+    "operations": [
+      "DescribeInstances",
+      "MonitorInstances",
+      "RebootInstances",
+      "RunInstances",
+      "StartInstances",
+      "StopInstances",
+      "TerminateInstances",
+      "UnmonitorInstances"
+    ],
+    "tested": [
+      "DescribeInstances",
+      "RebootInstances",
+      "RunInstances",
+      "StartInstances",
+      "StopInstances",
+      "TerminateInstances"
+    ],
+    "untested": [
+      "MonitorInstances",
+      "UnmonitorInstances"
+    ],
+    "size": 8,
+    "untested_count": 2,
+    "probe_status": {
+      "DescribeInstances": "working",
+      "MonitorInstances": "not_implemented",
+      "RebootInstances": "working",
+      "RunInstances": "working",
+      "StartInstances": "working",
+      "StopInstances": "working",
+      "TerminateInstances": "unknown",
+      "UnmonitorInstances": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "InterruptibleCapacityReservationAllocation",
+    "operations": [
+      "CreateInterruptibleCapacityReservationAllocation",
+      "UpdateInterruptibleCapacityReservationAllocation"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateInterruptibleCapacityReservationAllocation",
+      "UpdateInterruptibleCapacityReservationAllocation"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "CreateInterruptibleCapacityReservationAllocation": "not_implemented",
+      "UpdateInterruptibleCapacityReservationAllocation": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "IpamAddressHistory",
+    "operations": [
+      "GetIpamAddressHistory"
+    ],
+    "tested": [],
+    "untested": [
+      "GetIpamAddressHistory"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetIpamAddressHistory": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "IpamByoasn",
+    "operations": [
+      "AssociateIpamByoasn",
+      "DescribeIpamByoasn",
+      "DisassociateIpamByoasn"
+    ],
+    "tested": [
+      "DescribeIpamByoasn"
+    ],
+    "untested": [
+      "AssociateIpamByoasn",
+      "DisassociateIpamByoasn"
+    ],
+    "size": 3,
+    "untested_count": 2,
+    "probe_status": {
+      "AssociateIpamByoasn": "not_implemented",
+      "DescribeIpamByoasn": "working",
+      "DisassociateIpamByoasn": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "IpamDiscoveredAccounts",
+    "operations": [
+      "GetIpamDiscoveredAccounts"
+    ],
+    "tested": [],
+    "untested": [
+      "GetIpamDiscoveredAccounts"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetIpamDiscoveredAccounts": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "IpamDiscoveredPublicAddresses",
+    "operations": [
+      "GetIpamDiscoveredPublicAddresses"
+    ],
+    "tested": [],
+    "untested": [
+      "GetIpamDiscoveredPublicAddresses"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetIpamDiscoveredPublicAddresses": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "IpamDiscoveredResourceCidrs",
+    "operations": [
+      "GetIpamDiscoveredResourceCidrs"
+    ],
+    "tested": [],
+    "untested": [
+      "GetIpamDiscoveredResourceCidrs"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetIpamDiscoveredResourceCidrs": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "IpamExternalResourceVerificationToken",
+    "operations": [
+      "CreateIpamExternalResourceVerificationToken",
+      "DeleteIpamExternalResourceVerificationToken"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateIpamExternalResourceVerificationToken",
+      "DeleteIpamExternalResourceVerificationToken"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "CreateIpamExternalResourceVerificationToken": "not_implemented",
+      "DeleteIpamExternalResourceVerificationToken": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "IpamOrganizationAdminAccount",
+    "operations": [
+      "DisableIpamOrganizationAdminAccount",
+      "EnableIpamOrganizationAdminAccount"
+    ],
+    "tested": [],
+    "untested": [
+      "DisableIpamOrganizationAdminAccount",
+      "EnableIpamOrganizationAdminAccount"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "DisableIpamOrganizationAdminAccount": "not_implemented",
+      "EnableIpamOrganizationAdminAccount": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "IpamPolicy",
+    "operations": [
+      "CreateIpamPolicy",
+      "DeleteIpamPolicy",
+      "DisableIpamPolicy",
+      "EnableIpamPolicy"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateIpamPolicy",
+      "DeleteIpamPolicy",
+      "DisableIpamPolicy",
+      "EnableIpamPolicy"
+    ],
+    "size": 4,
+    "untested_count": 4,
+    "probe_status": {
+      "CreateIpamPolicy": "not_implemented",
+      "DeleteIpamPolicy": "not_implemented",
+      "DisableIpamPolicy": "not_implemented",
+      "EnableIpamPolicy": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "IpamPolicyAllocationRules",
+    "operations": [
+      "GetIpamPolicyAllocationRules",
+      "ModifyIpamPolicyAllocationRules"
+    ],
+    "tested": [],
+    "untested": [
+      "GetIpamPolicyAllocationRules",
+      "ModifyIpamPolicyAllocationRules"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "GetIpamPolicyAllocationRules": "not_implemented",
+      "ModifyIpamPolicyAllocationRules": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "IpamPolicyOrganizationTargets",
+    "operations": [
+      "GetIpamPolicyOrganizationTargets"
+    ],
+    "tested": [],
+    "untested": [
+      "GetIpamPolicyOrganizationTargets"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetIpamPolicyOrganizationTargets": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "IpamPrefixListResolver",
+    "operations": [
+      "CreateIpamPrefixListResolver",
+      "DeleteIpamPrefixListResolver",
+      "ModifyIpamPrefixListResolver"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateIpamPrefixListResolver",
+      "DeleteIpamPrefixListResolver",
+      "ModifyIpamPrefixListResolver"
+    ],
+    "size": 3,
+    "untested_count": 3,
+    "probe_status": {
+      "CreateIpamPrefixListResolver": "not_implemented",
+      "DeleteIpamPrefixListResolver": "not_implemented",
+      "ModifyIpamPrefixListResolver": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "IpamPrefixListResolverRules",
+    "operations": [
+      "GetIpamPrefixListResolverRules"
+    ],
+    "tested": [],
+    "untested": [
+      "GetIpamPrefixListResolverRules"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetIpamPrefixListResolverRules": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "IpamPrefixListResolverTarget",
+    "operations": [
+      "CreateIpamPrefixListResolverTarget",
+      "DeleteIpamPrefixListResolverTarget",
+      "ModifyIpamPrefixListResolverTarget"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateIpamPrefixListResolverTarget",
+      "DeleteIpamPrefixListResolverTarget",
+      "ModifyIpamPrefixListResolverTarget"
+    ],
+    "size": 3,
+    "untested_count": 3,
+    "probe_status": {
+      "CreateIpamPrefixListResolverTarget": "not_implemented",
+      "DeleteIpamPrefixListResolverTarget": "not_implemented",
+      "ModifyIpamPrefixListResolverTarget": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "IpamPrefixListResolverVersionEntries",
+    "operations": [
+      "GetIpamPrefixListResolverVersionEntries"
+    ],
+    "tested": [],
+    "untested": [
+      "GetIpamPrefixListResolverVersionEntries"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetIpamPrefixListResolverVersionEntries": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "IpamPrefixListResolverVersions",
+    "operations": [
+      "GetIpamPrefixListResolverVersions"
+    ],
+    "tested": [],
+    "untested": [
+      "GetIpamPrefixListResolverVersions"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetIpamPrefixListResolverVersions": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "IpamResourceCidr",
+    "operations": [
+      "ModifyIpamResourceCidr"
+    ],
+    "tested": [],
+    "untested": [
+      "ModifyIpamResourceCidr"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ModifyIpamResourceCidr": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "IpamResourceDiscovery",
+    "operations": [
+      "AssociateIpamResourceDiscovery",
+      "CreateIpamResourceDiscovery",
+      "DeleteIpamResourceDiscovery",
+      "DisassociateIpamResourceDiscovery",
+      "ModifyIpamResourceDiscovery"
+    ],
+    "tested": [
+      "CreateIpamResourceDiscovery"
+    ],
+    "untested": [
+      "AssociateIpamResourceDiscovery",
+      "DeleteIpamResourceDiscovery",
+      "DisassociateIpamResourceDiscovery",
+      "ModifyIpamResourceDiscovery"
+    ],
+    "size": 5,
+    "untested_count": 4,
+    "probe_status": {
+      "AssociateIpamResourceDiscovery": "not_implemented",
+      "CreateIpamResourceDiscovery": "working",
+      "DeleteIpamResourceDiscovery": "not_implemented",
+      "DisassociateIpamResourceDiscovery": "not_implemented",
+      "ModifyIpamResourceDiscovery": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "IpamScope",
+    "operations": [
+      "CreateIpamScope",
+      "DeleteIpamScope",
+      "ModifyIpamScope"
+    ],
+    "tested": [
+      "CreateIpamScope",
+      "DeleteIpamScope"
+    ],
+    "untested": [
+      "ModifyIpamScope"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateIpamScope": "working",
+      "DeleteIpamScope": "working",
+      "ModifyIpamScope": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "LaunchTemplateVersions",
+    "operations": [
+      "DeleteLaunchTemplateVersions",
+      "DescribeLaunchTemplateVersions"
+    ],
+    "tested": [
+      "DescribeLaunchTemplateVersions"
+    ],
+    "untested": [
+      "DeleteLaunchTemplateVersions"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "DeleteLaunchTemplateVersions": "not_implemented",
+      "DescribeLaunchTemplateVersions": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "LocalGatewayRoute",
+    "operations": [
+      "CreateLocalGatewayRoute",
+      "DeleteLocalGatewayRoute",
+      "ModifyLocalGatewayRoute"
+    ],
+    "tested": [
+      "CreateLocalGatewayRoute"
+    ],
+    "untested": [
+      "DeleteLocalGatewayRoute",
+      "ModifyLocalGatewayRoute"
+    ],
+    "size": 3,
+    "untested_count": 2,
+    "probe_status": {
+      "CreateLocalGatewayRoute": "working",
+      "DeleteLocalGatewayRoute": "not_implemented",
+      "ModifyLocalGatewayRoute": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "LocalGatewayRouteTableVirtualInterfaceGroupAssociation",
+    "operations": [
+      "CreateLocalGatewayRouteTableVirtualInterfaceGroupAssociation",
+      "DeleteLocalGatewayRouteTableVirtualInterfaceGroupAssociation"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateLocalGatewayRouteTableVirtualInterfaceGroupAssociation",
+      "DeleteLocalGatewayRouteTableVirtualInterfaceGroupAssociation"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "CreateLocalGatewayRouteTableVirtualInterfaceGroupAssociation": "not_implemented",
+      "DeleteLocalGatewayRouteTableVirtualInterfaceGroupAssociation": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "LocalGatewayRouteTableVpcAssociation",
+    "operations": [
+      "CreateLocalGatewayRouteTableVpcAssociation",
+      "DeleteLocalGatewayRouteTableVpcAssociation"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateLocalGatewayRouteTableVpcAssociation",
+      "DeleteLocalGatewayRouteTableVpcAssociation"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "CreateLocalGatewayRouteTableVpcAssociation": "not_implemented",
+      "DeleteLocalGatewayRouteTableVpcAssociation": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "LocalGatewayVirtualInterface",
+    "operations": [
+      "CreateLocalGatewayVirtualInterface",
+      "DeleteLocalGatewayVirtualInterface"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateLocalGatewayVirtualInterface",
+      "DeleteLocalGatewayVirtualInterface"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "CreateLocalGatewayVirtualInterface": "not_implemented",
+      "DeleteLocalGatewayVirtualInterface": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "LocalGatewayVirtualInterfaceGroup",
+    "operations": [
+      "CreateLocalGatewayVirtualInterfaceGroup",
+      "DeleteLocalGatewayVirtualInterfaceGroup"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateLocalGatewayVirtualInterfaceGroup",
+      "DeleteLocalGatewayVirtualInterfaceGroup"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "CreateLocalGatewayVirtualInterfaceGroup": "not_implemented",
+      "DeleteLocalGatewayVirtualInterfaceGroup": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "LockSnapshot",
+    "operations": [
+      "LockSnapshot"
+    ],
+    "tested": [],
+    "untested": [
+      "LockSnapshot"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "LockSnapshot": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "MacSystemIntegrityProtectionModificationTask",
+    "operations": [
+      "CreateMacSystemIntegrityProtectionModificationTask"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateMacSystemIntegrityProtectionModificationTask"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateMacSystemIntegrityProtectionModificationTask": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ManagedPrefixListAssociations",
+    "operations": [
+      "GetManagedPrefixListAssociations"
+    ],
+    "tested": [],
+    "untested": [
+      "GetManagedPrefixListAssociations"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetManagedPrefixListAssociations": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ManagedPrefixListVersion",
+    "operations": [
+      "RestoreManagedPrefixListVersion"
+    ],
+    "tested": [],
+    "untested": [
+      "RestoreManagedPrefixListVersion"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "RestoreManagedPrefixListVersion": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "NatGatewayAddress",
+    "operations": [
+      "AssociateNatGatewayAddress",
+      "DisassociateNatGatewayAddress"
+    ],
+    "tested": [],
+    "untested": [
+      "AssociateNatGatewayAddress",
+      "DisassociateNatGatewayAddress"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "AssociateNatGatewayAddress": "not_implemented",
+      "DisassociateNatGatewayAddress": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "NetworkInsightsAccessScopeAnalysis",
+    "operations": [
+      "DeleteNetworkInsightsAccessScopeAnalysis",
+      "StartNetworkInsightsAccessScopeAnalysis"
+    ],
+    "tested": [
+      "StartNetworkInsightsAccessScopeAnalysis"
+    ],
+    "untested": [
+      "DeleteNetworkInsightsAccessScopeAnalysis"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "DeleteNetworkInsightsAccessScopeAnalysis": "not_implemented",
+      "StartNetworkInsightsAccessScopeAnalysis": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "NetworkInsightsAnalysis",
+    "operations": [
+      "DeleteNetworkInsightsAnalysis",
+      "StartNetworkInsightsAnalysis"
+    ],
+    "tested": [
+      "StartNetworkInsightsAnalysis"
+    ],
+    "untested": [
+      "DeleteNetworkInsightsAnalysis"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "DeleteNetworkInsightsAnalysis": "not_implemented",
+      "StartNetworkInsightsAnalysis": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "NetworkInterfaceAttribute",
+    "operations": [
+      "DescribeNetworkInterfaceAttribute",
+      "ModifyNetworkInterfaceAttribute",
+      "ResetNetworkInterfaceAttribute"
+    ],
+    "tested": [
+      "DescribeNetworkInterfaceAttribute",
+      "ModifyNetworkInterfaceAttribute"
+    ],
+    "untested": [
+      "ResetNetworkInterfaceAttribute"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeNetworkInterfaceAttribute": "working",
+      "ModifyNetworkInterfaceAttribute": "working",
+      "ResetNetworkInterfaceAttribute": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "NetworkInterfacePermission",
+    "operations": [
+      "CreateNetworkInterfacePermission",
+      "DeleteNetworkInterfacePermission"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateNetworkInterfacePermission",
+      "DeleteNetworkInterfacePermission"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "CreateNetworkInterfacePermission": "not_implemented",
+      "DeleteNetworkInterfacePermission": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "PrivateDnsNameOptions",
+    "operations": [
+      "ModifyPrivateDnsNameOptions"
+    ],
+    "tested": [],
+    "untested": [
+      "ModifyPrivateDnsNameOptions"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ModifyPrivateDnsNameOptions": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "PrivateNatGatewayAddress",
+    "operations": [
+      "AssignPrivateNatGatewayAddress",
+      "UnassignPrivateNatGatewayAddress"
+    ],
+    "tested": [],
+    "untested": [
+      "AssignPrivateNatGatewayAddress",
+      "UnassignPrivateNatGatewayAddress"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "AssignPrivateNatGatewayAddress": "not_implemented",
+      "UnassignPrivateNatGatewayAddress": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ProductInstance",
+    "operations": [
+      "ConfirmProductInstance"
+    ],
+    "tested": [],
+    "untested": [
+      "ConfirmProductInstance"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ConfirmProductInstance": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ProvisionByoipCidr",
+    "operations": [
+      "ProvisionByoipCidr"
+    ],
+    "tested": [],
+    "untested": [
+      "ProvisionByoipCidr"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ProvisionByoipCidr": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ProvisionIpamByoasn",
+    "operations": [
+      "ProvisionIpamByoasn"
+    ],
+    "tested": [],
+    "untested": [
+      "ProvisionIpamByoasn"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ProvisionIpamByoasn": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "PublicIpDnsNameOptions",
+    "operations": [
+      "ModifyPublicIpDnsNameOptions"
+    ],
+    "tested": [],
+    "untested": [
+      "ModifyPublicIpDnsNameOptions"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ModifyPublicIpDnsNameOptions": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "PurchaseCapacityBlockExtension",
+    "operations": [
+      "PurchaseCapacityBlockExtension"
+    ],
+    "tested": [],
+    "untested": [
+      "PurchaseCapacityBlockExtension"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "PurchaseCapacityBlockExtension": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "PurchaseReservedInstancesOffering",
+    "operations": [
+      "PurchaseReservedInstancesOffering"
+    ],
+    "tested": [],
+    "untested": [
+      "PurchaseReservedInstancesOffering"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "PurchaseReservedInstancesOffering": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "PurchaseScheduledInstances",
+    "operations": [
+      "PurchaseScheduledInstances"
+    ],
+    "tested": [],
+    "untested": [
+      "PurchaseScheduledInstances"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "PurchaseScheduledInstances": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "QueuedReservedInstances",
+    "operations": [
+      "DeleteQueuedReservedInstances"
+    ],
+    "tested": [],
+    "untested": [
+      "DeleteQueuedReservedInstances"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DeleteQueuedReservedInstances": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ReportInstanceStatus",
+    "operations": [
+      "ReportInstanceStatus"
+    ],
+    "tested": [],
+    "untested": [
+      "ReportInstanceStatus"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ReportInstanceStatus": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ReservedInstances",
+    "operations": [
+      "DescribeReservedInstances",
+      "ModifyReservedInstances"
+    ],
+    "tested": [
+      "DescribeReservedInstances"
+    ],
+    "untested": [
+      "ModifyReservedInstances"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeReservedInstances": "working",
+      "ModifyReservedInstances": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ReservedInstancesExchangeQuote",
+    "operations": [
+      "AcceptReservedInstancesExchangeQuote",
+      "GetReservedInstancesExchangeQuote"
+    ],
+    "tested": [],
+    "untested": [
+      "AcceptReservedInstancesExchangeQuote",
+      "GetReservedInstancesExchangeQuote"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "AcceptReservedInstancesExchangeQuote": "not_implemented",
+      "GetReservedInstancesExchangeQuote": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ReservedInstancesListing",
+    "operations": [
+      "CancelReservedInstancesListing",
+      "CreateReservedInstancesListing"
+    ],
+    "tested": [],
+    "untested": [
+      "CancelReservedInstancesListing",
+      "CreateReservedInstancesListing"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "CancelReservedInstancesListing": "not_implemented",
+      "CreateReservedInstancesListing": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "RestoreImageTask",
+    "operations": [
+      "CreateRestoreImageTask"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateRestoreImageTask"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateRestoreImageTask": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "RouteServer",
+    "operations": [
+      "AssociateRouteServer",
+      "CreateRouteServer",
+      "DeleteRouteServer",
+      "DisassociateRouteServer",
+      "ModifyRouteServer"
+    ],
+    "tested": [],
+    "untested": [
+      "AssociateRouteServer",
+      "CreateRouteServer",
+      "DeleteRouteServer",
+      "DisassociateRouteServer",
+      "ModifyRouteServer"
+    ],
+    "size": 5,
+    "untested_count": 5,
+    "probe_status": {
+      "AssociateRouteServer": "not_implemented",
+      "CreateRouteServer": "not_implemented",
+      "DeleteRouteServer": "not_implemented",
+      "DisassociateRouteServer": "not_implemented",
+      "ModifyRouteServer": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "RouteServerAssociations",
+    "operations": [
+      "GetRouteServerAssociations"
+    ],
+    "tested": [],
+    "untested": [
+      "GetRouteServerAssociations"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetRouteServerAssociations": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "RouteServerEndpoint",
+    "operations": [
+      "CreateRouteServerEndpoint",
+      "DeleteRouteServerEndpoint"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateRouteServerEndpoint",
+      "DeleteRouteServerEndpoint"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "CreateRouteServerEndpoint": "not_implemented",
+      "DeleteRouteServerEndpoint": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "RouteServerPeer",
+    "operations": [
+      "CreateRouteServerPeer",
+      "DeleteRouteServerPeer"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateRouteServerPeer",
+      "DeleteRouteServerPeer"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "CreateRouteServerPeer": "not_implemented",
+      "DeleteRouteServerPeer": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "RouteServerPropagation",
+    "operations": [
+      "DisableRouteServerPropagation",
+      "EnableRouteServerPropagation"
+    ],
+    "tested": [],
+    "untested": [
+      "DisableRouteServerPropagation",
+      "EnableRouteServerPropagation"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "DisableRouteServerPropagation": "not_implemented",
+      "EnableRouteServerPropagation": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "RouteServerPropagations",
+    "operations": [
+      "GetRouteServerPropagations"
+    ],
+    "tested": [],
+    "untested": [
+      "GetRouteServerPropagations"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetRouteServerPropagations": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "RouteServerRoutingDatabase",
+    "operations": [
+      "GetRouteServerRoutingDatabase"
+    ],
+    "tested": [],
+    "untested": [
+      "GetRouteServerRoutingDatabase"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetRouteServerRoutingDatabase": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ScheduledInstanceAvailability",
+    "operations": [
+      "DescribeScheduledInstanceAvailability"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeScheduledInstanceAvailability"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeScheduledInstanceAvailability": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ScheduledInstances",
+    "operations": [
+      "DescribeScheduledInstances",
+      "RunScheduledInstances"
+    ],
+    "tested": [
+      "DescribeScheduledInstances"
+    ],
+    "untested": [
+      "RunScheduledInstances"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeScheduledInstances": "working",
+      "RunScheduledInstances": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SearchTransitGatewayMulticastGroups",
+    "operations": [
+      "SearchTransitGatewayMulticastGroups"
+    ],
+    "tested": [],
+    "untested": [
+      "SearchTransitGatewayMulticastGroups"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "SearchTransitGatewayMulticastGroups": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SecondaryNetwork",
+    "operations": [
+      "CreateSecondaryNetwork",
+      "DeleteSecondaryNetwork"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateSecondaryNetwork",
+      "DeleteSecondaryNetwork"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "CreateSecondaryNetwork": "not_implemented",
+      "DeleteSecondaryNetwork": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SecondarySubnet",
+    "operations": [
+      "CreateSecondarySubnet",
+      "DeleteSecondarySubnet"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateSecondarySubnet",
+      "DeleteSecondarySubnet"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "CreateSecondarySubnet": "not_implemented",
+      "DeleteSecondarySubnet": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SecurityGroupReferences",
+    "operations": [
+      "DescribeSecurityGroupReferences"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeSecurityGroupReferences"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeSecurityGroupReferences": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SecurityGroupsForVpc",
+    "operations": [
+      "GetSecurityGroupsForVpc"
+    ],
+    "tested": [],
+    "untested": [
+      "GetSecurityGroupsForVpc"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetSecurityGroupsForVpc": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SecurityGroupsToClientVpnTargetNetwork",
+    "operations": [
+      "ApplySecurityGroupsToClientVpnTargetNetwork"
+    ],
+    "tested": [],
+    "untested": [
+      "ApplySecurityGroupsToClientVpnTargetNetwork"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ApplySecurityGroupsToClientVpnTargetNetwork": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SnapshotAttribute",
+    "operations": [
+      "DescribeSnapshotAttribute",
+      "ModifySnapshotAttribute",
+      "ResetSnapshotAttribute"
+    ],
+    "tested": [
+      "DescribeSnapshotAttribute",
+      "ModifySnapshotAttribute"
+    ],
+    "untested": [
+      "ResetSnapshotAttribute"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeSnapshotAttribute": "working",
+      "ModifySnapshotAttribute": "working",
+      "ResetSnapshotAttribute": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SnapshotFromRecycleBin",
+    "operations": [
+      "RestoreSnapshotFromRecycleBin"
+    ],
+    "tested": [],
+    "untested": [
+      "RestoreSnapshotFromRecycleBin"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "RestoreSnapshotFromRecycleBin": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SnapshotTier",
+    "operations": [
+      "ModifySnapshotTier",
+      "RestoreSnapshotTier"
+    ],
+    "tested": [],
+    "untested": [
+      "ModifySnapshotTier",
+      "RestoreSnapshotTier"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "ModifySnapshotTier": "not_implemented",
+      "RestoreSnapshotTier": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SpotFleetRequestHistory",
+    "operations": [
+      "DescribeSpotFleetRequestHistory"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeSpotFleetRequestHistory"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeSpotFleetRequestHistory": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SpotPlacementScores",
+    "operations": [
+      "GetSpotPlacementScores"
+    ],
+    "tested": [],
+    "untested": [
+      "GetSpotPlacementScores"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetSpotPlacementScores": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TrafficMirrorFilterNetworkServices",
+    "operations": [
+      "ModifyTrafficMirrorFilterNetworkServices"
+    ],
+    "tested": [],
+    "untested": [
+      "ModifyTrafficMirrorFilterNetworkServices"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ModifyTrafficMirrorFilterNetworkServices": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TrafficMirrorFilterRule",
+    "operations": [
+      "CreateTrafficMirrorFilterRule",
+      "DeleteTrafficMirrorFilterRule",
+      "ModifyTrafficMirrorFilterRule"
+    ],
+    "tested": [
+      "CreateTrafficMirrorFilterRule",
+      "DeleteTrafficMirrorFilterRule"
+    ],
+    "untested": [
+      "ModifyTrafficMirrorFilterRule"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateTrafficMirrorFilterRule": "working",
+      "DeleteTrafficMirrorFilterRule": "working",
+      "ModifyTrafficMirrorFilterRule": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TrafficMirrorSession",
+    "operations": [
+      "CreateTrafficMirrorSession",
+      "DeleteTrafficMirrorSession",
+      "ModifyTrafficMirrorSession"
+    ],
+    "tested": [
+      "CreateTrafficMirrorSession",
+      "DeleteTrafficMirrorSession"
+    ],
+    "untested": [
+      "ModifyTrafficMirrorSession"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateTrafficMirrorSession": "working",
+      "DeleteTrafficMirrorSession": "working",
+      "ModifyTrafficMirrorSession": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TransitGatewayAttachmentPropagations",
+    "operations": [
+      "GetTransitGatewayAttachmentPropagations"
+    ],
+    "tested": [],
+    "untested": [
+      "GetTransitGatewayAttachmentPropagations"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetTransitGatewayAttachmentPropagations": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TransitGatewayMeteringPolicy",
+    "operations": [
+      "CreateTransitGatewayMeteringPolicy",
+      "DeleteTransitGatewayMeteringPolicy",
+      "ModifyTransitGatewayMeteringPolicy"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateTransitGatewayMeteringPolicy",
+      "DeleteTransitGatewayMeteringPolicy",
+      "ModifyTransitGatewayMeteringPolicy"
+    ],
+    "size": 3,
+    "untested_count": 3,
+    "probe_status": {
+      "CreateTransitGatewayMeteringPolicy": "not_implemented",
+      "DeleteTransitGatewayMeteringPolicy": "not_implemented",
+      "ModifyTransitGatewayMeteringPolicy": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TransitGatewayMeteringPolicyEntries",
+    "operations": [
+      "GetTransitGatewayMeteringPolicyEntries"
+    ],
+    "tested": [],
+    "untested": [
+      "GetTransitGatewayMeteringPolicyEntries"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetTransitGatewayMeteringPolicyEntries": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TransitGatewayMeteringPolicyEntry",
+    "operations": [
+      "CreateTransitGatewayMeteringPolicyEntry",
+      "DeleteTransitGatewayMeteringPolicyEntry"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateTransitGatewayMeteringPolicyEntry",
+      "DeleteTransitGatewayMeteringPolicyEntry"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "CreateTransitGatewayMeteringPolicyEntry": "not_implemented",
+      "DeleteTransitGatewayMeteringPolicyEntry": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TransitGatewayMulticastDomain",
+    "operations": [
+      "AssociateTransitGatewayMulticastDomain",
+      "CreateTransitGatewayMulticastDomain",
+      "DeleteTransitGatewayMulticastDomain",
+      "DisassociateTransitGatewayMulticastDomain"
+    ],
+    "tested": [],
+    "untested": [
+      "AssociateTransitGatewayMulticastDomain",
+      "CreateTransitGatewayMulticastDomain",
+      "DeleteTransitGatewayMulticastDomain",
+      "DisassociateTransitGatewayMulticastDomain"
+    ],
+    "size": 4,
+    "untested_count": 4,
+    "probe_status": {
+      "AssociateTransitGatewayMulticastDomain": "not_implemented",
+      "CreateTransitGatewayMulticastDomain": "not_implemented",
+      "DeleteTransitGatewayMulticastDomain": "not_implemented",
+      "DisassociateTransitGatewayMulticastDomain": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TransitGatewayMulticastDomainAssociations",
+    "operations": [
+      "AcceptTransitGatewayMulticastDomainAssociations",
+      "GetTransitGatewayMulticastDomainAssociations",
+      "RejectTransitGatewayMulticastDomainAssociations"
+    ],
+    "tested": [
+      "AcceptTransitGatewayMulticastDomainAssociations",
+      "RejectTransitGatewayMulticastDomainAssociations"
+    ],
+    "untested": [
+      "GetTransitGatewayMulticastDomainAssociations"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "AcceptTransitGatewayMulticastDomainAssociations": "working",
+      "GetTransitGatewayMulticastDomainAssociations": "not_implemented",
+      "RejectTransitGatewayMulticastDomainAssociations": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TransitGatewayMulticastGroupMembers",
+    "operations": [
+      "DeregisterTransitGatewayMulticastGroupMembers",
+      "RegisterTransitGatewayMulticastGroupMembers"
+    ],
+    "tested": [
+      "DeregisterTransitGatewayMulticastGroupMembers"
+    ],
+    "untested": [
+      "RegisterTransitGatewayMulticastGroupMembers"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "DeregisterTransitGatewayMulticastGroupMembers": "working",
+      "RegisterTransitGatewayMulticastGroupMembers": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TransitGatewayMulticastGroupSources",
+    "operations": [
+      "DeregisterTransitGatewayMulticastGroupSources",
+      "RegisterTransitGatewayMulticastGroupSources"
+    ],
+    "tested": [
+      "DeregisterTransitGatewayMulticastGroupSources"
+    ],
+    "untested": [
+      "RegisterTransitGatewayMulticastGroupSources"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "DeregisterTransitGatewayMulticastGroupSources": "working",
+      "RegisterTransitGatewayMulticastGroupSources": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TransitGatewayPolicyTable",
+    "operations": [
+      "AssociateTransitGatewayPolicyTable",
+      "CreateTransitGatewayPolicyTable",
+      "DeleteTransitGatewayPolicyTable",
+      "DisassociateTransitGatewayPolicyTable"
+    ],
+    "tested": [],
+    "untested": [
+      "AssociateTransitGatewayPolicyTable",
+      "CreateTransitGatewayPolicyTable",
+      "DeleteTransitGatewayPolicyTable",
+      "DisassociateTransitGatewayPolicyTable"
+    ],
+    "size": 4,
+    "untested_count": 4,
+    "probe_status": {
+      "AssociateTransitGatewayPolicyTable": "not_implemented",
+      "CreateTransitGatewayPolicyTable": "not_implemented",
+      "DeleteTransitGatewayPolicyTable": "not_implemented",
+      "DisassociateTransitGatewayPolicyTable": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TransitGatewayPolicyTableAssociations",
+    "operations": [
+      "GetTransitGatewayPolicyTableAssociations"
+    ],
+    "tested": [],
+    "untested": [
+      "GetTransitGatewayPolicyTableAssociations"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetTransitGatewayPolicyTableAssociations": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TransitGatewayPolicyTableEntries",
+    "operations": [
+      "GetTransitGatewayPolicyTableEntries"
+    ],
+    "tested": [],
+    "untested": [
+      "GetTransitGatewayPolicyTableEntries"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetTransitGatewayPolicyTableEntries": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TransitGatewayPrefixListReference",
+    "operations": [
+      "CreateTransitGatewayPrefixListReference",
+      "DeleteTransitGatewayPrefixListReference",
+      "ModifyTransitGatewayPrefixListReference"
+    ],
+    "tested": [
+      "CreateTransitGatewayPrefixListReference",
+      "DeleteTransitGatewayPrefixListReference"
+    ],
+    "untested": [
+      "ModifyTransitGatewayPrefixListReference"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateTransitGatewayPrefixListReference": "working",
+      "DeleteTransitGatewayPrefixListReference": "working",
+      "ModifyTransitGatewayPrefixListReference": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TransitGatewayRoute",
+    "operations": [
+      "CreateTransitGatewayRoute",
+      "DeleteTransitGatewayRoute",
+      "ReplaceTransitGatewayRoute"
+    ],
+    "tested": [
+      "CreateTransitGatewayRoute",
+      "DeleteTransitGatewayRoute"
+    ],
+    "untested": [
+      "ReplaceTransitGatewayRoute"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateTransitGatewayRoute": "500_error",
+      "DeleteTransitGatewayRoute": "500_error",
+      "ReplaceTransitGatewayRoute": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TransitGatewayRouteTableAnnouncement",
+    "operations": [
+      "CreateTransitGatewayRouteTableAnnouncement",
+      "DeleteTransitGatewayRouteTableAnnouncement"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateTransitGatewayRouteTableAnnouncement",
+      "DeleteTransitGatewayRouteTableAnnouncement"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "CreateTransitGatewayRouteTableAnnouncement": "not_implemented",
+      "DeleteTransitGatewayRouteTableAnnouncement": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TransitGatewayRoutes",
+    "operations": [
+      "ExportTransitGatewayRoutes"
+    ],
+    "tested": [],
+    "untested": [
+      "ExportTransitGatewayRoutes"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ExportTransitGatewayRoutes": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TransitGatewayVpcAttachment",
+    "operations": [
+      "AcceptTransitGatewayVpcAttachment",
+      "CreateTransitGatewayVpcAttachment",
+      "DeleteTransitGatewayVpcAttachment",
+      "ModifyTransitGatewayVpcAttachment",
+      "RejectTransitGatewayVpcAttachment"
+    ],
+    "tested": [
+      "CreateTransitGatewayVpcAttachment",
+      "DeleteTransitGatewayVpcAttachment",
+      "ModifyTransitGatewayVpcAttachment"
+    ],
+    "untested": [
+      "AcceptTransitGatewayVpcAttachment",
+      "RejectTransitGatewayVpcAttachment"
+    ],
+    "size": 5,
+    "untested_count": 2,
+    "probe_status": {
+      "AcceptTransitGatewayVpcAttachment": "not_implemented",
+      "CreateTransitGatewayVpcAttachment": "working",
+      "DeleteTransitGatewayVpcAttachment": "working",
+      "ModifyTransitGatewayVpcAttachment": "working",
+      "RejectTransitGatewayVpcAttachment": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TrunkInterface",
+    "operations": [
+      "AssociateTrunkInterface",
+      "DisassociateTrunkInterface"
+    ],
+    "tested": [],
+    "untested": [
+      "AssociateTrunkInterface",
+      "DisassociateTrunkInterface"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "AssociateTrunkInterface": "not_implemented",
+      "DisassociateTrunkInterface": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "UnlockSnapshot",
+    "operations": [
+      "UnlockSnapshot"
+    ],
+    "tested": [],
+    "untested": [
+      "UnlockSnapshot"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "UnlockSnapshot": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "VerifiedAccessEndpoint",
+    "operations": [
+      "CreateVerifiedAccessEndpoint",
+      "DeleteVerifiedAccessEndpoint",
+      "ModifyVerifiedAccessEndpoint"
+    ],
+    "tested": [
+      "CreateVerifiedAccessEndpoint",
+      "DeleteVerifiedAccessEndpoint"
+    ],
+    "untested": [
+      "ModifyVerifiedAccessEndpoint"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateVerifiedAccessEndpoint": "working",
+      "DeleteVerifiedAccessEndpoint": "working",
+      "ModifyVerifiedAccessEndpoint": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "VerifiedAccessEndpointPolicy",
+    "operations": [
+      "GetVerifiedAccessEndpointPolicy",
+      "ModifyVerifiedAccessEndpointPolicy"
+    ],
+    "tested": [],
+    "untested": [
+      "GetVerifiedAccessEndpointPolicy",
+      "ModifyVerifiedAccessEndpointPolicy"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "GetVerifiedAccessEndpointPolicy": "not_implemented",
+      "ModifyVerifiedAccessEndpointPolicy": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "VerifiedAccessEndpointTargets",
+    "operations": [
+      "GetVerifiedAccessEndpointTargets"
+    ],
+    "tested": [],
+    "untested": [
+      "GetVerifiedAccessEndpointTargets"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetVerifiedAccessEndpointTargets": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "VerifiedAccessGroup",
+    "operations": [
+      "CreateVerifiedAccessGroup",
+      "DeleteVerifiedAccessGroup",
+      "ModifyVerifiedAccessGroup"
+    ],
+    "tested": [
+      "CreateVerifiedAccessGroup",
+      "DeleteVerifiedAccessGroup"
+    ],
+    "untested": [
+      "ModifyVerifiedAccessGroup"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateVerifiedAccessGroup": "working",
+      "DeleteVerifiedAccessGroup": "working",
+      "ModifyVerifiedAccessGroup": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "VerifiedAccessGroupPolicy",
+    "operations": [
+      "GetVerifiedAccessGroupPolicy",
+      "ModifyVerifiedAccessGroupPolicy"
+    ],
+    "tested": [],
+    "untested": [
+      "GetVerifiedAccessGroupPolicy",
+      "ModifyVerifiedAccessGroupPolicy"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "GetVerifiedAccessGroupPolicy": "not_implemented",
+      "ModifyVerifiedAccessGroupPolicy": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "VerifiedAccessInstance",
+    "operations": [
+      "CreateVerifiedAccessInstance",
+      "DeleteVerifiedAccessInstance",
+      "ModifyVerifiedAccessInstance"
+    ],
+    "tested": [
+      "CreateVerifiedAccessInstance",
+      "DeleteVerifiedAccessInstance"
+    ],
+    "untested": [
+      "ModifyVerifiedAccessInstance"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateVerifiedAccessInstance": "working",
+      "DeleteVerifiedAccessInstance": "working",
+      "ModifyVerifiedAccessInstance": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "VerifiedAccessInstanceClientConfiguration",
+    "operations": [
+      "ExportVerifiedAccessInstanceClientConfiguration"
+    ],
+    "tested": [],
+    "untested": [
+      "ExportVerifiedAccessInstanceClientConfiguration"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ExportVerifiedAccessInstanceClientConfiguration": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "VerifiedAccessInstanceLoggingConfiguration",
+    "operations": [
+      "ModifyVerifiedAccessInstanceLoggingConfiguration"
+    ],
+    "tested": [],
+    "untested": [
+      "ModifyVerifiedAccessInstanceLoggingConfiguration"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ModifyVerifiedAccessInstanceLoggingConfiguration": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "VerifiedAccessTrustProvider",
+    "operations": [
+      "AttachVerifiedAccessTrustProvider",
+      "CreateVerifiedAccessTrustProvider",
+      "DeleteVerifiedAccessTrustProvider",
+      "DetachVerifiedAccessTrustProvider",
+      "ModifyVerifiedAccessTrustProvider"
+    ],
+    "tested": [
+      "AttachVerifiedAccessTrustProvider",
+      "CreateVerifiedAccessTrustProvider",
+      "DeleteVerifiedAccessTrustProvider",
+      "DetachVerifiedAccessTrustProvider"
+    ],
+    "untested": [
+      "ModifyVerifiedAccessTrustProvider"
+    ],
+    "size": 5,
+    "untested_count": 1,
+    "probe_status": {
+      "AttachVerifiedAccessTrustProvider": "not_implemented",
+      "CreateVerifiedAccessTrustProvider": "working",
+      "DeleteVerifiedAccessTrustProvider": "working",
+      "DetachVerifiedAccessTrustProvider": "not_implemented",
+      "ModifyVerifiedAccessTrustProvider": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "VgwRoutePropagation",
+    "operations": [
+      "DisableVgwRoutePropagation",
+      "EnableVgwRoutePropagation"
+    ],
+    "tested": [],
+    "untested": [
+      "DisableVgwRoutePropagation",
+      "EnableVgwRoutePropagation"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "DisableVgwRoutePropagation": "not_implemented",
+      "EnableVgwRoutePropagation": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Volume",
+    "operations": [
+      "AttachVolume",
+      "CreateVolume",
+      "DeleteVolume",
+      "DetachVolume",
+      "ImportVolume",
+      "ModifyVolume"
+    ],
+    "tested": [
+      "AttachVolume",
+      "CreateVolume",
+      "DeleteVolume",
+      "DetachVolume",
+      "ModifyVolume"
+    ],
+    "untested": [
+      "ImportVolume"
+    ],
+    "size": 6,
+    "untested_count": 1,
+    "probe_status": {
+      "AttachVolume": "working",
+      "CreateVolume": "working",
+      "DeleteVolume": "working",
+      "DetachVolume": "500_error",
+      "ImportVolume": "not_implemented",
+      "ModifyVolume": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "VolumeFromRecycleBin",
+    "operations": [
+      "RestoreVolumeFromRecycleBin"
+    ],
+    "tested": [],
+    "untested": [
+      "RestoreVolumeFromRecycleBin"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "RestoreVolumeFromRecycleBin": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "VolumeIO",
+    "operations": [
+      "EnableVolumeIO"
+    ],
+    "tested": [],
+    "untested": [
+      "EnableVolumeIO"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "EnableVolumeIO": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Volumes",
+    "operations": [
+      "CopyVolumes",
+      "DescribeVolumes"
+    ],
+    "tested": [
+      "DescribeVolumes"
+    ],
+    "untested": [
+      "CopyVolumes"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "CopyVolumes": "not_implemented",
+      "DescribeVolumes": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "VpcBlockPublicAccessExclusion",
+    "operations": [
+      "CreateVpcBlockPublicAccessExclusion",
+      "DeleteVpcBlockPublicAccessExclusion",
+      "ModifyVpcBlockPublicAccessExclusion"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateVpcBlockPublicAccessExclusion",
+      "DeleteVpcBlockPublicAccessExclusion",
+      "ModifyVpcBlockPublicAccessExclusion"
+    ],
+    "size": 3,
+    "untested_count": 3,
+    "probe_status": {
+      "CreateVpcBlockPublicAccessExclusion": "not_implemented",
+      "DeleteVpcBlockPublicAccessExclusion": "not_implemented",
+      "ModifyVpcBlockPublicAccessExclusion": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "VpcBlockPublicAccessOptions",
+    "operations": [
+      "DescribeVpcBlockPublicAccessOptions",
+      "ModifyVpcBlockPublicAccessOptions"
+    ],
+    "tested": [
+      "DescribeVpcBlockPublicAccessOptions"
+    ],
+    "untested": [
+      "ModifyVpcBlockPublicAccessOptions"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeVpcBlockPublicAccessOptions": "working",
+      "ModifyVpcBlockPublicAccessOptions": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "VpcEncryptionControl",
+    "operations": [
+      "CreateVpcEncryptionControl",
+      "DeleteVpcEncryptionControl",
+      "ModifyVpcEncryptionControl"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateVpcEncryptionControl",
+      "DeleteVpcEncryptionControl",
+      "ModifyVpcEncryptionControl"
+    ],
+    "size": 3,
+    "untested_count": 3,
+    "probe_status": {
+      "CreateVpcEncryptionControl": "not_implemented",
+      "DeleteVpcEncryptionControl": "not_implemented",
+      "ModifyVpcEncryptionControl": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "VpcEndpointConnectionNotification",
+    "operations": [
+      "CreateVpcEndpointConnectionNotification",
+      "ModifyVpcEndpointConnectionNotification"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateVpcEndpointConnectionNotification",
+      "ModifyVpcEndpointConnectionNotification"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "CreateVpcEndpointConnectionNotification": "not_implemented",
+      "ModifyVpcEndpointConnectionNotification": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "VpcEndpointConnectionNotifications",
+    "operations": [
+      "DeleteVpcEndpointConnectionNotifications",
+      "DescribeVpcEndpointConnectionNotifications"
+    ],
+    "tested": [
+      "DescribeVpcEndpointConnectionNotifications"
+    ],
+    "untested": [
+      "DeleteVpcEndpointConnectionNotifications"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "DeleteVpcEndpointConnectionNotifications": "not_implemented",
+      "DescribeVpcEndpointConnectionNotifications": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "VpcEndpointServicePayerResponsibility",
+    "operations": [
+      "ModifyVpcEndpointServicePayerResponsibility"
+    ],
+    "tested": [],
+    "untested": [
+      "ModifyVpcEndpointServicePayerResponsibility"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ModifyVpcEndpointServicePayerResponsibility": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "VpcEndpointServicePrivateDnsVerification",
+    "operations": [
+      "StartVpcEndpointServicePrivateDnsVerification"
+    ],
+    "tested": [],
+    "untested": [
+      "StartVpcEndpointServicePrivateDnsVerification"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "StartVpcEndpointServicePrivateDnsVerification": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "VpcResourcesBlockingEncryptionEnforcement",
+    "operations": [
+      "GetVpcResourcesBlockingEncryptionEnforcement"
+    ],
+    "tested": [],
+    "untested": [
+      "GetVpcResourcesBlockingEncryptionEnforcement"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetVpcResourcesBlockingEncryptionEnforcement": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "VpnConcentrator",
+    "operations": [
+      "CreateVpnConcentrator",
+      "DeleteVpnConcentrator"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateVpnConcentrator",
+      "DeleteVpnConcentrator"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "CreateVpnConcentrator": "not_implemented",
+      "DeleteVpnConcentrator": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "VpnConnection",
+    "operations": [
+      "CreateVpnConnection",
+      "DeleteVpnConnection",
+      "ModifyVpnConnection"
+    ],
+    "tested": [
+      "CreateVpnConnection",
+      "DeleteVpnConnection"
+    ],
+    "untested": [
+      "ModifyVpnConnection"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateVpnConnection": "working",
+      "DeleteVpnConnection": "working",
+      "ModifyVpnConnection": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "VpnConnectionDeviceSampleConfiguration",
+    "operations": [
+      "GetVpnConnectionDeviceSampleConfiguration"
+    ],
+    "tested": [],
+    "untested": [
+      "GetVpnConnectionDeviceSampleConfiguration"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetVpnConnectionDeviceSampleConfiguration": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "VpnConnectionOptions",
+    "operations": [
+      "ModifyVpnConnectionOptions"
+    ],
+    "tested": [],
+    "untested": [
+      "ModifyVpnConnectionOptions"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ModifyVpnConnectionOptions": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "VpnConnectionRoute",
+    "operations": [
+      "CreateVpnConnectionRoute",
+      "DeleteVpnConnectionRoute"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateVpnConnectionRoute",
+      "DeleteVpnConnectionRoute"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "CreateVpnConnectionRoute": "not_implemented",
+      "DeleteVpnConnectionRoute": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "VpnTunnel",
+    "operations": [
+      "ReplaceVpnTunnel"
+    ],
+    "tested": [],
+    "untested": [
+      "ReplaceVpnTunnel"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ReplaceVpnTunnel": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "VpnTunnelCertificate",
+    "operations": [
+      "ModifyVpnTunnelCertificate"
+    ],
+    "tested": [],
+    "untested": [
+      "ModifyVpnTunnelCertificate"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ModifyVpnTunnelCertificate": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "VpnTunnelOptions",
+    "operations": [
+      "ModifyVpnTunnelOptions"
+    ],
+    "tested": [],
+    "untested": [
+      "ModifyVpnTunnelOptions"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ModifyVpnTunnelOptions": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "VpnTunnelReplacementStatus",
+    "operations": [
+      "GetVpnTunnelReplacementStatus"
+    ],
+    "tested": [],
+    "untested": [
+      "GetVpnTunnelReplacementStatus"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetVpnTunnelReplacementStatus": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/ecr.json
+++ b/chunks/ecr.json
@@ -1,0 +1,181 @@
+[
+  {
+    "noun": "CompleteLayerUpload",
+    "operations": [
+      "CompleteLayerUpload"
+    ],
+    "tested": [],
+    "untested": [
+      "CompleteLayerUpload"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "CompleteLayerUpload": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DownloadUrlForLayer",
+    "operations": [
+      "GetDownloadUrlForLayer"
+    ],
+    "tested": [],
+    "untested": [
+      "GetDownloadUrlForLayer"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetDownloadUrlForLayer": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ImageReferrers",
+    "operations": [
+      "ListImageReferrers"
+    ],
+    "tested": [],
+    "untested": [
+      "ListImageReferrers"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListImageReferrers": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ImageSigningStatus",
+    "operations": [
+      "DescribeImageSigningStatus"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeImageSigningStatus"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeImageSigningStatus": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ImageStorageClass",
+    "operations": [
+      "UpdateImageStorageClass"
+    ],
+    "tested": [],
+    "untested": [
+      "UpdateImageStorageClass"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "UpdateImageStorageClass": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "InitiateLayerUpload",
+    "operations": [
+      "InitiateLayerUpload"
+    ],
+    "tested": [],
+    "untested": [
+      "InitiateLayerUpload"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "InitiateLayerUpload": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "PullTimeUpdateExclusion",
+    "operations": [
+      "DeregisterPullTimeUpdateExclusion",
+      "RegisterPullTimeUpdateExclusion"
+    ],
+    "tested": [],
+    "untested": [
+      "DeregisterPullTimeUpdateExclusion",
+      "RegisterPullTimeUpdateExclusion"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "DeregisterPullTimeUpdateExclusion": "not_implemented",
+      "RegisterPullTimeUpdateExclusion": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "PullTimeUpdateExclusions",
+    "operations": [
+      "ListPullTimeUpdateExclusions"
+    ],
+    "tested": [],
+    "untested": [
+      "ListPullTimeUpdateExclusions"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListPullTimeUpdateExclusions": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SigningConfiguration",
+    "operations": [
+      "DeleteSigningConfiguration",
+      "GetSigningConfiguration",
+      "PutSigningConfiguration"
+    ],
+    "tested": [],
+    "untested": [
+      "DeleteSigningConfiguration",
+      "GetSigningConfiguration",
+      "PutSigningConfiguration"
+    ],
+    "size": 3,
+    "untested_count": 3,
+    "probe_status": {
+      "DeleteSigningConfiguration": "not_implemented",
+      "GetSigningConfiguration": "not_implemented",
+      "PutSigningConfiguration": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "UploadLayerPart",
+    "operations": [
+      "UploadLayerPart"
+    ],
+    "tested": [],
+    "untested": [
+      "UploadLayerPart"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "UploadLayerPart": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/ecs.json
+++ b/chunks/ecs.json
@@ -1,0 +1,99 @@
+[
+  {
+    "noun": "ExpressGatewayService",
+    "operations": [
+      "CreateExpressGatewayService",
+      "DeleteExpressGatewayService",
+      "DescribeExpressGatewayService",
+      "UpdateExpressGatewayService"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateExpressGatewayService",
+      "DeleteExpressGatewayService",
+      "DescribeExpressGatewayService",
+      "UpdateExpressGatewayService"
+    ],
+    "size": 4,
+    "untested_count": 4,
+    "probe_status": {
+      "CreateExpressGatewayService": "not_implemented",
+      "DeleteExpressGatewayService": "not_implemented",
+      "DescribeExpressGatewayService": "not_implemented",
+      "UpdateExpressGatewayService": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ServiceDeployment",
+    "operations": [
+      "StopServiceDeployment"
+    ],
+    "tested": [],
+    "untested": [
+      "StopServiceDeployment"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "StopServiceDeployment": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ServiceDeployments",
+    "operations": [
+      "DescribeServiceDeployments",
+      "ListServiceDeployments"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeServiceDeployments",
+      "ListServiceDeployments"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "DescribeServiceDeployments": "not_implemented",
+      "ListServiceDeployments": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ServiceRevisions",
+    "operations": [
+      "DescribeServiceRevisions"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeServiceRevisions"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeServiceRevisions": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SubmitAttachmentStateChanges",
+    "operations": [
+      "SubmitAttachmentStateChanges"
+    ],
+    "tested": [],
+    "untested": [
+      "SubmitAttachmentStateChanges"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "SubmitAttachmentStateChanges": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/efs.json
+++ b/chunks/efs.json
@@ -1,0 +1,63 @@
+[
+  {
+    "noun": "FileSystemProtection",
+    "operations": [
+      "UpdateFileSystemProtection"
+    ],
+    "tested": [],
+    "untested": [
+      "UpdateFileSystemProtection"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "UpdateFileSystemProtection": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ReplicationConfiguration",
+    "operations": [
+      "CreateReplicationConfiguration",
+      "DeleteReplicationConfiguration"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateReplicationConfiguration",
+      "DeleteReplicationConfiguration"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "CreateReplicationConfiguration": "not_implemented",
+      "DeleteReplicationConfiguration": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Tags",
+    "operations": [
+      "CreateTags",
+      "DeleteTags",
+      "DescribeTags"
+    ],
+    "tested": [
+      "DescribeTags"
+    ],
+    "untested": [
+      "CreateTags",
+      "DeleteTags"
+    ],
+    "size": 3,
+    "untested_count": 2,
+    "probe_status": {
+      "CreateTags": "not_implemented",
+      "DeleteTags": "needs_params",
+      "DescribeTags": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/eks.json
+++ b/chunks/eks.json
@@ -1,0 +1,194 @@
+[
+  {
+    "noun": "AccessEntry",
+    "operations": [
+      "CreateAccessEntry",
+      "DeleteAccessEntry",
+      "DescribeAccessEntry",
+      "UpdateAccessEntry"
+    ],
+    "tested": [
+      "CreateAccessEntry"
+    ],
+    "untested": [
+      "DeleteAccessEntry",
+      "DescribeAccessEntry",
+      "UpdateAccessEntry"
+    ],
+    "size": 4,
+    "untested_count": 3,
+    "probe_status": {
+      "CreateAccessEntry": "working",
+      "DeleteAccessEntry": "not_implemented",
+      "DescribeAccessEntry": "not_implemented",
+      "UpdateAccessEntry": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "AccessPolicy",
+    "operations": [
+      "AssociateAccessPolicy",
+      "DisassociateAccessPolicy"
+    ],
+    "tested": [],
+    "untested": [
+      "AssociateAccessPolicy",
+      "DisassociateAccessPolicy"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "AssociateAccessPolicy": "not_implemented",
+      "DisassociateAccessPolicy": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "AssociatedAccessPolicies",
+    "operations": [
+      "ListAssociatedAccessPolicies"
+    ],
+    "tested": [],
+    "untested": [
+      "ListAssociatedAccessPolicies"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListAssociatedAccessPolicies": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Cluster",
+    "operations": [
+      "CreateCluster",
+      "DeleteCluster",
+      "DeregisterCluster",
+      "DescribeCluster",
+      "RegisterCluster"
+    ],
+    "tested": [
+      "CreateCluster",
+      "DeleteCluster",
+      "DeregisterCluster",
+      "DescribeCluster"
+    ],
+    "untested": [
+      "RegisterCluster"
+    ],
+    "size": 5,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateCluster": "500_error",
+      "DeleteCluster": "unknown",
+      "DeregisterCluster": "working",
+      "DescribeCluster": "working",
+      "RegisterCluster": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "InsightsRefresh",
+    "operations": [
+      "DescribeInsightsRefresh",
+      "StartInsightsRefresh"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeInsightsRefresh",
+      "StartInsightsRefresh"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "DescribeInsightsRefresh": "not_implemented",
+      "StartInsightsRefresh": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "NodegroupVersion",
+    "operations": [
+      "UpdateNodegroupVersion"
+    ],
+    "tested": [],
+    "untested": [
+      "UpdateNodegroupVersion"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "UpdateNodegroupVersion": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "PodIdentityAssociation",
+    "operations": [
+      "CreatePodIdentityAssociation",
+      "DeletePodIdentityAssociation",
+      "DescribePodIdentityAssociation",
+      "UpdatePodIdentityAssociation"
+    ],
+    "tested": [
+      "CreatePodIdentityAssociation",
+      "DeletePodIdentityAssociation",
+      "DescribePodIdentityAssociation"
+    ],
+    "untested": [
+      "UpdatePodIdentityAssociation"
+    ],
+    "size": 4,
+    "untested_count": 1,
+    "probe_status": {
+      "CreatePodIdentityAssociation": "working",
+      "DeletePodIdentityAssociation": "working",
+      "DescribePodIdentityAssociation": "working",
+      "UpdatePodIdentityAssociation": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Update",
+    "operations": [
+      "DescribeUpdate"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeUpdate"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeUpdate": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Updates",
+    "operations": [
+      "ListUpdates"
+    ],
+    "tested": [],
+    "untested": [
+      "ListUpdates"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListUpdates": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/elasticache.json
+++ b/chunks/elasticache.json
@@ -1,0 +1,230 @@
+[
+  {
+    "noun": "AllowedNodeTypeModifications",
+    "operations": [
+      "ListAllowedNodeTypeModifications"
+    ],
+    "tested": [],
+    "untested": [
+      "ListAllowedNodeTypeModifications"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListAllowedNodeTypeModifications": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "CacheCluster",
+    "operations": [
+      "CreateCacheCluster",
+      "DeleteCacheCluster",
+      "ModifyCacheCluster",
+      "RebootCacheCluster"
+    ],
+    "tested": [
+      "CreateCacheCluster",
+      "DeleteCacheCluster",
+      "ModifyCacheCluster"
+    ],
+    "untested": [
+      "RebootCacheCluster"
+    ],
+    "size": 4,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateCacheCluster": "working",
+      "DeleteCacheCluster": "unknown",
+      "ModifyCacheCluster": "working",
+      "RebootCacheCluster": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "CacheSecurityGroupIngress",
+    "operations": [
+      "AuthorizeCacheSecurityGroupIngress",
+      "RevokeCacheSecurityGroupIngress"
+    ],
+    "tested": [
+      "RevokeCacheSecurityGroupIngress"
+    ],
+    "untested": [
+      "AuthorizeCacheSecurityGroupIngress"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "AuthorizeCacheSecurityGroupIngress": "not_implemented",
+      "RevokeCacheSecurityGroupIngress": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DecreaseNodeGroupsInGlobalReplicationGroup",
+    "operations": [
+      "DecreaseNodeGroupsInGlobalReplicationGroup"
+    ],
+    "tested": [],
+    "untested": [
+      "DecreaseNodeGroupsInGlobalReplicationGroup"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DecreaseNodeGroupsInGlobalReplicationGroup": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "EngineDefaultParameters",
+    "operations": [
+      "DescribeEngineDefaultParameters"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeEngineDefaultParameters"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeEngineDefaultParameters": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "IncreaseNodeGroupsInGlobalReplicationGroup",
+    "operations": [
+      "IncreaseNodeGroupsInGlobalReplicationGroup"
+    ],
+    "tested": [],
+    "untested": [
+      "IncreaseNodeGroupsInGlobalReplicationGroup"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "IncreaseNodeGroupsInGlobalReplicationGroup": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Migration",
+    "operations": [
+      "StartMigration"
+    ],
+    "tested": [],
+    "untested": [
+      "StartMigration"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "StartMigration": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "PurchaseReservedCacheNodesOffering",
+    "operations": [
+      "PurchaseReservedCacheNodesOffering"
+    ],
+    "tested": [],
+    "untested": [
+      "PurchaseReservedCacheNodesOffering"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "PurchaseReservedCacheNodesOffering": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ReplicationGroupShardConfiguration",
+    "operations": [
+      "ModifyReplicationGroupShardConfiguration"
+    ],
+    "tested": [],
+    "untested": [
+      "ModifyReplicationGroupShardConfiguration"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ModifyReplicationGroupShardConfiguration": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ReservedCacheNodes",
+    "operations": [
+      "DescribeReservedCacheNodes"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeReservedCacheNodes"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeReservedCacheNodes": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ReservedCacheNodesOfferings",
+    "operations": [
+      "DescribeReservedCacheNodesOfferings"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeReservedCacheNodesOfferings"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeReservedCacheNodesOfferings": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ServerlessCacheSnapshot",
+    "operations": [
+      "CopyServerlessCacheSnapshot",
+      "CreateServerlessCacheSnapshot",
+      "DeleteServerlessCacheSnapshot",
+      "ExportServerlessCacheSnapshot"
+    ],
+    "tested": [
+      "CreateServerlessCacheSnapshot",
+      "DeleteServerlessCacheSnapshot"
+    ],
+    "untested": [
+      "CopyServerlessCacheSnapshot",
+      "ExportServerlessCacheSnapshot"
+    ],
+    "size": 4,
+    "untested_count": 2,
+    "probe_status": {
+      "CopyServerlessCacheSnapshot": "not_implemented",
+      "CreateServerlessCacheSnapshot": "working",
+      "DeleteServerlessCacheSnapshot": "working",
+      "ExportServerlessCacheSnapshot": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/elasticbeanstalk.json
+++ b/chunks/elasticbeanstalk.json
@@ -1,0 +1,213 @@
+[
+  {
+    "noun": "Application",
+    "operations": [
+      "CreateApplication",
+      "DeleteApplication",
+      "UpdateApplication"
+    ],
+    "tested": [
+      "CreateApplication",
+      "DeleteApplication"
+    ],
+    "untested": [
+      "UpdateApplication"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateApplication": "working",
+      "DeleteApplication": "working",
+      "UpdateApplication": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ApplicationResourceLifecycle",
+    "operations": [
+      "UpdateApplicationResourceLifecycle"
+    ],
+    "tested": [],
+    "untested": [
+      "UpdateApplicationResourceLifecycle"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "UpdateApplicationResourceLifecycle": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ApplicationVersion",
+    "operations": [
+      "CreateApplicationVersion",
+      "DeleteApplicationVersion",
+      "UpdateApplicationVersion"
+    ],
+    "tested": [
+      "CreateApplicationVersion"
+    ],
+    "untested": [
+      "DeleteApplicationVersion",
+      "UpdateApplicationVersion"
+    ],
+    "size": 3,
+    "untested_count": 2,
+    "probe_status": {
+      "CreateApplicationVersion": "working",
+      "DeleteApplicationVersion": "not_implemented",
+      "UpdateApplicationVersion": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "CheckDNSAvailability",
+    "operations": [
+      "CheckDNSAvailability"
+    ],
+    "tested": [],
+    "untested": [
+      "CheckDNSAvailability"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "CheckDNSAvailability": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Environment",
+    "operations": [
+      "CreateEnvironment",
+      "TerminateEnvironment",
+      "UpdateEnvironment"
+    ],
+    "tested": [
+      "CreateEnvironment",
+      "UpdateEnvironment"
+    ],
+    "untested": [
+      "TerminateEnvironment"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateEnvironment": "working",
+      "TerminateEnvironment": "unknown",
+      "UpdateEnvironment": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "EnvironmentConfiguration",
+    "operations": [
+      "DeleteEnvironmentConfiguration"
+    ],
+    "tested": [],
+    "untested": [
+      "DeleteEnvironmentConfiguration"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DeleteEnvironmentConfiguration": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "EnvironmentOperationsRole",
+    "operations": [
+      "AssociateEnvironmentOperationsRole",
+      "DisassociateEnvironmentOperationsRole"
+    ],
+    "tested": [],
+    "untested": [
+      "AssociateEnvironmentOperationsRole",
+      "DisassociateEnvironmentOperationsRole"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "AssociateEnvironmentOperationsRole": "not_implemented",
+      "DisassociateEnvironmentOperationsRole": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "RestartAppServer",
+    "operations": [
+      "RestartAppServer"
+    ],
+    "tested": [],
+    "untested": [
+      "RestartAppServer"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "RestartAppServer": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "StorageLocation",
+    "operations": [
+      "CreateStorageLocation"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateStorageLocation"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateStorageLocation": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SwapEnvironmentCNAMEs",
+    "operations": [
+      "SwapEnvironmentCNAMEs"
+    ],
+    "tested": [],
+    "untested": [
+      "SwapEnvironmentCNAMEs"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "SwapEnvironmentCNAMEs": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ValidateConfigurationSettings",
+    "operations": [
+      "ValidateConfigurationSettings"
+    ],
+    "tested": [],
+    "untested": [
+      "ValidateConfigurationSettings"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ValidateConfigurationSettings": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/elb.json
+++ b/chunks/elb.json
@@ -1,0 +1,72 @@
+[
+  {
+    "noun": "LoadBalancerListenerSSLCertificate",
+    "operations": [
+      "SetLoadBalancerListenerSSLCertificate"
+    ],
+    "tested": [],
+    "untested": [
+      "SetLoadBalancerListenerSSLCertificate"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "SetLoadBalancerListenerSSLCertificate": "working"
+    },
+    "working_untested": [
+      "SetLoadBalancerListenerSSLCertificate"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "AccountLimits",
+    "operations": [
+      "DescribeAccountLimits"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeAccountLimits"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeAccountLimits": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "LBCookieStickinessPolicy",
+    "operations": [
+      "CreateLBCookieStickinessPolicy"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateLBCookieStickinessPolicy"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateLBCookieStickinessPolicy": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "LoadBalancerPolicyTypes",
+    "operations": [
+      "DescribeLoadBalancerPolicyTypes"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeLoadBalancerPolicyTypes"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeLoadBalancerPolicyTypes": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/emr.json
+++ b/chunks/emr.json
@@ -1,0 +1,198 @@
+[
+  {
+    "noun": "JobFlows",
+    "operations": [
+      "DescribeJobFlows",
+      "TerminateJobFlows"
+    ],
+    "tested": [
+      "TerminateJobFlows"
+    ],
+    "untested": [
+      "DescribeJobFlows"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeJobFlows": "working",
+      "TerminateJobFlows": "working"
+    },
+    "working_untested": [
+      "DescribeJobFlows"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "ClusterSessionCredentials",
+    "operations": [
+      "GetClusterSessionCredentials"
+    ],
+    "tested": [],
+    "untested": [
+      "GetClusterSessionCredentials"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetClusterSessionCredentials": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "KeepJobFlowAliveWhenNoSteps",
+    "operations": [
+      "SetKeepJobFlowAliveWhenNoSteps"
+    ],
+    "tested": [],
+    "untested": [
+      "SetKeepJobFlowAliveWhenNoSteps"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "SetKeepJobFlowAliveWhenNoSteps": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "NotebookExecution",
+    "operations": [
+      "DescribeNotebookExecution",
+      "StartNotebookExecution",
+      "StopNotebookExecution"
+    ],
+    "tested": [
+      "DescribeNotebookExecution",
+      "StopNotebookExecution"
+    ],
+    "untested": [
+      "StartNotebookExecution"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeNotebookExecution": "working",
+      "StartNotebookExecution": "not_implemented",
+      "StopNotebookExecution": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "OnClusterAppUIPresignedURL",
+    "operations": [
+      "GetOnClusterAppUIPresignedURL"
+    ],
+    "tested": [],
+    "untested": [
+      "GetOnClusterAppUIPresignedURL"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetOnClusterAppUIPresignedURL": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "PersistentAppUI",
+    "operations": [
+      "CreatePersistentAppUI",
+      "DescribePersistentAppUI"
+    ],
+    "tested": [],
+    "untested": [
+      "CreatePersistentAppUI",
+      "DescribePersistentAppUI"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "CreatePersistentAppUI": "not_implemented",
+      "DescribePersistentAppUI": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "PersistentAppUIPresignedURL",
+    "operations": [
+      "GetPersistentAppUIPresignedURL"
+    ],
+    "tested": [],
+    "untested": [
+      "GetPersistentAppUIPresignedURL"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetPersistentAppUIPresignedURL": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Studio",
+    "operations": [
+      "CreateStudio",
+      "DeleteStudio",
+      "DescribeStudio",
+      "UpdateStudio"
+    ],
+    "tested": [
+      "CreateStudio",
+      "DeleteStudio",
+      "DescribeStudio"
+    ],
+    "untested": [
+      "UpdateStudio"
+    ],
+    "size": 4,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateStudio": "working",
+      "DeleteStudio": "working",
+      "DescribeStudio": "working",
+      "UpdateStudio": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "StudioSessionMappings",
+    "operations": [
+      "ListStudioSessionMappings"
+    ],
+    "tested": [],
+    "untested": [
+      "ListStudioSessionMappings"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListStudioSessionMappings": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "UnhealthyNodeReplacement",
+    "operations": [
+      "SetUnhealthyNodeReplacement"
+    ],
+    "tested": [],
+    "untested": [
+      "SetUnhealthyNodeReplacement"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "SetUnhealthyNodeReplacement": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/es.json
+++ b/chunks/es.json
@@ -1,0 +1,199 @@
+[
+  {
+    "noun": "PurchaseReservedElasticsearchInstanceOffering",
+    "operations": [
+      "PurchaseReservedElasticsearchInstanceOffering"
+    ],
+    "tested": [],
+    "untested": [
+      "PurchaseReservedElasticsearchInstanceOffering"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "PurchaseReservedElasticsearchInstanceOffering": "working"
+    },
+    "working_untested": [
+      "PurchaseReservedElasticsearchInstanceOffering"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "VpcEndpoint",
+    "operations": [
+      "CreateVpcEndpoint",
+      "DeleteVpcEndpoint",
+      "UpdateVpcEndpoint"
+    ],
+    "tested": [
+      "CreateVpcEndpoint",
+      "DeleteVpcEndpoint"
+    ],
+    "untested": [
+      "UpdateVpcEndpoint"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateVpcEndpoint": "working",
+      "DeleteVpcEndpoint": "working",
+      "UpdateVpcEndpoint": "working"
+    },
+    "working_untested": [
+      "UpdateVpcEndpoint"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "DomainConfigChange",
+    "operations": [
+      "CancelDomainConfigChange"
+    ],
+    "tested": [],
+    "untested": [
+      "CancelDomainConfigChange"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "CancelDomainConfigChange": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ElasticsearchServiceSoftwareUpdate",
+    "operations": [
+      "CancelElasticsearchServiceSoftwareUpdate",
+      "StartElasticsearchServiceSoftwareUpdate"
+    ],
+    "tested": [],
+    "untested": [
+      "CancelElasticsearchServiceSoftwareUpdate",
+      "StartElasticsearchServiceSoftwareUpdate"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "CancelElasticsearchServiceSoftwareUpdate": "not_implemented",
+      "StartElasticsearchServiceSoftwareUpdate": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "InboundCrossClusterSearchConnection",
+    "operations": [
+      "AcceptInboundCrossClusterSearchConnection",
+      "DeleteInboundCrossClusterSearchConnection",
+      "RejectInboundCrossClusterSearchConnection"
+    ],
+    "tested": [
+      "AcceptInboundCrossClusterSearchConnection",
+      "DeleteInboundCrossClusterSearchConnection"
+    ],
+    "untested": [
+      "RejectInboundCrossClusterSearchConnection"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "AcceptInboundCrossClusterSearchConnection": "working",
+      "DeleteInboundCrossClusterSearchConnection": "working",
+      "RejectInboundCrossClusterSearchConnection": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "PackagesForDomain",
+    "operations": [
+      "ListPackagesForDomain"
+    ],
+    "tested": [],
+    "untested": [
+      "ListPackagesForDomain"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListPackagesForDomain": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "UpgradeElasticsearchDomain",
+    "operations": [
+      "UpgradeElasticsearchDomain"
+    ],
+    "tested": [],
+    "untested": [
+      "UpgradeElasticsearchDomain"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "UpgradeElasticsearchDomain": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "UpgradeHistory",
+    "operations": [
+      "GetUpgradeHistory"
+    ],
+    "tested": [],
+    "untested": [
+      "GetUpgradeHistory"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetUpgradeHistory": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "UpgradeStatus",
+    "operations": [
+      "GetUpgradeStatus"
+    ],
+    "tested": [],
+    "untested": [
+      "GetUpgradeStatus"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetUpgradeStatus": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "VpcEndpointAccess",
+    "operations": [
+      "AuthorizeVpcEndpointAccess",
+      "ListVpcEndpointAccess",
+      "RevokeVpcEndpointAccess"
+    ],
+    "tested": [],
+    "untested": [
+      "AuthorizeVpcEndpointAccess",
+      "ListVpcEndpointAccess",
+      "RevokeVpcEndpointAccess"
+    ],
+    "size": 3,
+    "untested_count": 3,
+    "probe_status": {
+      "AuthorizeVpcEndpointAccess": "not_implemented",
+      "ListVpcEndpointAccess": "not_implemented",
+      "RevokeVpcEndpointAccess": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/events.json
+++ b/chunks/events.json
@@ -1,0 +1,69 @@
+[
+  {
+    "noun": "DeauthorizeConnection",
+    "operations": [
+      "DeauthorizeConnection"
+    ],
+    "tested": [],
+    "untested": [
+      "DeauthorizeConnection"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DeauthorizeConnection": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Endpoint",
+    "operations": [
+      "CreateEndpoint",
+      "DeleteEndpoint",
+      "DescribeEndpoint",
+      "UpdateEndpoint"
+    ],
+    "tested": [
+      "DescribeEndpoint"
+    ],
+    "untested": [
+      "CreateEndpoint",
+      "DeleteEndpoint",
+      "UpdateEndpoint"
+    ],
+    "size": 4,
+    "untested_count": 3,
+    "probe_status": {
+      "CreateEndpoint": "needs_params",
+      "DeleteEndpoint": "not_implemented",
+      "DescribeEndpoint": "working",
+      "UpdateEndpoint": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "EventSource",
+    "operations": [
+      "ActivateEventSource",
+      "DeactivateEventSource",
+      "DescribeEventSource"
+    ],
+    "tested": [],
+    "untested": [
+      "ActivateEventSource",
+      "DeactivateEventSource",
+      "DescribeEventSource"
+    ],
+    "size": 3,
+    "untested_count": 3,
+    "probe_status": {
+      "ActivateEventSource": "not_implemented",
+      "DeactivateEventSource": "not_implemented",
+      "DescribeEventSource": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/fsx.json
+++ b/chunks/fsx.json
@@ -1,0 +1,240 @@
+[
+  {
+    "noun": "AndAttachS3AccessPoint",
+    "operations": [
+      "CreateAndAttachS3AccessPoint"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateAndAttachS3AccessPoint"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateAndAttachS3AccessPoint": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "AndDeleteS3AccessPoint",
+    "operations": [
+      "DetachAndDeleteS3AccessPoint"
+    ],
+    "tested": [],
+    "untested": [
+      "DetachAndDeleteS3AccessPoint"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DetachAndDeleteS3AccessPoint": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Backup",
+    "operations": [
+      "CopyBackup",
+      "CreateBackup",
+      "DeleteBackup"
+    ],
+    "tested": [
+      "CreateBackup",
+      "DeleteBackup"
+    ],
+    "untested": [
+      "CopyBackup"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "CopyBackup": "not_implemented",
+      "CreateBackup": "working",
+      "DeleteBackup": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DataRepositoryTask",
+    "operations": [
+      "CancelDataRepositoryTask",
+      "CreateDataRepositoryTask"
+    ],
+    "tested": [],
+    "untested": [
+      "CancelDataRepositoryTask",
+      "CreateDataRepositoryTask"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "CancelDataRepositoryTask": "not_implemented",
+      "CreateDataRepositoryTask": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "FileCache",
+    "operations": [
+      "CreateFileCache",
+      "DeleteFileCache",
+      "UpdateFileCache"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateFileCache",
+      "DeleteFileCache",
+      "UpdateFileCache"
+    ],
+    "size": 3,
+    "untested_count": 3,
+    "probe_status": {
+      "CreateFileCache": "not_implemented",
+      "DeleteFileCache": "not_implemented",
+      "UpdateFileCache": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "FileSystemNfsV3Locks",
+    "operations": [
+      "ReleaseFileSystemNfsV3Locks"
+    ],
+    "tested": [],
+    "untested": [
+      "ReleaseFileSystemNfsV3Locks"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ReleaseFileSystemNfsV3Locks": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "MisconfiguredStateRecovery",
+    "operations": [
+      "StartMisconfiguredStateRecovery"
+    ],
+    "tested": [],
+    "untested": [
+      "StartMisconfiguredStateRecovery"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "StartMisconfiguredStateRecovery": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SharedVpcConfiguration",
+    "operations": [
+      "DescribeSharedVpcConfiguration",
+      "UpdateSharedVpcConfiguration"
+    ],
+    "tested": [
+      "DescribeSharedVpcConfiguration"
+    ],
+    "untested": [
+      "UpdateSharedVpcConfiguration"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeSharedVpcConfiguration": "working",
+      "UpdateSharedVpcConfiguration": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SnapshotAndUpdateVolume",
+    "operations": [
+      "CopySnapshotAndUpdateVolume"
+    ],
+    "tested": [],
+    "untested": [
+      "CopySnapshotAndUpdateVolume"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "CopySnapshotAndUpdateVolume": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "StorageVirtualMachine",
+    "operations": [
+      "CreateStorageVirtualMachine",
+      "DeleteStorageVirtualMachine",
+      "UpdateStorageVirtualMachine"
+    ],
+    "tested": [
+      "CreateStorageVirtualMachine",
+      "DeleteStorageVirtualMachine"
+    ],
+    "untested": [
+      "UpdateStorageVirtualMachine"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateStorageVirtualMachine": "working",
+      "DeleteStorageVirtualMachine": "needs_params",
+      "UpdateStorageVirtualMachine": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Volume",
+    "operations": [
+      "CreateVolume",
+      "DeleteVolume",
+      "UpdateVolume"
+    ],
+    "tested": [
+      "CreateVolume",
+      "DeleteVolume"
+    ],
+    "untested": [
+      "UpdateVolume"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateVolume": "working",
+      "DeleteVolume": "needs_params",
+      "UpdateVolume": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "VolumeFromSnapshot",
+    "operations": [
+      "RestoreVolumeFromSnapshot"
+    ],
+    "tested": [],
+    "untested": [
+      "RestoreVolumeFromSnapshot"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "RestoreVolumeFromSnapshot": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/glacier.json
+++ b/chunks/glacier.json
@@ -1,0 +1,21 @@
+[
+  {
+    "noun": "JobOutput",
+    "operations": [
+      "GetJobOutput"
+    ],
+    "tested": [],
+    "untested": [
+      "GetJobOutput"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetJobOutput": "working"
+    },
+    "working_untested": [
+      "GetJobOutput"
+    ],
+    "working_untested_count": 1
+  }
+]

--- a/chunks/glue.json
+++ b/chunks/glue.json
@@ -1,0 +1,699 @@
+[
+  {
+    "noun": "MLTransform",
+    "operations": [
+      "CreateMLTransform",
+      "DeleteMLTransform",
+      "GetMLTransform",
+      "UpdateMLTransform"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateMLTransform",
+      "DeleteMLTransform",
+      "GetMLTransform",
+      "UpdateMLTransform"
+    ],
+    "size": 4,
+    "untested_count": 4,
+    "probe_status": {
+      "CreateMLTransform": "working",
+      "DeleteMLTransform": "working",
+      "GetMLTransform": "working",
+      "UpdateMLTransform": "working"
+    },
+    "working_untested": [
+      "CreateMLTransform",
+      "DeleteMLTransform",
+      "GetMLTransform",
+      "UpdateMLTransform"
+    ],
+    "working_untested_count": 4
+  },
+  {
+    "noun": "MLTransforms",
+    "operations": [
+      "GetMLTransforms",
+      "ListMLTransforms"
+    ],
+    "tested": [],
+    "untested": [
+      "GetMLTransforms",
+      "ListMLTransforms"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "GetMLTransforms": "working",
+      "ListMLTransforms": "working"
+    },
+    "working_untested": [
+      "GetMLTransforms",
+      "ListMLTransforms"
+    ],
+    "working_untested_count": 2
+  },
+  {
+    "noun": "MLTaskRun",
+    "operations": [
+      "CancelMLTaskRun",
+      "GetMLTaskRun"
+    ],
+    "tested": [],
+    "untested": [
+      "CancelMLTaskRun",
+      "GetMLTaskRun"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "CancelMLTaskRun": "not_implemented",
+      "GetMLTaskRun": "working"
+    },
+    "working_untested": [
+      "GetMLTaskRun"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "MLTaskRuns",
+    "operations": [
+      "GetMLTaskRuns"
+    ],
+    "tested": [],
+    "untested": [
+      "GetMLTaskRuns"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetMLTaskRuns": "working"
+    },
+    "working_untested": [
+      "GetMLTaskRuns"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "ConnectionType",
+    "operations": [
+      "DeleteConnectionType",
+      "DescribeConnectionType",
+      "RegisterConnectionType"
+    ],
+    "tested": [],
+    "untested": [
+      "DeleteConnectionType",
+      "DescribeConnectionType",
+      "RegisterConnectionType"
+    ],
+    "size": 3,
+    "untested_count": 3,
+    "probe_status": {
+      "DeleteConnectionType": "not_implemented",
+      "DescribeConnectionType": "not_implemented",
+      "RegisterConnectionType": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ConnectionTypes",
+    "operations": [
+      "ListConnectionTypes"
+    ],
+    "tested": [],
+    "untested": [
+      "ListConnectionTypes"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListConnectionTypes": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DataQualityRulesetEvaluationRun",
+    "operations": [
+      "CancelDataQualityRulesetEvaluationRun",
+      "GetDataQualityRulesetEvaluationRun",
+      "StartDataQualityRulesetEvaluationRun"
+    ],
+    "tested": [
+      "CancelDataQualityRulesetEvaluationRun",
+      "GetDataQualityRulesetEvaluationRun"
+    ],
+    "untested": [
+      "StartDataQualityRulesetEvaluationRun"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "CancelDataQualityRulesetEvaluationRun": "working",
+      "GetDataQualityRulesetEvaluationRun": "working",
+      "StartDataQualityRulesetEvaluationRun": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DataflowGraph",
+    "operations": [
+      "GetDataflowGraph"
+    ],
+    "tested": [],
+    "untested": [
+      "GetDataflowGraph"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetDataflowGraph": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Entities",
+    "operations": [
+      "ListEntities"
+    ],
+    "tested": [],
+    "untested": [
+      "ListEntities"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListEntities": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Entity",
+    "operations": [
+      "DescribeEntity"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeEntity"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeEntity": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ExportLabelsTaskRun",
+    "operations": [
+      "StartExportLabelsTaskRun"
+    ],
+    "tested": [],
+    "untested": [
+      "StartExportLabelsTaskRun"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "StartExportLabelsTaskRun": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "GetDataQualityResult",
+    "operations": [
+      "BatchGetDataQualityResult"
+    ],
+    "tested": [],
+    "untested": [
+      "BatchGetDataQualityResult"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "BatchGetDataQualityResult": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "GetTableOptimizer",
+    "operations": [
+      "BatchGetTableOptimizer"
+    ],
+    "tested": [],
+    "untested": [
+      "BatchGetTableOptimizer"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "BatchGetTableOptimizer": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "GlueIdentityCenterConfiguration",
+    "operations": [
+      "CreateGlueIdentityCenterConfiguration",
+      "DeleteGlueIdentityCenterConfiguration",
+      "GetGlueIdentityCenterConfiguration",
+      "UpdateGlueIdentityCenterConfiguration"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateGlueIdentityCenterConfiguration",
+      "DeleteGlueIdentityCenterConfiguration",
+      "GetGlueIdentityCenterConfiguration",
+      "UpdateGlueIdentityCenterConfiguration"
+    ],
+    "size": 4,
+    "untested_count": 4,
+    "probe_status": {
+      "CreateGlueIdentityCenterConfiguration": "not_implemented",
+      "DeleteGlueIdentityCenterConfiguration": "not_implemented",
+      "GetGlueIdentityCenterConfiguration": "not_implemented",
+      "UpdateGlueIdentityCenterConfiguration": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ImportLabelsTaskRun",
+    "operations": [
+      "StartImportLabelsTaskRun"
+    ],
+    "tested": [],
+    "untested": [
+      "StartImportLabelsTaskRun"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "StartImportLabelsTaskRun": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Integration",
+    "operations": [
+      "CreateIntegration",
+      "DeleteIntegration",
+      "ModifyIntegration"
+    ],
+    "tested": [
+      "CreateIntegration",
+      "ModifyIntegration"
+    ],
+    "untested": [
+      "DeleteIntegration"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateIntegration": "working",
+      "DeleteIntegration": "500_error",
+      "ModifyIntegration": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "IntegrationResourceProperties",
+    "operations": [
+      "ListIntegrationResourceProperties"
+    ],
+    "tested": [],
+    "untested": [
+      "ListIntegrationResourceProperties"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListIntegrationResourceProperties": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "JobFromSourceControl",
+    "operations": [
+      "UpdateJobFromSourceControl"
+    ],
+    "tested": [],
+    "untested": [
+      "UpdateJobFromSourceControl"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "UpdateJobFromSourceControl": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "MLEvaluationTaskRun",
+    "operations": [
+      "StartMLEvaluationTaskRun"
+    ],
+    "tested": [],
+    "untested": [
+      "StartMLEvaluationTaskRun"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "StartMLEvaluationTaskRun": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "MLLabelingSetGenerationTaskRun",
+    "operations": [
+      "StartMLLabelingSetGenerationTaskRun"
+    ],
+    "tested": [],
+    "untested": [
+      "StartMLLabelingSetGenerationTaskRun"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "StartMLLabelingSetGenerationTaskRun": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "MaterializedViewRefreshTaskRun",
+    "operations": [
+      "GetMaterializedViewRefreshTaskRun",
+      "StartMaterializedViewRefreshTaskRun",
+      "StopMaterializedViewRefreshTaskRun"
+    ],
+    "tested": [],
+    "untested": [
+      "GetMaterializedViewRefreshTaskRun",
+      "StartMaterializedViewRefreshTaskRun",
+      "StopMaterializedViewRefreshTaskRun"
+    ],
+    "size": 3,
+    "untested_count": 3,
+    "probe_status": {
+      "GetMaterializedViewRefreshTaskRun": "not_implemented",
+      "StartMaterializedViewRefreshTaskRun": "not_implemented",
+      "StopMaterializedViewRefreshTaskRun": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "MaterializedViewRefreshTaskRuns",
+    "operations": [
+      "ListMaterializedViewRefreshTaskRuns"
+    ],
+    "tested": [],
+    "untested": [
+      "ListMaterializedViewRefreshTaskRuns"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListMaterializedViewRefreshTaskRuns": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Plan",
+    "operations": [
+      "GetPlan"
+    ],
+    "tested": [],
+    "untested": [
+      "GetPlan"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetPlan": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "QuerySchemaVersionMetadata",
+    "operations": [
+      "QuerySchemaVersionMetadata"
+    ],
+    "tested": [],
+    "untested": [
+      "QuerySchemaVersionMetadata"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "QuerySchemaVersionMetadata": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Registry",
+    "operations": [
+      "CreateRegistry",
+      "DeleteRegistry",
+      "GetRegistry",
+      "UpdateRegistry"
+    ],
+    "tested": [
+      "CreateRegistry",
+      "DeleteRegistry",
+      "GetRegistry"
+    ],
+    "untested": [
+      "UpdateRegistry"
+    ],
+    "size": 4,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateRegistry": "working",
+      "DeleteRegistry": "working",
+      "GetRegistry": "working",
+      "UpdateRegistry": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SchemaVersionMetadata",
+    "operations": [
+      "PutSchemaVersionMetadata",
+      "RemoveSchemaVersionMetadata"
+    ],
+    "tested": [
+      "PutSchemaVersionMetadata"
+    ],
+    "untested": [
+      "RemoveSchemaVersionMetadata"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "PutSchemaVersionMetadata": "working",
+      "RemoveSchemaVersionMetadata": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SchemaVersionsDiff",
+    "operations": [
+      "GetSchemaVersionsDiff"
+    ],
+    "tested": [],
+    "untested": [
+      "GetSchemaVersionsDiff"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetSchemaVersionsDiff": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Script",
+    "operations": [
+      "CreateScript"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateScript"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateScript": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SourceControlFromJob",
+    "operations": [
+      "UpdateSourceControlFromJob"
+    ],
+    "tested": [],
+    "untested": [
+      "UpdateSourceControlFromJob"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "UpdateSourceControlFromJob": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TableOptimizer",
+    "operations": [
+      "CreateTableOptimizer",
+      "DeleteTableOptimizer",
+      "GetTableOptimizer",
+      "UpdateTableOptimizer"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateTableOptimizer",
+      "DeleteTableOptimizer",
+      "GetTableOptimizer",
+      "UpdateTableOptimizer"
+    ],
+    "size": 4,
+    "untested_count": 4,
+    "probe_status": {
+      "CreateTableOptimizer": "not_implemented",
+      "DeleteTableOptimizer": "not_implemented",
+      "GetTableOptimizer": "not_implemented",
+      "UpdateTableOptimizer": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TableOptimizerRuns",
+    "operations": [
+      "ListTableOptimizerRuns"
+    ],
+    "tested": [],
+    "untested": [
+      "ListTableOptimizerRuns"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListTableOptimizerRuns": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TestConnection",
+    "operations": [
+      "TestConnection"
+    ],
+    "tested": [],
+    "untested": [
+      "TestConnection"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "TestConnection": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "UnfilteredPartitionMetadata",
+    "operations": [
+      "GetUnfilteredPartitionMetadata"
+    ],
+    "tested": [],
+    "untested": [
+      "GetUnfilteredPartitionMetadata"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetUnfilteredPartitionMetadata": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "UnfilteredPartitionsMetadata",
+    "operations": [
+      "GetUnfilteredPartitionsMetadata"
+    ],
+    "tested": [],
+    "untested": [
+      "GetUnfilteredPartitionsMetadata"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetUnfilteredPartitionsMetadata": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "UnfilteredTableMetadata",
+    "operations": [
+      "GetUnfilteredTableMetadata"
+    ],
+    "tested": [],
+    "untested": [
+      "GetUnfilteredTableMetadata"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetUnfilteredTableMetadata": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "UserDefinedFunctions",
+    "operations": [
+      "GetUserDefinedFunctions"
+    ],
+    "tested": [],
+    "untested": [
+      "GetUserDefinedFunctions"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetUserDefinedFunctions": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/greengrass.json
+++ b/chunks/greengrass.json
@@ -1,0 +1,296 @@
+[
+  {
+    "noun": "BulkDeployment",
+    "operations": [
+      "StartBulkDeployment",
+      "StopBulkDeployment"
+    ],
+    "tested": [],
+    "untested": [
+      "StartBulkDeployment",
+      "StopBulkDeployment"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "StartBulkDeployment": "not_implemented",
+      "StopBulkDeployment": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "BulkDeploymentDetailedReports",
+    "operations": [
+      "ListBulkDeploymentDetailedReports"
+    ],
+    "tested": [],
+    "untested": [
+      "ListBulkDeploymentDetailedReports"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListBulkDeploymentDetailedReports": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "BulkDeploymentStatus",
+    "operations": [
+      "GetBulkDeploymentStatus"
+    ],
+    "tested": [],
+    "untested": [
+      "GetBulkDeploymentStatus"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetBulkDeploymentStatus": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "BulkDeployments",
+    "operations": [
+      "ListBulkDeployments"
+    ],
+    "tested": [],
+    "untested": [
+      "ListBulkDeployments"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListBulkDeployments": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ConnectivityInfo",
+    "operations": [
+      "GetConnectivityInfo",
+      "UpdateConnectivityInfo"
+    ],
+    "tested": [],
+    "untested": [
+      "GetConnectivityInfo",
+      "UpdateConnectivityInfo"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "GetConnectivityInfo": "not_implemented",
+      "UpdateConnectivityInfo": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Deployments",
+    "operations": [
+      "ListDeployments",
+      "ResetDeployments"
+    ],
+    "tested": [
+      "ListDeployments"
+    ],
+    "untested": [
+      "ResetDeployments"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "ListDeployments": "working",
+      "ResetDeployments": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "GroupCertificateAuthorities",
+    "operations": [
+      "ListGroupCertificateAuthorities"
+    ],
+    "tested": [],
+    "untested": [
+      "ListGroupCertificateAuthorities"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListGroupCertificateAuthorities": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "GroupCertificateAuthority",
+    "operations": [
+      "CreateGroupCertificateAuthority",
+      "GetGroupCertificateAuthority"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateGroupCertificateAuthority",
+      "GetGroupCertificateAuthority"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "CreateGroupCertificateAuthority": "not_implemented",
+      "GetGroupCertificateAuthority": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "GroupCertificateConfiguration",
+    "operations": [
+      "GetGroupCertificateConfiguration",
+      "UpdateGroupCertificateConfiguration"
+    ],
+    "tested": [],
+    "untested": [
+      "GetGroupCertificateConfiguration",
+      "UpdateGroupCertificateConfiguration"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "GetGroupCertificateConfiguration": "not_implemented",
+      "UpdateGroupCertificateConfiguration": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Resource",
+    "operations": [
+      "TagResource",
+      "UntagResource"
+    ],
+    "tested": [],
+    "untested": [
+      "TagResource",
+      "UntagResource"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "TagResource": "not_implemented",
+      "UntagResource": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ServiceRoleForAccount",
+    "operations": [
+      "GetServiceRoleForAccount"
+    ],
+    "tested": [],
+    "untested": [
+      "GetServiceRoleForAccount"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetServiceRoleForAccount": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ServiceRoleFromAccount",
+    "operations": [
+      "DisassociateServiceRoleFromAccount"
+    ],
+    "tested": [],
+    "untested": [
+      "DisassociateServiceRoleFromAccount"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DisassociateServiceRoleFromAccount": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ServiceRoleToAccount",
+    "operations": [
+      "AssociateServiceRoleToAccount"
+    ],
+    "tested": [],
+    "untested": [
+      "AssociateServiceRoleToAccount"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "AssociateServiceRoleToAccount": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SoftwareUpdateJob",
+    "operations": [
+      "CreateSoftwareUpdateJob"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateSoftwareUpdateJob"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateSoftwareUpdateJob": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TagsForResource",
+    "operations": [
+      "ListTagsForResource"
+    ],
+    "tested": [],
+    "untested": [
+      "ListTagsForResource"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListTagsForResource": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ThingRuntimeConfiguration",
+    "operations": [
+      "GetThingRuntimeConfiguration",
+      "UpdateThingRuntimeConfiguration"
+    ],
+    "tested": [],
+    "untested": [
+      "GetThingRuntimeConfiguration",
+      "UpdateThingRuntimeConfiguration"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "GetThingRuntimeConfiguration": "not_implemented",
+      "UpdateThingRuntimeConfiguration": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/iam.json
+++ b/chunks/iam.json
@@ -1,0 +1,547 @@
+[
+  {
+    "noun": "MFADevice",
+    "operations": [
+      "DeactivateMFADevice",
+      "EnableMFADevice",
+      "GetMFADevice",
+      "TagMFADevice",
+      "UntagMFADevice"
+    ],
+    "tested": [],
+    "untested": [
+      "DeactivateMFADevice",
+      "EnableMFADevice",
+      "GetMFADevice",
+      "TagMFADevice",
+      "UntagMFADevice"
+    ],
+    "size": 5,
+    "untested_count": 5,
+    "probe_status": {
+      "DeactivateMFADevice": "working",
+      "EnableMFADevice": "working",
+      "GetMFADevice": "working",
+      "TagMFADevice": "working",
+      "UntagMFADevice": "working"
+    },
+    "working_untested": [
+      "DeactivateMFADevice",
+      "EnableMFADevice",
+      "GetMFADevice",
+      "TagMFADevice",
+      "UntagMFADevice"
+    ],
+    "working_untested_count": 5
+  },
+  {
+    "noun": "OpenIDConnectProvider",
+    "operations": [
+      "CreateOpenIDConnectProvider",
+      "DeleteOpenIDConnectProvider",
+      "GetOpenIDConnectProvider",
+      "TagOpenIDConnectProvider",
+      "UntagOpenIDConnectProvider"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateOpenIDConnectProvider",
+      "DeleteOpenIDConnectProvider",
+      "GetOpenIDConnectProvider",
+      "TagOpenIDConnectProvider",
+      "UntagOpenIDConnectProvider"
+    ],
+    "size": 5,
+    "untested_count": 5,
+    "probe_status": {
+      "CreateOpenIDConnectProvider": "working",
+      "DeleteOpenIDConnectProvider": "working",
+      "GetOpenIDConnectProvider": "working",
+      "TagOpenIDConnectProvider": "working",
+      "UntagOpenIDConnectProvider": "working"
+    },
+    "working_untested": [
+      "CreateOpenIDConnectProvider",
+      "DeleteOpenIDConnectProvider",
+      "GetOpenIDConnectProvider",
+      "TagOpenIDConnectProvider",
+      "UntagOpenIDConnectProvider"
+    ],
+    "working_untested_count": 5
+  },
+  {
+    "noun": "SAMLProvider",
+    "operations": [
+      "CreateSAMLProvider",
+      "DeleteSAMLProvider",
+      "GetSAMLProvider",
+      "TagSAMLProvider",
+      "UntagSAMLProvider",
+      "UpdateSAMLProvider"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateSAMLProvider",
+      "DeleteSAMLProvider",
+      "GetSAMLProvider",
+      "TagSAMLProvider",
+      "UntagSAMLProvider",
+      "UpdateSAMLProvider"
+    ],
+    "size": 6,
+    "untested_count": 6,
+    "probe_status": {
+      "CreateSAMLProvider": "needs_params",
+      "DeleteSAMLProvider": "working",
+      "GetSAMLProvider": "working",
+      "TagSAMLProvider": "working",
+      "UntagSAMLProvider": "working",
+      "UpdateSAMLProvider": "working"
+    },
+    "working_untested": [
+      "DeleteSAMLProvider",
+      "GetSAMLProvider",
+      "TagSAMLProvider",
+      "UntagSAMLProvider",
+      "UpdateSAMLProvider"
+    ],
+    "working_untested_count": 5
+  },
+  {
+    "noun": "VirtualMFADevice",
+    "operations": [
+      "CreateVirtualMFADevice",
+      "DeleteVirtualMFADevice"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateVirtualMFADevice",
+      "DeleteVirtualMFADevice"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "CreateVirtualMFADevice": "working",
+      "DeleteVirtualMFADevice": "working"
+    },
+    "working_untested": [
+      "CreateVirtualMFADevice",
+      "DeleteVirtualMFADevice"
+    ],
+    "working_untested_count": 2
+  },
+  {
+    "noun": "ClientIDFromOpenIDConnectProvider",
+    "operations": [
+      "RemoveClientIDFromOpenIDConnectProvider"
+    ],
+    "tested": [],
+    "untested": [
+      "RemoveClientIDFromOpenIDConnectProvider"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "RemoveClientIDFromOpenIDConnectProvider": "working"
+    },
+    "working_untested": [
+      "RemoveClientIDFromOpenIDConnectProvider"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "ClientIDToOpenIDConnectProvider",
+    "operations": [
+      "AddClientIDToOpenIDConnectProvider"
+    ],
+    "tested": [],
+    "untested": [
+      "AddClientIDToOpenIDConnectProvider"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "AddClientIDToOpenIDConnectProvider": "working"
+    },
+    "working_untested": [
+      "AddClientIDToOpenIDConnectProvider"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "MFADeviceTags",
+    "operations": [
+      "ListMFADeviceTags"
+    ],
+    "tested": [],
+    "untested": [
+      "ListMFADeviceTags"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListMFADeviceTags": "working"
+    },
+    "working_untested": [
+      "ListMFADeviceTags"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "MFADevices",
+    "operations": [
+      "ListMFADevices"
+    ],
+    "tested": [],
+    "untested": [
+      "ListMFADevices"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListMFADevices": "working"
+    },
+    "working_untested": [
+      "ListMFADevices"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "OpenIDConnectProviderTags",
+    "operations": [
+      "ListOpenIDConnectProviderTags"
+    ],
+    "tested": [],
+    "untested": [
+      "ListOpenIDConnectProviderTags"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListOpenIDConnectProviderTags": "working"
+    },
+    "working_untested": [
+      "ListOpenIDConnectProviderTags"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "OpenIDConnectProviderThumbprint",
+    "operations": [
+      "UpdateOpenIDConnectProviderThumbprint"
+    ],
+    "tested": [],
+    "untested": [
+      "UpdateOpenIDConnectProviderThumbprint"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "UpdateOpenIDConnectProviderThumbprint": "working"
+    },
+    "working_untested": [
+      "UpdateOpenIDConnectProviderThumbprint"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "OpenIDConnectProviders",
+    "operations": [
+      "ListOpenIDConnectProviders"
+    ],
+    "tested": [],
+    "untested": [
+      "ListOpenIDConnectProviders"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListOpenIDConnectProviders": "working"
+    },
+    "working_untested": [
+      "ListOpenIDConnectProviders"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "ResyncMFADevice",
+    "operations": [
+      "ResyncMFADevice"
+    ],
+    "tested": [],
+    "untested": [
+      "ResyncMFADevice"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ResyncMFADevice": "working"
+    },
+    "working_untested": [
+      "ResyncMFADevice"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "SAMLProviderTags",
+    "operations": [
+      "ListSAMLProviderTags"
+    ],
+    "tested": [],
+    "untested": [
+      "ListSAMLProviderTags"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListSAMLProviderTags": "working"
+    },
+    "working_untested": [
+      "ListSAMLProviderTags"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "SAMLProviders",
+    "operations": [
+      "ListSAMLProviders"
+    ],
+    "tested": [],
+    "untested": [
+      "ListSAMLProviders"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListSAMLProviders": "working"
+    },
+    "working_untested": [
+      "ListSAMLProviders"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "SSHPublicKeys",
+    "operations": [
+      "ListSSHPublicKeys"
+    ],
+    "tested": [],
+    "untested": [
+      "ListSSHPublicKeys"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListSSHPublicKeys": "working"
+    },
+    "working_untested": [
+      "ListSSHPublicKeys"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "UploadSSHPublicKey",
+    "operations": [
+      "UploadSSHPublicKey"
+    ],
+    "tested": [],
+    "untested": [
+      "UploadSSHPublicKey"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "UploadSSHPublicKey": "working"
+    },
+    "working_untested": [
+      "UploadSSHPublicKey"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "VirtualMFADevices",
+    "operations": [
+      "ListVirtualMFADevices"
+    ],
+    "tested": [],
+    "untested": [
+      "ListVirtualMFADevices"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListVirtualMFADevices": "working"
+    },
+    "working_untested": [
+      "ListVirtualMFADevices"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "DelegationRequest",
+    "operations": [
+      "AcceptDelegationRequest",
+      "AssociateDelegationRequest",
+      "CreateDelegationRequest",
+      "GetDelegationRequest",
+      "RejectDelegationRequest",
+      "UpdateDelegationRequest"
+    ],
+    "tested": [],
+    "untested": [
+      "AcceptDelegationRequest",
+      "AssociateDelegationRequest",
+      "CreateDelegationRequest",
+      "GetDelegationRequest",
+      "RejectDelegationRequest",
+      "UpdateDelegationRequest"
+    ],
+    "size": 6,
+    "untested_count": 6,
+    "probe_status": {
+      "AcceptDelegationRequest": "not_implemented",
+      "AssociateDelegationRequest": "not_implemented",
+      "CreateDelegationRequest": "needs_params",
+      "GetDelegationRequest": "not_implemented",
+      "RejectDelegationRequest": "not_implemented",
+      "UpdateDelegationRequest": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DelegationToken",
+    "operations": [
+      "SendDelegationToken"
+    ],
+    "tested": [],
+    "untested": [
+      "SendDelegationToken"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "SendDelegationToken": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "GenerateOrganizationsAccessReport",
+    "operations": [
+      "GenerateOrganizationsAccessReport"
+    ],
+    "tested": [],
+    "untested": [
+      "GenerateOrganizationsAccessReport"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GenerateOrganizationsAccessReport": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "HumanReadableSummary",
+    "operations": [
+      "GetHumanReadableSummary"
+    ],
+    "tested": [],
+    "untested": [
+      "GetHumanReadableSummary"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetHumanReadableSummary": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "OrganizationsAccessReport",
+    "operations": [
+      "GetOrganizationsAccessReport"
+    ],
+    "tested": [],
+    "untested": [
+      "GetOrganizationsAccessReport"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetOrganizationsAccessReport": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "PoliciesGrantingServiceAccess",
+    "operations": [
+      "ListPoliciesGrantingServiceAccess"
+    ],
+    "tested": [],
+    "untested": [
+      "ListPoliciesGrantingServiceAccess"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListPoliciesGrantingServiceAccess": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SSHPublicKey",
+    "operations": [
+      "DeleteSSHPublicKey",
+      "GetSSHPublicKey",
+      "UpdateSSHPublicKey"
+    ],
+    "tested": [],
+    "untested": [
+      "DeleteSSHPublicKey",
+      "GetSSHPublicKey",
+      "UpdateSSHPublicKey"
+    ],
+    "size": 3,
+    "untested_count": 3,
+    "probe_status": {
+      "DeleteSSHPublicKey": "needs_params",
+      "GetSSHPublicKey": "needs_params",
+      "UpdateSSHPublicKey": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ServiceSpecificCredential",
+    "operations": [
+      "CreateServiceSpecificCredential",
+      "DeleteServiceSpecificCredential",
+      "ResetServiceSpecificCredential",
+      "UpdateServiceSpecificCredential"
+    ],
+    "tested": [
+      "CreateServiceSpecificCredential"
+    ],
+    "untested": [
+      "DeleteServiceSpecificCredential",
+      "ResetServiceSpecificCredential",
+      "UpdateServiceSpecificCredential"
+    ],
+    "size": 4,
+    "untested_count": 3,
+    "probe_status": {
+      "CreateServiceSpecificCredential": "working",
+      "DeleteServiceSpecificCredential": "needs_params",
+      "ResetServiceSpecificCredential": "needs_params",
+      "UpdateServiceSpecificCredential": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/identitystore.json
+++ b/chunks/identitystore.json
@@ -1,0 +1,165 @@
+[
+  {
+    "noun": "Group",
+    "operations": [
+      "CreateGroup",
+      "DeleteGroup",
+      "DescribeGroup",
+      "UpdateGroup"
+    ],
+    "tested": [
+      "CreateGroup",
+      "DeleteGroup",
+      "DescribeGroup"
+    ],
+    "untested": [
+      "UpdateGroup"
+    ],
+    "size": 4,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateGroup": "working",
+      "DeleteGroup": "working",
+      "DescribeGroup": "working",
+      "UpdateGroup": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "GroupId",
+    "operations": [
+      "GetGroupId"
+    ],
+    "tested": [],
+    "untested": [
+      "GetGroupId"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetGroupId": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "GroupMembership",
+    "operations": [
+      "CreateGroupMembership",
+      "DeleteGroupMembership",
+      "DescribeGroupMembership"
+    ],
+    "tested": [
+      "CreateGroupMembership",
+      "DeleteGroupMembership"
+    ],
+    "untested": [
+      "DescribeGroupMembership"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateGroupMembership": "needs_params",
+      "DeleteGroupMembership": "working",
+      "DescribeGroupMembership": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "GroupMembershipId",
+    "operations": [
+      "GetGroupMembershipId"
+    ],
+    "tested": [],
+    "untested": [
+      "GetGroupMembershipId"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetGroupMembershipId": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "GroupMembershipsForMember",
+    "operations": [
+      "ListGroupMembershipsForMember"
+    ],
+    "tested": [],
+    "untested": [
+      "ListGroupMembershipsForMember"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListGroupMembershipsForMember": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "IsMemberInGroups",
+    "operations": [
+      "IsMemberInGroups"
+    ],
+    "tested": [],
+    "untested": [
+      "IsMemberInGroups"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "IsMemberInGroups": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "User",
+    "operations": [
+      "CreateUser",
+      "DeleteUser",
+      "DescribeUser",
+      "UpdateUser"
+    ],
+    "tested": [
+      "CreateUser",
+      "DeleteUser",
+      "DescribeUser"
+    ],
+    "untested": [
+      "UpdateUser"
+    ],
+    "size": 4,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateUser": "working",
+      "DeleteUser": "working",
+      "DescribeUser": "working",
+      "UpdateUser": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "UserId",
+    "operations": [
+      "GetUserId"
+    ],
+    "tested": [],
+    "untested": [
+      "GetUserId"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetUserId": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/inspector2.json
+++ b/chunks/inspector2.json
@@ -1,0 +1,202 @@
+[
+  {
+    "noun": "AssociateCodeSecurityScanConfiguration",
+    "operations": [
+      "BatchAssociateCodeSecurityScanConfiguration"
+    ],
+    "tested": [],
+    "untested": [
+      "BatchAssociateCodeSecurityScanConfiguration"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "BatchAssociateCodeSecurityScanConfiguration": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "CisSessionTelemetry",
+    "operations": [
+      "SendCisSessionTelemetry"
+    ],
+    "tested": [],
+    "untested": [
+      "SendCisSessionTelemetry"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "SendCisSessionTelemetry": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "CodeSecurityIntegration",
+    "operations": [
+      "CreateCodeSecurityIntegration",
+      "DeleteCodeSecurityIntegration",
+      "GetCodeSecurityIntegration",
+      "UpdateCodeSecurityIntegration"
+    ],
+    "tested": [
+      "CreateCodeSecurityIntegration",
+      "DeleteCodeSecurityIntegration",
+      "GetCodeSecurityIntegration"
+    ],
+    "untested": [
+      "UpdateCodeSecurityIntegration"
+    ],
+    "size": 4,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateCodeSecurityIntegration": "working",
+      "DeleteCodeSecurityIntegration": "working",
+      "GetCodeSecurityIntegration": "working",
+      "UpdateCodeSecurityIntegration": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "CodeSecurityScan",
+    "operations": [
+      "GetCodeSecurityScan",
+      "StartCodeSecurityScan"
+    ],
+    "tested": [],
+    "untested": [
+      "GetCodeSecurityScan",
+      "StartCodeSecurityScan"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "GetCodeSecurityScan": "needs_params",
+      "StartCodeSecurityScan": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "CodeSecurityScanConfiguration",
+    "operations": [
+      "CreateCodeSecurityScanConfiguration",
+      "DeleteCodeSecurityScanConfiguration",
+      "GetCodeSecurityScanConfiguration",
+      "UpdateCodeSecurityScanConfiguration"
+    ],
+    "tested": [
+      "DeleteCodeSecurityScanConfiguration",
+      "GetCodeSecurityScanConfiguration"
+    ],
+    "untested": [
+      "CreateCodeSecurityScanConfiguration",
+      "UpdateCodeSecurityScanConfiguration"
+    ],
+    "size": 4,
+    "untested_count": 2,
+    "probe_status": {
+      "CreateCodeSecurityScanConfiguration": "needs_params",
+      "DeleteCodeSecurityScanConfiguration": "working",
+      "GetCodeSecurityScanConfiguration": "working",
+      "UpdateCodeSecurityScanConfiguration": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DisassociateCodeSecurityScanConfiguration",
+    "operations": [
+      "BatchDisassociateCodeSecurityScanConfiguration"
+    ],
+    "tested": [],
+    "untested": [
+      "BatchDisassociateCodeSecurityScanConfiguration"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "BatchDisassociateCodeSecurityScanConfiguration": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Filter",
+    "operations": [
+      "CreateFilter",
+      "DeleteFilter",
+      "UpdateFilter"
+    ],
+    "tested": [
+      "CreateFilter",
+      "DeleteFilter"
+    ],
+    "untested": [
+      "UpdateFilter"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateFilter": "working",
+      "DeleteFilter": "working",
+      "UpdateFilter": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "GetCodeSnippet",
+    "operations": [
+      "BatchGetCodeSnippet"
+    ],
+    "tested": [],
+    "untested": [
+      "BatchGetCodeSnippet"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "BatchGetCodeSnippet": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "GetFindingDetails",
+    "operations": [
+      "BatchGetFindingDetails"
+    ],
+    "tested": [],
+    "untested": [
+      "BatchGetFindingDetails"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "BatchGetFindingDetails": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SearchVulnerabilities",
+    "operations": [
+      "SearchVulnerabilities"
+    ],
+    "tested": [],
+    "untested": [
+      "SearchVulnerabilities"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "SearchVulnerabilities": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/iot.json
+++ b/chunks/iot.json
@@ -1,0 +1,764 @@
+[
+  {
+    "noun": "OTAUpdate",
+    "operations": [
+      "CreateOTAUpdate",
+      "DeleteOTAUpdate",
+      "GetOTAUpdate"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateOTAUpdate",
+      "DeleteOTAUpdate",
+      "GetOTAUpdate"
+    ],
+    "size": 3,
+    "untested_count": 3,
+    "probe_status": {
+      "CreateOTAUpdate": "needs_params",
+      "DeleteOTAUpdate": "working",
+      "GetOTAUpdate": "working"
+    },
+    "working_untested": [
+      "DeleteOTAUpdate",
+      "GetOTAUpdate"
+    ],
+    "working_untested_count": 2
+  },
+  {
+    "noun": "Resource",
+    "operations": [
+      "TagResource",
+      "UntagResource"
+    ],
+    "tested": [],
+    "untested": [
+      "TagResource",
+      "UntagResource"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "TagResource": "working",
+      "UntagResource": "working"
+    },
+    "working_untested": [
+      "TagResource",
+      "UntagResource"
+    ],
+    "working_untested_count": 2
+  },
+  {
+    "noun": "CACertificate",
+    "operations": [
+      "DeleteCACertificate",
+      "DescribeCACertificate",
+      "RegisterCACertificate",
+      "UpdateCACertificate"
+    ],
+    "tested": [],
+    "untested": [
+      "DeleteCACertificate",
+      "DescribeCACertificate",
+      "RegisterCACertificate",
+      "UpdateCACertificate"
+    ],
+    "size": 4,
+    "untested_count": 4,
+    "probe_status": {
+      "DeleteCACertificate": "needs_params",
+      "DescribeCACertificate": "needs_params",
+      "RegisterCACertificate": "working",
+      "UpdateCACertificate": "needs_params"
+    },
+    "working_untested": [
+      "RegisterCACertificate"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "CACertificates",
+    "operations": [
+      "ListCACertificates"
+    ],
+    "tested": [],
+    "untested": [
+      "ListCACertificates"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListCACertificates": "working"
+    },
+    "working_untested": [
+      "ListCACertificates"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "CertificateWithoutCA",
+    "operations": [
+      "RegisterCertificateWithoutCA"
+    ],
+    "tested": [],
+    "untested": [
+      "RegisterCertificateWithoutCA"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "RegisterCertificateWithoutCA": "working"
+    },
+    "working_untested": [
+      "RegisterCertificateWithoutCA"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "OTAUpdates",
+    "operations": [
+      "ListOTAUpdates"
+    ],
+    "tested": [],
+    "untested": [
+      "ListOTAUpdates"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListOTAUpdates": "working"
+    },
+    "working_untested": [
+      "ListOTAUpdates"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "TagsForResource",
+    "operations": [
+      "ListTagsForResource"
+    ],
+    "tested": [],
+    "untested": [
+      "ListTagsForResource"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListTagsForResource": "working"
+    },
+    "working_untested": [
+      "ListTagsForResource"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "BehaviorModelTrainingSummaries",
+    "operations": [
+      "GetBehaviorModelTrainingSummaries"
+    ],
+    "tested": [],
+    "untested": [
+      "GetBehaviorModelTrainingSummaries"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetBehaviorModelTrainingSummaries": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "BucketsAggregation",
+    "operations": [
+      "GetBucketsAggregation"
+    ],
+    "tested": [],
+    "untested": [
+      "GetBucketsAggregation"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetBucketsAggregation": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Cardinality",
+    "operations": [
+      "GetCardinality"
+    ],
+    "tested": [],
+    "untested": [
+      "GetCardinality"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetCardinality": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "CertificateProvider",
+    "operations": [
+      "CreateCertificateProvider",
+      "DeleteCertificateProvider",
+      "DescribeCertificateProvider",
+      "UpdateCertificateProvider"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateCertificateProvider",
+      "DeleteCertificateProvider",
+      "DescribeCertificateProvider",
+      "UpdateCertificateProvider"
+    ],
+    "size": 4,
+    "untested_count": 4,
+    "probe_status": {
+      "CreateCertificateProvider": "needs_params",
+      "DeleteCertificateProvider": "not_implemented",
+      "DescribeCertificateProvider": "not_implemented",
+      "UpdateCertificateProvider": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "CertificateProviders",
+    "operations": [
+      "ListCertificateProviders"
+    ],
+    "tested": [],
+    "untested": [
+      "ListCertificateProviders"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListCertificateProviders": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "CertificateTransfer",
+    "operations": [
+      "AcceptCertificateTransfer",
+      "CancelCertificateTransfer",
+      "RejectCertificateTransfer"
+    ],
+    "tested": [],
+    "untested": [
+      "AcceptCertificateTransfer",
+      "CancelCertificateTransfer",
+      "RejectCertificateTransfer"
+    ],
+    "size": 3,
+    "untested_count": 3,
+    "probe_status": {
+      "AcceptCertificateTransfer": "needs_params",
+      "CancelCertificateTransfer": "needs_params",
+      "RejectCertificateTransfer": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "CertificatesByCA",
+    "operations": [
+      "ListCertificatesByCA"
+    ],
+    "tested": [],
+    "untested": [
+      "ListCertificatesByCA"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListCertificatesByCA": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ClearDefaultAuthorizer",
+    "operations": [
+      "ClearDefaultAuthorizer"
+    ],
+    "tested": [],
+    "untested": [
+      "ClearDefaultAuthorizer"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ClearDefaultAuthorizer": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Command",
+    "operations": [
+      "CreateCommand",
+      "DeleteCommand",
+      "GetCommand",
+      "UpdateCommand"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateCommand",
+      "DeleteCommand",
+      "GetCommand",
+      "UpdateCommand"
+    ],
+    "size": 4,
+    "untested_count": 4,
+    "probe_status": {
+      "CreateCommand": "not_implemented",
+      "DeleteCommand": "not_implemented",
+      "GetCommand": "not_implemented",
+      "UpdateCommand": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "CommandExecution",
+    "operations": [
+      "DeleteCommandExecution",
+      "GetCommandExecution"
+    ],
+    "tested": [],
+    "untested": [
+      "DeleteCommandExecution",
+      "GetCommandExecution"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "DeleteCommandExecution": "not_implemented",
+      "GetCommandExecution": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "CommandExecutions",
+    "operations": [
+      "ListCommandExecutions"
+    ],
+    "tested": [],
+    "untested": [
+      "ListCommandExecutions"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListCommandExecutions": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Commands",
+    "operations": [
+      "ListCommands"
+    ],
+    "tested": [],
+    "untested": [
+      "ListCommands"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListCommands": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DetectMitigationActionsTask",
+    "operations": [
+      "CancelDetectMitigationActionsTask",
+      "DescribeDetectMitigationActionsTask",
+      "StartDetectMitigationActionsTask"
+    ],
+    "tested": [
+      "DescribeDetectMitigationActionsTask"
+    ],
+    "untested": [
+      "CancelDetectMitigationActionsTask",
+      "StartDetectMitigationActionsTask"
+    ],
+    "size": 3,
+    "untested_count": 2,
+    "probe_status": {
+      "CancelDetectMitigationActionsTask": "not_implemented",
+      "DescribeDetectMitigationActionsTask": "working",
+      "StartDetectMitigationActionsTask": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "EncryptionConfiguration",
+    "operations": [
+      "DescribeEncryptionConfiguration",
+      "UpdateEncryptionConfiguration"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeEncryptionConfiguration",
+      "UpdateEncryptionConfiguration"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "DescribeEncryptionConfiguration": "not_implemented",
+      "UpdateEncryptionConfiguration": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "EventConfigurations",
+    "operations": [
+      "DescribeEventConfigurations",
+      "UpdateEventConfigurations"
+    ],
+    "tested": [
+      "DescribeEventConfigurations"
+    ],
+    "untested": [
+      "UpdateEventConfigurations"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeEventConfigurations": "working",
+      "UpdateEventConfigurations": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Percentiles",
+    "operations": [
+      "GetPercentiles"
+    ],
+    "tested": [],
+    "untested": [
+      "GetPercentiles"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetPercentiles": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "PrincipalThingsV2",
+    "operations": [
+      "ListPrincipalThingsV2"
+    ],
+    "tested": [],
+    "untested": [
+      "ListPrincipalThingsV2"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListPrincipalThingsV2": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ProvisioningClaim",
+    "operations": [
+      "CreateProvisioningClaim"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateProvisioningClaim"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateProvisioningClaim": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "RegistrationCode",
+    "operations": [
+      "DeleteRegistrationCode",
+      "GetRegistrationCode"
+    ],
+    "tested": [
+      "GetRegistrationCode"
+    ],
+    "untested": [
+      "DeleteRegistrationCode"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "DeleteRegistrationCode": "not_implemented",
+      "GetRegistrationCode": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SbomFromPackageVersion",
+    "operations": [
+      "DisassociateSbomFromPackageVersion"
+    ],
+    "tested": [],
+    "untested": [
+      "DisassociateSbomFromPackageVersion"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DisassociateSbomFromPackageVersion": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SbomValidationResults",
+    "operations": [
+      "ListSbomValidationResults"
+    ],
+    "tested": [],
+    "untested": [
+      "ListSbomValidationResults"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListSbomValidationResults": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SbomWithPackageVersion",
+    "operations": [
+      "AssociateSbomWithPackageVersion"
+    ],
+    "tested": [],
+    "untested": [
+      "AssociateSbomWithPackageVersion"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "AssociateSbomWithPackageVersion": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TargetsWithJob",
+    "operations": [
+      "AssociateTargetsWithJob"
+    ],
+    "tested": [],
+    "untested": [
+      "AssociateTargetsWithJob"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "AssociateTargetsWithJob": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TestAuthorization",
+    "operations": [
+      "TestAuthorization"
+    ],
+    "tested": [],
+    "untested": [
+      "TestAuthorization"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "TestAuthorization": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TestInvokeAuthorizer",
+    "operations": [
+      "TestInvokeAuthorizer"
+    ],
+    "tested": [],
+    "untested": [
+      "TestInvokeAuthorizer"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "TestInvokeAuthorizer": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Thing",
+    "operations": [
+      "CreateThing",
+      "DeleteThing",
+      "DescribeThing",
+      "RegisterThing",
+      "UpdateThing"
+    ],
+    "tested": [
+      "CreateThing",
+      "DeleteThing",
+      "DescribeThing",
+      "UpdateThing"
+    ],
+    "untested": [
+      "RegisterThing"
+    ],
+    "size": 5,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateThing": "working",
+      "DeleteThing": "working",
+      "DescribeThing": "working",
+      "RegisterThing": "not_implemented",
+      "UpdateThing": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ThingConnectivityData",
+    "operations": [
+      "GetThingConnectivityData"
+    ],
+    "tested": [],
+    "untested": [
+      "GetThingConnectivityData"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetThingConnectivityData": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ThingRegistrationTask",
+    "operations": [
+      "DescribeThingRegistrationTask",
+      "StartThingRegistrationTask",
+      "StopThingRegistrationTask"
+    ],
+    "tested": [
+      "DescribeThingRegistrationTask"
+    ],
+    "untested": [
+      "StartThingRegistrationTask",
+      "StopThingRegistrationTask"
+    ],
+    "size": 3,
+    "untested_count": 2,
+    "probe_status": {
+      "DescribeThingRegistrationTask": "working",
+      "StartThingRegistrationTask": "not_implemented",
+      "StopThingRegistrationTask": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ThingRegistrationTaskReports",
+    "operations": [
+      "ListThingRegistrationTaskReports"
+    ],
+    "tested": [],
+    "untested": [
+      "ListThingRegistrationTaskReports"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListThingRegistrationTaskReports": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ThingRegistrationTasks",
+    "operations": [
+      "ListThingRegistrationTasks"
+    ],
+    "tested": [],
+    "untested": [
+      "ListThingRegistrationTasks"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListThingRegistrationTasks": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TransferCertificate",
+    "operations": [
+      "TransferCertificate"
+    ],
+    "tested": [],
+    "untested": [
+      "TransferCertificate"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "TransferCertificate": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "VerificationStateOnViolation",
+    "operations": [
+      "PutVerificationStateOnViolation"
+    ],
+    "tested": [],
+    "untested": [
+      "PutVerificationStateOnViolation"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "PutVerificationStateOnViolation": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/ivs.json
+++ b/chunks/ivs.json
@@ -1,0 +1,233 @@
+[
+  {
+    "noun": "PlaybackKeyPair",
+    "operations": [
+      "DeletePlaybackKeyPair",
+      "GetPlaybackKeyPair",
+      "ImportPlaybackKeyPair"
+    ],
+    "tested": [
+      "DeletePlaybackKeyPair",
+      "GetPlaybackKeyPair"
+    ],
+    "untested": [
+      "ImportPlaybackKeyPair"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "DeletePlaybackKeyPair": "working",
+      "GetPlaybackKeyPair": "working",
+      "ImportPlaybackKeyPair": "working"
+    },
+    "working_untested": [
+      "ImportPlaybackKeyPair"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "Resource",
+    "operations": [
+      "TagResource",
+      "UntagResource"
+    ],
+    "tested": [
+      "TagResource"
+    ],
+    "untested": [
+      "UntagResource"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "TagResource": "working",
+      "UntagResource": "working"
+    },
+    "working_untested": [
+      "UntagResource"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "GetStreamKey",
+    "operations": [
+      "BatchGetStreamKey"
+    ],
+    "tested": [],
+    "untested": [
+      "BatchGetStreamKey"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "BatchGetStreamKey": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Metadata",
+    "operations": [
+      "PutMetadata"
+    ],
+    "tested": [],
+    "untested": [
+      "PutMetadata"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "PutMetadata": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "PlaybackRestrictionPolicies",
+    "operations": [
+      "ListPlaybackRestrictionPolicies"
+    ],
+    "tested": [],
+    "untested": [
+      "ListPlaybackRestrictionPolicies"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListPlaybackRestrictionPolicies": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "PlaybackRestrictionPolicy",
+    "operations": [
+      "CreatePlaybackRestrictionPolicy",
+      "DeletePlaybackRestrictionPolicy",
+      "GetPlaybackRestrictionPolicy",
+      "UpdatePlaybackRestrictionPolicy"
+    ],
+    "tested": [],
+    "untested": [
+      "CreatePlaybackRestrictionPolicy",
+      "DeletePlaybackRestrictionPolicy",
+      "GetPlaybackRestrictionPolicy",
+      "UpdatePlaybackRestrictionPolicy"
+    ],
+    "size": 4,
+    "untested_count": 4,
+    "probe_status": {
+      "CreatePlaybackRestrictionPolicy": "not_implemented",
+      "DeletePlaybackRestrictionPolicy": "not_implemented",
+      "GetPlaybackRestrictionPolicy": "not_implemented",
+      "UpdatePlaybackRestrictionPolicy": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "StartViewerSessionRevocation",
+    "operations": [
+      "BatchStartViewerSessionRevocation"
+    ],
+    "tested": [],
+    "untested": [
+      "BatchStartViewerSessionRevocation"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "BatchStartViewerSessionRevocation": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Stream",
+    "operations": [
+      "GetStream",
+      "StopStream"
+    ],
+    "tested": [],
+    "untested": [
+      "GetStream",
+      "StopStream"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "GetStream": "not_implemented",
+      "StopStream": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "StreamSession",
+    "operations": [
+      "GetStreamSession"
+    ],
+    "tested": [],
+    "untested": [
+      "GetStreamSession"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetStreamSession": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "StreamSessions",
+    "operations": [
+      "ListStreamSessions"
+    ],
+    "tested": [],
+    "untested": [
+      "ListStreamSessions"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListStreamSessions": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Streams",
+    "operations": [
+      "ListStreams"
+    ],
+    "tested": [],
+    "untested": [
+      "ListStreams"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListStreams": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ViewerSessionRevocation",
+    "operations": [
+      "StartViewerSessionRevocation"
+    ],
+    "tested": [],
+    "untested": [
+      "StartViewerSessionRevocation"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "StartViewerSessionRevocation": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/kinesis.json
+++ b/chunks/kinesis.json
@@ -1,0 +1,128 @@
+[
+  {
+    "noun": "AccountSettings",
+    "operations": [
+      "DescribeAccountSettings",
+      "UpdateAccountSettings"
+    ],
+    "tested": [
+      "DescribeAccountSettings"
+    ],
+    "untested": [
+      "UpdateAccountSettings"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeAccountSettings": "working",
+      "UpdateAccountSettings": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "MaxRecordSize",
+    "operations": [
+      "UpdateMaxRecordSize"
+    ],
+    "tested": [],
+    "untested": [
+      "UpdateMaxRecordSize"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "UpdateMaxRecordSize": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Resource",
+    "operations": [
+      "TagResource",
+      "UntagResource"
+    ],
+    "tested": [],
+    "untested": [
+      "TagResource",
+      "UntagResource"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "TagResource": "not_implemented",
+      "UntagResource": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "StreamMode",
+    "operations": [
+      "UpdateStreamMode"
+    ],
+    "tested": [],
+    "untested": [
+      "UpdateStreamMode"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "UpdateStreamMode": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "StreamWarmThroughput",
+    "operations": [
+      "UpdateStreamWarmThroughput"
+    ],
+    "tested": [],
+    "untested": [
+      "UpdateStreamWarmThroughput"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "UpdateStreamWarmThroughput": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TagsForResource",
+    "operations": [
+      "ListTagsForResource"
+    ],
+    "tested": [],
+    "untested": [
+      "ListTagsForResource"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListTagsForResource": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ToShard",
+    "operations": [
+      "SubscribeToShard"
+    ],
+    "tested": [],
+    "untested": [
+      "SubscribeToShard"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "SubscribeToShard": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/kinesisvideo.json
+++ b/chunks/kinesisvideo.json
@@ -1,0 +1,237 @@
+[
+  {
+    "noun": "DataRetention",
+    "operations": [
+      "UpdateDataRetention"
+    ],
+    "tested": [],
+    "untested": [
+      "UpdateDataRetention"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "UpdateDataRetention": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "EdgeAgentConfigurations",
+    "operations": [
+      "ListEdgeAgentConfigurations"
+    ],
+    "tested": [],
+    "untested": [
+      "ListEdgeAgentConfigurations"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListEdgeAgentConfigurations": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "EdgeConfiguration",
+    "operations": [
+      "DeleteEdgeConfiguration",
+      "DescribeEdgeConfiguration"
+    ],
+    "tested": [],
+    "untested": [
+      "DeleteEdgeConfiguration",
+      "DescribeEdgeConfiguration"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "DeleteEdgeConfiguration": "not_implemented",
+      "DescribeEdgeConfiguration": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "EdgeConfigurationUpdate",
+    "operations": [
+      "StartEdgeConfigurationUpdate"
+    ],
+    "tested": [],
+    "untested": [
+      "StartEdgeConfigurationUpdate"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "StartEdgeConfigurationUpdate": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ImageGenerationConfiguration",
+    "operations": [
+      "DescribeImageGenerationConfiguration",
+      "UpdateImageGenerationConfiguration"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeImageGenerationConfiguration",
+      "UpdateImageGenerationConfiguration"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "DescribeImageGenerationConfiguration": "not_implemented",
+      "UpdateImageGenerationConfiguration": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "MappedResourceConfiguration",
+    "operations": [
+      "DescribeMappedResourceConfiguration"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeMappedResourceConfiguration"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeMappedResourceConfiguration": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "MediaStorageConfiguration",
+    "operations": [
+      "DescribeMediaStorageConfiguration",
+      "UpdateMediaStorageConfiguration"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeMediaStorageConfiguration",
+      "UpdateMediaStorageConfiguration"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "DescribeMediaStorageConfiguration": "not_implemented",
+      "UpdateMediaStorageConfiguration": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "NotificationConfiguration",
+    "operations": [
+      "DescribeNotificationConfiguration",
+      "UpdateNotificationConfiguration"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeNotificationConfiguration",
+      "UpdateNotificationConfiguration"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "DescribeNotificationConfiguration": "not_implemented",
+      "UpdateNotificationConfiguration": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SignalingChannelEndpoint",
+    "operations": [
+      "GetSignalingChannelEndpoint"
+    ],
+    "tested": [],
+    "untested": [
+      "GetSignalingChannelEndpoint"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetSignalingChannelEndpoint": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Stream",
+    "operations": [
+      "CreateStream",
+      "DeleteStream",
+      "DescribeStream",
+      "TagStream",
+      "UntagStream",
+      "UpdateStream"
+    ],
+    "tested": [
+      "CreateStream",
+      "DeleteStream",
+      "DescribeStream",
+      "TagStream",
+      "UpdateStream"
+    ],
+    "untested": [
+      "UntagStream"
+    ],
+    "size": 6,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateStream": "working",
+      "DeleteStream": "working",
+      "DescribeStream": "working",
+      "TagStream": "working",
+      "UntagStream": "needs_params",
+      "UpdateStream": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "StreamStorageConfiguration",
+    "operations": [
+      "DescribeStreamStorageConfiguration",
+      "UpdateStreamStorageConfiguration"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeStreamStorageConfiguration",
+      "UpdateStreamStorageConfiguration"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "DescribeStreamStorageConfiguration": "not_implemented",
+      "UpdateStreamStorageConfiguration": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TagsForStream",
+    "operations": [
+      "ListTagsForStream"
+    ],
+    "tested": [],
+    "untested": [
+      "ListTagsForStream"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListTagsForStream": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/lakeformation.json
+++ b/chunks/lakeformation.json
@@ -1,0 +1,482 @@
+[
+  {
+    "noun": "LFTag",
+    "operations": [
+      "CreateLFTag",
+      "DeleteLFTag",
+      "GetLFTag",
+      "UpdateLFTag"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateLFTag",
+      "DeleteLFTag",
+      "GetLFTag",
+      "UpdateLFTag"
+    ],
+    "size": 4,
+    "untested_count": 4,
+    "probe_status": {
+      "CreateLFTag": "needs_params",
+      "DeleteLFTag": "working",
+      "GetLFTag": "working",
+      "UpdateLFTag": "500_error"
+    },
+    "working_untested": [
+      "DeleteLFTag",
+      "GetLFTag"
+    ],
+    "working_untested_count": 2
+  },
+  {
+    "noun": "LFTags",
+    "operations": [
+      "ListLFTags"
+    ],
+    "tested": [],
+    "untested": [
+      "ListLFTags"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListLFTags": "working"
+    },
+    "working_untested": [
+      "ListLFTags"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "ResourceLFTags",
+    "operations": [
+      "GetResourceLFTags"
+    ],
+    "tested": [],
+    "untested": [
+      "GetResourceLFTags"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetResourceLFTags": "working"
+    },
+    "working_untested": [
+      "GetResourceLFTags"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "SearchDatabasesByLFTags",
+    "operations": [
+      "SearchDatabasesByLFTags"
+    ],
+    "tested": [],
+    "untested": [
+      "SearchDatabasesByLFTags"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "SearchDatabasesByLFTags": "working"
+    },
+    "working_untested": [
+      "SearchDatabasesByLFTags"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "SearchTablesByLFTags",
+    "operations": [
+      "SearchTablesByLFTags"
+    ],
+    "tested": [],
+    "untested": [
+      "SearchTablesByLFTags"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "SearchTablesByLFTags": "working"
+    },
+    "working_untested": [
+      "SearchTablesByLFTags"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "AssumeDecoratedRoleWithSAML",
+    "operations": [
+      "AssumeDecoratedRoleWithSAML"
+    ],
+    "tested": [],
+    "untested": [
+      "AssumeDecoratedRoleWithSAML"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "AssumeDecoratedRoleWithSAML": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ExtendTransaction",
+    "operations": [
+      "ExtendTransaction"
+    ],
+    "tested": [],
+    "untested": [
+      "ExtendTransaction"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ExtendTransaction": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "LFTagExpression",
+    "operations": [
+      "CreateLFTagExpression",
+      "DeleteLFTagExpression",
+      "GetLFTagExpression",
+      "UpdateLFTagExpression"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateLFTagExpression",
+      "DeleteLFTagExpression",
+      "GetLFTagExpression",
+      "UpdateLFTagExpression"
+    ],
+    "size": 4,
+    "untested_count": 4,
+    "probe_status": {
+      "CreateLFTagExpression": "not_implemented",
+      "DeleteLFTagExpression": "not_implemented",
+      "GetLFTagExpression": "not_implemented",
+      "UpdateLFTagExpression": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "LFTagExpressions",
+    "operations": [
+      "ListLFTagExpressions"
+    ],
+    "tested": [],
+    "untested": [
+      "ListLFTagExpressions"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListLFTagExpressions": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "LFTagsFromResource",
+    "operations": [
+      "RemoveLFTagsFromResource"
+    ],
+    "tested": [],
+    "untested": [
+      "RemoveLFTagsFromResource"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "RemoveLFTagsFromResource": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "LFTagsToResource",
+    "operations": [
+      "AddLFTagsToResource"
+    ],
+    "tested": [],
+    "untested": [
+      "AddLFTagsToResource"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "AddLFTagsToResource": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "LakeFormationIdentityCenterConfiguration",
+    "operations": [
+      "CreateLakeFormationIdentityCenterConfiguration",
+      "DeleteLakeFormationIdentityCenterConfiguration",
+      "DescribeLakeFormationIdentityCenterConfiguration",
+      "UpdateLakeFormationIdentityCenterConfiguration"
+    ],
+    "tested": [
+      "DescribeLakeFormationIdentityCenterConfiguration"
+    ],
+    "untested": [
+      "CreateLakeFormationIdentityCenterConfiguration",
+      "DeleteLakeFormationIdentityCenterConfiguration",
+      "UpdateLakeFormationIdentityCenterConfiguration"
+    ],
+    "size": 4,
+    "untested_count": 3,
+    "probe_status": {
+      "CreateLakeFormationIdentityCenterConfiguration": "not_implemented",
+      "DeleteLakeFormationIdentityCenterConfiguration": "not_implemented",
+      "DescribeLakeFormationIdentityCenterConfiguration": "working",
+      "UpdateLakeFormationIdentityCenterConfiguration": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "LakeFormationOptIn",
+    "operations": [
+      "CreateLakeFormationOptIn",
+      "DeleteLakeFormationOptIn"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateLakeFormationOptIn",
+      "DeleteLakeFormationOptIn"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "CreateLakeFormationOptIn": "not_implemented",
+      "DeleteLakeFormationOptIn": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "LakeFormationOptIns",
+    "operations": [
+      "ListLakeFormationOptIns"
+    ],
+    "tested": [],
+    "untested": [
+      "ListLakeFormationOptIns"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListLakeFormationOptIns": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ObjectsOnCancel",
+    "operations": [
+      "DeleteObjectsOnCancel"
+    ],
+    "tested": [],
+    "untested": [
+      "DeleteObjectsOnCancel"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DeleteObjectsOnCancel": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "QueryPlanning",
+    "operations": [
+      "StartQueryPlanning"
+    ],
+    "tested": [],
+    "untested": [
+      "StartQueryPlanning"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "StartQueryPlanning": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "QueryState",
+    "operations": [
+      "GetQueryState"
+    ],
+    "tested": [],
+    "untested": [
+      "GetQueryState"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetQueryState": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "QueryStatistics",
+    "operations": [
+      "GetQueryStatistics"
+    ],
+    "tested": [],
+    "untested": [
+      "GetQueryStatistics"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetQueryStatistics": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Resource",
+    "operations": [
+      "DeregisterResource",
+      "DescribeResource",
+      "RegisterResource",
+      "UpdateResource"
+    ],
+    "tested": [
+      "DeregisterResource",
+      "DescribeResource",
+      "RegisterResource"
+    ],
+    "untested": [
+      "UpdateResource"
+    ],
+    "size": 4,
+    "untested_count": 1,
+    "probe_status": {
+      "DeregisterResource": "working",
+      "DescribeResource": "working",
+      "RegisterResource": "working",
+      "UpdateResource": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TableObjects",
+    "operations": [
+      "GetTableObjects",
+      "UpdateTableObjects"
+    ],
+    "tested": [],
+    "untested": [
+      "GetTableObjects",
+      "UpdateTableObjects"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "GetTableObjects": "not_implemented",
+      "UpdateTableObjects": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TableStorageOptimizer",
+    "operations": [
+      "UpdateTableStorageOptimizer"
+    ],
+    "tested": [],
+    "untested": [
+      "UpdateTableStorageOptimizer"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "UpdateTableStorageOptimizer": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TableStorageOptimizers",
+    "operations": [
+      "ListTableStorageOptimizers"
+    ],
+    "tested": [],
+    "untested": [
+      "ListTableStorageOptimizers"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListTableStorageOptimizers": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TemporaryDataLocationCredentials",
+    "operations": [
+      "GetTemporaryDataLocationCredentials"
+    ],
+    "tested": [],
+    "untested": [
+      "GetTemporaryDataLocationCredentials"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetTemporaryDataLocationCredentials": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "WorkUnitResults",
+    "operations": [
+      "GetWorkUnitResults"
+    ],
+    "tested": [],
+    "untested": [
+      "GetWorkUnitResults"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetWorkUnitResults": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "WorkUnits",
+    "operations": [
+      "GetWorkUnits"
+    ],
+    "tested": [],
+    "untested": [
+      "GetWorkUnits"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetWorkUnits": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/lambda.json
+++ b/chunks/lambda.json
@@ -1,0 +1,244 @@
+[
+  {
+    "noun": "CapacityProvider",
+    "operations": [
+      "CreateCapacityProvider",
+      "DeleteCapacityProvider",
+      "GetCapacityProvider",
+      "UpdateCapacityProvider"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateCapacityProvider",
+      "DeleteCapacityProvider",
+      "GetCapacityProvider",
+      "UpdateCapacityProvider"
+    ],
+    "size": 4,
+    "untested_count": 4,
+    "probe_status": {
+      "CreateCapacityProvider": "needs_params",
+      "DeleteCapacityProvider": "not_implemented",
+      "GetCapacityProvider": "not_implemented",
+      "UpdateCapacityProvider": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "CapacityProviders",
+    "operations": [
+      "ListCapacityProviders"
+    ],
+    "tested": [],
+    "untested": [
+      "ListCapacityProviders"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListCapacityProviders": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "CheckpointDurableExecution",
+    "operations": [
+      "CheckpointDurableExecution"
+    ],
+    "tested": [],
+    "untested": [
+      "CheckpointDurableExecution"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "CheckpointDurableExecution": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "CodeSigningConfig",
+    "operations": [
+      "CreateCodeSigningConfig",
+      "DeleteCodeSigningConfig",
+      "GetCodeSigningConfig",
+      "UpdateCodeSigningConfig"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateCodeSigningConfig",
+      "DeleteCodeSigningConfig",
+      "GetCodeSigningConfig",
+      "UpdateCodeSigningConfig"
+    ],
+    "size": 4,
+    "untested_count": 4,
+    "probe_status": {
+      "CreateCodeSigningConfig": "needs_params",
+      "DeleteCodeSigningConfig": "not_implemented",
+      "GetCodeSigningConfig": "not_implemented",
+      "UpdateCodeSigningConfig": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "CodeSigningConfigs",
+    "operations": [
+      "ListCodeSigningConfigs"
+    ],
+    "tested": [],
+    "untested": [
+      "ListCodeSigningConfigs"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListCodeSigningConfigs": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DurableExecution",
+    "operations": [
+      "GetDurableExecution",
+      "StopDurableExecution"
+    ],
+    "tested": [],
+    "untested": [
+      "GetDurableExecution",
+      "StopDurableExecution"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "GetDurableExecution": "not_implemented",
+      "StopDurableExecution": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DurableExecutionCallbackFailure",
+    "operations": [
+      "SendDurableExecutionCallbackFailure"
+    ],
+    "tested": [],
+    "untested": [
+      "SendDurableExecutionCallbackFailure"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "SendDurableExecutionCallbackFailure": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DurableExecutionCallbackHeartbeat",
+    "operations": [
+      "SendDurableExecutionCallbackHeartbeat"
+    ],
+    "tested": [],
+    "untested": [
+      "SendDurableExecutionCallbackHeartbeat"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "SendDurableExecutionCallbackHeartbeat": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DurableExecutionCallbackSuccess",
+    "operations": [
+      "SendDurableExecutionCallbackSuccess"
+    ],
+    "tested": [],
+    "untested": [
+      "SendDurableExecutionCallbackSuccess"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "SendDurableExecutionCallbackSuccess": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DurableExecutionHistory",
+    "operations": [
+      "GetDurableExecutionHistory"
+    ],
+    "tested": [],
+    "untested": [
+      "GetDurableExecutionHistory"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetDurableExecutionHistory": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DurableExecutionState",
+    "operations": [
+      "GetDurableExecutionState"
+    ],
+    "tested": [],
+    "untested": [
+      "GetDurableExecutionState"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetDurableExecutionState": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "FunctionVersionsByCapacityProvider",
+    "operations": [
+      "ListFunctionVersionsByCapacityProvider"
+    ],
+    "tested": [],
+    "untested": [
+      "ListFunctionVersionsByCapacityProvider"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListFunctionVersionsByCapacityProvider": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "FunctionsByCodeSigningConfig",
+    "operations": [
+      "ListFunctionsByCodeSigningConfig"
+    ],
+    "tested": [],
+    "untested": [
+      "ListFunctionsByCodeSigningConfig"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListFunctionsByCodeSigningConfig": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/logs.json
+++ b/chunks/logs.json
@@ -1,0 +1,272 @@
+[
+  {
+    "noun": "ScheduledQuery",
+    "operations": [
+      "CreateScheduledQuery",
+      "DeleteScheduledQuery",
+      "GetScheduledQuery",
+      "UpdateScheduledQuery"
+    ],
+    "tested": [
+      "DeleteScheduledQuery",
+      "GetScheduledQuery"
+    ],
+    "untested": [
+      "CreateScheduledQuery",
+      "UpdateScheduledQuery"
+    ],
+    "size": 4,
+    "untested_count": 2,
+    "probe_status": {
+      "CreateScheduledQuery": "working",
+      "DeleteScheduledQuery": "working",
+      "GetScheduledQuery": "working",
+      "UpdateScheduledQuery": "working"
+    },
+    "working_untested": [
+      "CreateScheduledQuery",
+      "UpdateScheduledQuery"
+    ],
+    "working_untested_count": 2
+  },
+  {
+    "noun": "ScheduledQueryHistory",
+    "operations": [
+      "GetScheduledQueryHistory"
+    ],
+    "tested": [],
+    "untested": [
+      "GetScheduledQueryHistory"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetScheduledQueryHistory": "working"
+    },
+    "working_untested": [
+      "GetScheduledQueryHistory"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "FieldIndexes",
+    "operations": [
+      "DescribeFieldIndexes"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeFieldIndexes"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeFieldIndexes": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ImportTask",
+    "operations": [
+      "CancelImportTask",
+      "CreateImportTask"
+    ],
+    "tested": [],
+    "untested": [
+      "CancelImportTask",
+      "CreateImportTask"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "CancelImportTask": "not_implemented",
+      "CreateImportTask": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "IndexPolicies",
+    "operations": [
+      "DescribeIndexPolicies"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeIndexPolicies"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeIndexPolicies": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Integration",
+    "operations": [
+      "DeleteIntegration",
+      "GetIntegration",
+      "PutIntegration"
+    ],
+    "tested": [
+      "DeleteIntegration",
+      "GetIntegration"
+    ],
+    "untested": [
+      "PutIntegration"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "DeleteIntegration": "working",
+      "GetIntegration": "working",
+      "PutIntegration": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "LiveTail",
+    "operations": [
+      "StartLiveTail"
+    ],
+    "tested": [],
+    "untested": [
+      "StartLiveTail"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "StartLiveTail": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "LogObject",
+    "operations": [
+      "GetLogObject"
+    ],
+    "tested": [],
+    "untested": [
+      "GetLogObject"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetLogObject": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SourceFromS3TableIntegration",
+    "operations": [
+      "DisassociateSourceFromS3TableIntegration"
+    ],
+    "tested": [],
+    "untested": [
+      "DisassociateSourceFromS3TableIntegration"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DisassociateSourceFromS3TableIntegration": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SourceToS3TableIntegration",
+    "operations": [
+      "AssociateSourceToS3TableIntegration"
+    ],
+    "tested": [],
+    "untested": [
+      "AssociateSourceToS3TableIntegration"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "AssociateSourceToS3TableIntegration": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SourcesForS3TableIntegration",
+    "operations": [
+      "ListSourcesForS3TableIntegration"
+    ],
+    "tested": [],
+    "untested": [
+      "ListSourcesForS3TableIntegration"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListSourcesForS3TableIntegration": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TestMetricFilter",
+    "operations": [
+      "TestMetricFilter"
+    ],
+    "tested": [],
+    "untested": [
+      "TestMetricFilter"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "TestMetricFilter": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TestTransformer",
+    "operations": [
+      "TestTransformer"
+    ],
+    "tested": [],
+    "untested": [
+      "TestTransformer"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "TestTransformer": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Transformer",
+    "operations": [
+      "DeleteTransformer",
+      "GetTransformer",
+      "PutTransformer"
+    ],
+    "tested": [
+      "DeleteTransformer",
+      "GetTransformer"
+    ],
+    "untested": [
+      "PutTransformer"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "DeleteTransformer": "working",
+      "GetTransformer": "working",
+      "PutTransformer": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/managedblockchain.json
+++ b/chunks/managedblockchain.json
@@ -1,0 +1,106 @@
+[
+  {
+    "noun": "Accessor",
+    "operations": [
+      "CreateAccessor",
+      "DeleteAccessor",
+      "GetAccessor"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateAccessor",
+      "DeleteAccessor",
+      "GetAccessor"
+    ],
+    "size": 3,
+    "untested_count": 3,
+    "probe_status": {
+      "CreateAccessor": "not_implemented",
+      "DeleteAccessor": "not_implemented",
+      "GetAccessor": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Accessors",
+    "operations": [
+      "ListAccessors"
+    ],
+    "tested": [],
+    "untested": [
+      "ListAccessors"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListAccessors": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Node",
+    "operations": [
+      "CreateNode",
+      "DeleteNode",
+      "GetNode",
+      "UpdateNode"
+    ],
+    "tested": [
+      "CreateNode",
+      "DeleteNode",
+      "GetNode"
+    ],
+    "untested": [
+      "UpdateNode"
+    ],
+    "size": 4,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateNode": "500_error",
+      "DeleteNode": "working",
+      "GetNode": "working",
+      "UpdateNode": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Resource",
+    "operations": [
+      "TagResource",
+      "UntagResource"
+    ],
+    "tested": [],
+    "untested": [
+      "TagResource",
+      "UntagResource"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "TagResource": "not_implemented",
+      "UntagResource": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TagsForResource",
+    "operations": [
+      "ListTagsForResource"
+    ],
+    "tested": [],
+    "untested": [
+      "ListTagsForResource"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListTagsForResource": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/mediaconnect.json
+++ b/chunks/mediaconnect.json
@@ -1,0 +1,61 @@
+[
+  {
+    "noun": "FlowMediaStream",
+    "operations": [
+      "RemoveFlowMediaStream",
+      "UpdateFlowMediaStream"
+    ],
+    "tested": [
+      "RemoveFlowMediaStream"
+    ],
+    "untested": [
+      "UpdateFlowMediaStream"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "RemoveFlowMediaStream": "not_implemented",
+      "UpdateFlowMediaStream": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "FlowMediaStreams",
+    "operations": [
+      "AddFlowMediaStreams"
+    ],
+    "tested": [],
+    "untested": [
+      "AddFlowMediaStreams"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "AddFlowMediaStreams": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "FlowOutput",
+    "operations": [
+      "RemoveFlowOutput",
+      "UpdateFlowOutput"
+    ],
+    "tested": [
+      "RemoveFlowOutput"
+    ],
+    "untested": [
+      "UpdateFlowOutput"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "RemoveFlowOutput": "not_implemented",
+      "UpdateFlowOutput": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/mediapackage.json
+++ b/chunks/mediapackage.json
@@ -1,0 +1,154 @@
+[
+  {
+    "noun": "Channel",
+    "operations": [
+      "CreateChannel",
+      "DeleteChannel",
+      "DescribeChannel",
+      "UpdateChannel"
+    ],
+    "tested": [
+      "CreateChannel",
+      "DeleteChannel",
+      "DescribeChannel"
+    ],
+    "untested": [
+      "UpdateChannel"
+    ],
+    "size": 4,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateChannel": "working",
+      "DeleteChannel": "working",
+      "DescribeChannel": "working",
+      "UpdateChannel": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ChannelCredentials",
+    "operations": [
+      "RotateChannelCredentials"
+    ],
+    "tested": [],
+    "untested": [
+      "RotateChannelCredentials"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "RotateChannelCredentials": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ConfigureLogs",
+    "operations": [
+      "ConfigureLogs"
+    ],
+    "tested": [],
+    "untested": [
+      "ConfigureLogs"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ConfigureLogs": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "HarvestJob",
+    "operations": [
+      "CreateHarvestJob",
+      "DescribeHarvestJob"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateHarvestJob",
+      "DescribeHarvestJob"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "CreateHarvestJob": "not_implemented",
+      "DescribeHarvestJob": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "HarvestJobs",
+    "operations": [
+      "ListHarvestJobs"
+    ],
+    "tested": [],
+    "untested": [
+      "ListHarvestJobs"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListHarvestJobs": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "IngestEndpointCredentials",
+    "operations": [
+      "RotateIngestEndpointCredentials"
+    ],
+    "tested": [],
+    "untested": [
+      "RotateIngestEndpointCredentials"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "RotateIngestEndpointCredentials": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Resource",
+    "operations": [
+      "TagResource",
+      "UntagResource"
+    ],
+    "tested": [],
+    "untested": [
+      "TagResource",
+      "UntagResource"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "TagResource": "not_implemented",
+      "UntagResource": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TagsForResource",
+    "operations": [
+      "ListTagsForResource"
+    ],
+    "tested": [],
+    "untested": [
+      "ListTagsForResource"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListTagsForResource": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/mediastore.json
+++ b/chunks/mediastore.json
@@ -1,0 +1,137 @@
+[
+  {
+    "noun": "AccessLogging",
+    "operations": [
+      "StartAccessLogging",
+      "StopAccessLogging"
+    ],
+    "tested": [],
+    "untested": [
+      "StartAccessLogging",
+      "StopAccessLogging"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "StartAccessLogging": "not_implemented",
+      "StopAccessLogging": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ContainerPolicy",
+    "operations": [
+      "DeleteContainerPolicy",
+      "GetContainerPolicy",
+      "PutContainerPolicy"
+    ],
+    "tested": [
+      "GetContainerPolicy",
+      "PutContainerPolicy"
+    ],
+    "untested": [
+      "DeleteContainerPolicy"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "DeleteContainerPolicy": "not_implemented",
+      "GetContainerPolicy": "working",
+      "PutContainerPolicy": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "CorsPolicy",
+    "operations": [
+      "DeleteCorsPolicy",
+      "GetCorsPolicy",
+      "PutCorsPolicy"
+    ],
+    "tested": [],
+    "untested": [
+      "DeleteCorsPolicy",
+      "GetCorsPolicy",
+      "PutCorsPolicy"
+    ],
+    "size": 3,
+    "untested_count": 3,
+    "probe_status": {
+      "DeleteCorsPolicy": "not_implemented",
+      "GetCorsPolicy": "not_implemented",
+      "PutCorsPolicy": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "LifecyclePolicy",
+    "operations": [
+      "DeleteLifecyclePolicy",
+      "GetLifecyclePolicy",
+      "PutLifecyclePolicy"
+    ],
+    "tested": [
+      "GetLifecyclePolicy",
+      "PutLifecyclePolicy"
+    ],
+    "untested": [
+      "DeleteLifecyclePolicy"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "DeleteLifecyclePolicy": "not_implemented",
+      "GetLifecyclePolicy": "working",
+      "PutLifecyclePolicy": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "MetricPolicy",
+    "operations": [
+      "DeleteMetricPolicy",
+      "GetMetricPolicy",
+      "PutMetricPolicy"
+    ],
+    "tested": [
+      "GetMetricPolicy",
+      "PutMetricPolicy"
+    ],
+    "untested": [
+      "DeleteMetricPolicy"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "DeleteMetricPolicy": "not_implemented",
+      "GetMetricPolicy": "working",
+      "PutMetricPolicy": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Resource",
+    "operations": [
+      "TagResource",
+      "UntagResource"
+    ],
+    "tested": [],
+    "untested": [
+      "TagResource",
+      "UntagResource"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "TagResource": "needs_params",
+      "UntagResource": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/memorydb.json
+++ b/chunks/memorydb.json
@@ -1,0 +1,297 @@
+[
+  {
+    "noun": "ACL",
+    "operations": [
+      "CreateACL",
+      "DeleteACL",
+      "UpdateACL"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateACL",
+      "DeleteACL",
+      "UpdateACL"
+    ],
+    "size": 3,
+    "untested_count": 3,
+    "probe_status": {
+      "CreateACL": "working",
+      "DeleteACL": "working",
+      "UpdateACL": "working"
+    },
+    "working_untested": [
+      "CreateACL",
+      "DeleteACL",
+      "UpdateACL"
+    ],
+    "working_untested_count": 3
+  },
+  {
+    "noun": "ACLs",
+    "operations": [
+      "DescribeACLs"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeACLs"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeACLs": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "AllowedMultiRegionClusterUpdates",
+    "operations": [
+      "ListAllowedMultiRegionClusterUpdates"
+    ],
+    "tested": [],
+    "untested": [
+      "ListAllowedMultiRegionClusterUpdates"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListAllowedMultiRegionClusterUpdates": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "AllowedNodeTypeUpdates",
+    "operations": [
+      "ListAllowedNodeTypeUpdates"
+    ],
+    "tested": [],
+    "untested": [
+      "ListAllowedNodeTypeUpdates"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListAllowedNodeTypeUpdates": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "FailoverShard",
+    "operations": [
+      "FailoverShard"
+    ],
+    "tested": [],
+    "untested": [
+      "FailoverShard"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "FailoverShard": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "MultiRegionCluster",
+    "operations": [
+      "CreateMultiRegionCluster",
+      "DeleteMultiRegionCluster",
+      "UpdateMultiRegionCluster"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateMultiRegionCluster",
+      "DeleteMultiRegionCluster",
+      "UpdateMultiRegionCluster"
+    ],
+    "size": 3,
+    "untested_count": 3,
+    "probe_status": {
+      "CreateMultiRegionCluster": "not_implemented",
+      "DeleteMultiRegionCluster": "not_implemented",
+      "UpdateMultiRegionCluster": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "MultiRegionClusters",
+    "operations": [
+      "DescribeMultiRegionClusters"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeMultiRegionClusters"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeMultiRegionClusters": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "MultiRegionParameterGroups",
+    "operations": [
+      "DescribeMultiRegionParameterGroups"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeMultiRegionParameterGroups"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeMultiRegionParameterGroups": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "MultiRegionParameters",
+    "operations": [
+      "DescribeMultiRegionParameters"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeMultiRegionParameters"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeMultiRegionParameters": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ParameterGroup",
+    "operations": [
+      "CreateParameterGroup",
+      "DeleteParameterGroup",
+      "ResetParameterGroup",
+      "UpdateParameterGroup"
+    ],
+    "tested": [
+      "CreateParameterGroup",
+      "DeleteParameterGroup",
+      "UpdateParameterGroup"
+    ],
+    "untested": [
+      "ResetParameterGroup"
+    ],
+    "size": 4,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateParameterGroup": "working",
+      "DeleteParameterGroup": "working",
+      "ResetParameterGroup": "not_implemented",
+      "UpdateParameterGroup": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Parameters",
+    "operations": [
+      "DescribeParameters"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeParameters"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeParameters": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "PurchaseReservedNodesOffering",
+    "operations": [
+      "PurchaseReservedNodesOffering"
+    ],
+    "tested": [],
+    "untested": [
+      "PurchaseReservedNodesOffering"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "PurchaseReservedNodesOffering": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Snapshot",
+    "operations": [
+      "CopySnapshot",
+      "CreateSnapshot",
+      "DeleteSnapshot"
+    ],
+    "tested": [
+      "CreateSnapshot",
+      "DeleteSnapshot"
+    ],
+    "untested": [
+      "CopySnapshot"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "CopySnapshot": "not_implemented",
+      "CreateSnapshot": "working",
+      "DeleteSnapshot": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SubnetGroup",
+    "operations": [
+      "CreateSubnetGroup",
+      "DeleteSubnetGroup",
+      "UpdateSubnetGroup"
+    ],
+    "tested": [
+      "CreateSubnetGroup",
+      "DeleteSubnetGroup"
+    ],
+    "untested": [
+      "UpdateSubnetGroup"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateSubnetGroup": "working",
+      "DeleteSubnetGroup": "working",
+      "UpdateSubnetGroup": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "UpdateCluster",
+    "operations": [
+      "BatchUpdateCluster"
+    ],
+    "tested": [],
+    "untested": [
+      "BatchUpdateCluster"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "BatchUpdateCluster": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/mq.json
+++ b/chunks/mq.json
@@ -1,0 +1,144 @@
+[
+  {
+    "noun": "Broker",
+    "operations": [
+      "CreateBroker",
+      "DeleteBroker",
+      "DescribeBroker",
+      "RebootBroker",
+      "UpdateBroker"
+    ],
+    "tested": [
+      "CreateBroker",
+      "DeleteBroker",
+      "DescribeBroker",
+      "UpdateBroker"
+    ],
+    "untested": [
+      "RebootBroker"
+    ],
+    "size": 5,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateBroker": "working",
+      "DeleteBroker": "500_error",
+      "DescribeBroker": "working",
+      "RebootBroker": "500_error",
+      "UpdateBroker": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "BrokerEngineTypes",
+    "operations": [
+      "DescribeBrokerEngineTypes"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeBrokerEngineTypes"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeBrokerEngineTypes": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "BrokerInstanceOptions",
+    "operations": [
+      "DescribeBrokerInstanceOptions"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeBrokerInstanceOptions"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeBrokerInstanceOptions": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Configuration",
+    "operations": [
+      "CreateConfiguration",
+      "DeleteConfiguration",
+      "DescribeConfiguration",
+      "UpdateConfiguration"
+    ],
+    "tested": [
+      "CreateConfiguration",
+      "DescribeConfiguration"
+    ],
+    "untested": [
+      "DeleteConfiguration",
+      "UpdateConfiguration"
+    ],
+    "size": 4,
+    "untested_count": 2,
+    "probe_status": {
+      "CreateConfiguration": "working",
+      "DeleteConfiguration": "not_implemented",
+      "DescribeConfiguration": "working",
+      "UpdateConfiguration": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ConfigurationRevision",
+    "operations": [
+      "DescribeConfigurationRevision"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeConfigurationRevision"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeConfigurationRevision": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ConfigurationRevisions",
+    "operations": [
+      "ListConfigurationRevisions"
+    ],
+    "tested": [],
+    "untested": [
+      "ListConfigurationRevisions"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListConfigurationRevisions": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Promote",
+    "operations": [
+      "Promote"
+    ],
+    "tested": [],
+    "untested": [
+      "Promote"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "Promote": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/neptune.json
+++ b/chunks/neptune.json
@@ -1,0 +1,667 @@
+[
+  {
+    "noun": "DBCluster",
+    "operations": [
+      "CreateDBCluster",
+      "DeleteDBCluster",
+      "ModifyDBCluster",
+      "StartDBCluster",
+      "StopDBCluster"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateDBCluster",
+      "DeleteDBCluster",
+      "ModifyDBCluster",
+      "StartDBCluster",
+      "StopDBCluster"
+    ],
+    "size": 5,
+    "untested_count": 5,
+    "probe_status": {
+      "CreateDBCluster": "working",
+      "DeleteDBCluster": "unknown",
+      "ModifyDBCluster": "working",
+      "StartDBCluster": "working",
+      "StopDBCluster": "working"
+    },
+    "working_untested": [
+      "CreateDBCluster",
+      "ModifyDBCluster",
+      "StartDBCluster",
+      "StopDBCluster"
+    ],
+    "working_untested_count": 4
+  },
+  {
+    "noun": "DBClusterParameterGroup",
+    "operations": [
+      "CopyDBClusterParameterGroup",
+      "CreateDBClusterParameterGroup",
+      "DeleteDBClusterParameterGroup",
+      "ModifyDBClusterParameterGroup",
+      "ResetDBClusterParameterGroup"
+    ],
+    "tested": [],
+    "untested": [
+      "CopyDBClusterParameterGroup",
+      "CreateDBClusterParameterGroup",
+      "DeleteDBClusterParameterGroup",
+      "ModifyDBClusterParameterGroup",
+      "ResetDBClusterParameterGroup"
+    ],
+    "size": 5,
+    "untested_count": 5,
+    "probe_status": {
+      "CopyDBClusterParameterGroup": "working",
+      "CreateDBClusterParameterGroup": "working",
+      "DeleteDBClusterParameterGroup": "working",
+      "ModifyDBClusterParameterGroup": "working",
+      "ResetDBClusterParameterGroup": "not_implemented"
+    },
+    "working_untested": [
+      "CopyDBClusterParameterGroup",
+      "CreateDBClusterParameterGroup",
+      "DeleteDBClusterParameterGroup",
+      "ModifyDBClusterParameterGroup"
+    ],
+    "working_untested_count": 4
+  },
+  {
+    "noun": "DBParameterGroup",
+    "operations": [
+      "CopyDBParameterGroup",
+      "CreateDBParameterGroup",
+      "DeleteDBParameterGroup",
+      "ModifyDBParameterGroup",
+      "ResetDBParameterGroup"
+    ],
+    "tested": [],
+    "untested": [
+      "CopyDBParameterGroup",
+      "CreateDBParameterGroup",
+      "DeleteDBParameterGroup",
+      "ModifyDBParameterGroup",
+      "ResetDBParameterGroup"
+    ],
+    "size": 5,
+    "untested_count": 5,
+    "probe_status": {
+      "CopyDBParameterGroup": "working",
+      "CreateDBParameterGroup": "working",
+      "DeleteDBParameterGroup": "working",
+      "ModifyDBParameterGroup": "working",
+      "ResetDBParameterGroup": "not_implemented"
+    },
+    "working_untested": [
+      "CopyDBParameterGroup",
+      "CreateDBParameterGroup",
+      "DeleteDBParameterGroup",
+      "ModifyDBParameterGroup"
+    ],
+    "working_untested_count": 4
+  },
+  {
+    "noun": "DBClusterEndpoint",
+    "operations": [
+      "CreateDBClusterEndpoint",
+      "DeleteDBClusterEndpoint",
+      "ModifyDBClusterEndpoint"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateDBClusterEndpoint",
+      "DeleteDBClusterEndpoint",
+      "ModifyDBClusterEndpoint"
+    ],
+    "size": 3,
+    "untested_count": 3,
+    "probe_status": {
+      "CreateDBClusterEndpoint": "working",
+      "DeleteDBClusterEndpoint": "working",
+      "ModifyDBClusterEndpoint": "working"
+    },
+    "working_untested": [
+      "CreateDBClusterEndpoint",
+      "DeleteDBClusterEndpoint",
+      "ModifyDBClusterEndpoint"
+    ],
+    "working_untested_count": 3
+  },
+  {
+    "noun": "DBClusterSnapshot",
+    "operations": [
+      "CopyDBClusterSnapshot",
+      "CreateDBClusterSnapshot",
+      "DeleteDBClusterSnapshot"
+    ],
+    "tested": [],
+    "untested": [
+      "CopyDBClusterSnapshot",
+      "CreateDBClusterSnapshot",
+      "DeleteDBClusterSnapshot"
+    ],
+    "size": 3,
+    "untested_count": 3,
+    "probe_status": {
+      "CopyDBClusterSnapshot": "working",
+      "CreateDBClusterSnapshot": "working",
+      "DeleteDBClusterSnapshot": "working"
+    },
+    "working_untested": [
+      "CopyDBClusterSnapshot",
+      "CreateDBClusterSnapshot",
+      "DeleteDBClusterSnapshot"
+    ],
+    "working_untested_count": 3
+  },
+  {
+    "noun": "DBInstance",
+    "operations": [
+      "CreateDBInstance",
+      "DeleteDBInstance",
+      "ModifyDBInstance",
+      "RebootDBInstance"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateDBInstance",
+      "DeleteDBInstance",
+      "ModifyDBInstance",
+      "RebootDBInstance"
+    ],
+    "size": 4,
+    "untested_count": 4,
+    "probe_status": {
+      "CreateDBInstance": "working",
+      "DeleteDBInstance": "unknown",
+      "ModifyDBInstance": "working",
+      "RebootDBInstance": "working"
+    },
+    "working_untested": [
+      "CreateDBInstance",
+      "ModifyDBInstance",
+      "RebootDBInstance"
+    ],
+    "working_untested_count": 3
+  },
+  {
+    "noun": "DBSubnetGroup",
+    "operations": [
+      "CreateDBSubnetGroup",
+      "DeleteDBSubnetGroup",
+      "ModifyDBSubnetGroup"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateDBSubnetGroup",
+      "DeleteDBSubnetGroup",
+      "ModifyDBSubnetGroup"
+    ],
+    "size": 3,
+    "untested_count": 3,
+    "probe_status": {
+      "CreateDBSubnetGroup": "working",
+      "DeleteDBSubnetGroup": "working",
+      "ModifyDBSubnetGroup": "working"
+    },
+    "working_untested": [
+      "CreateDBSubnetGroup",
+      "DeleteDBSubnetGroup",
+      "ModifyDBSubnetGroup"
+    ],
+    "working_untested_count": 3
+  },
+  {
+    "noun": "DBClusterEndpoints",
+    "operations": [
+      "DescribeDBClusterEndpoints"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeDBClusterEndpoints"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeDBClusterEndpoints": "working"
+    },
+    "working_untested": [
+      "DescribeDBClusterEndpoints"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "DBClusterFromSnapshot",
+    "operations": [
+      "RestoreDBClusterFromSnapshot"
+    ],
+    "tested": [],
+    "untested": [
+      "RestoreDBClusterFromSnapshot"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "RestoreDBClusterFromSnapshot": "working"
+    },
+    "working_untested": [
+      "RestoreDBClusterFromSnapshot"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "DBClusterParameterGroups",
+    "operations": [
+      "DescribeDBClusterParameterGroups"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeDBClusterParameterGroups"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeDBClusterParameterGroups": "working"
+    },
+    "working_untested": [
+      "DescribeDBClusterParameterGroups"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "DBClusterParameters",
+    "operations": [
+      "DescribeDBClusterParameters"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeDBClusterParameters"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeDBClusterParameters": "working"
+    },
+    "working_untested": [
+      "DescribeDBClusterParameters"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "DBClusterSnapshotAttribute",
+    "operations": [
+      "ModifyDBClusterSnapshotAttribute"
+    ],
+    "tested": [],
+    "untested": [
+      "ModifyDBClusterSnapshotAttribute"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ModifyDBClusterSnapshotAttribute": "working"
+    },
+    "working_untested": [
+      "ModifyDBClusterSnapshotAttribute"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "DBClusterSnapshotAttributes",
+    "operations": [
+      "DescribeDBClusterSnapshotAttributes"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeDBClusterSnapshotAttributes"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeDBClusterSnapshotAttributes": "working"
+    },
+    "working_untested": [
+      "DescribeDBClusterSnapshotAttributes"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "DBClusterSnapshots",
+    "operations": [
+      "DescribeDBClusterSnapshots"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeDBClusterSnapshots"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeDBClusterSnapshots": "working"
+    },
+    "working_untested": [
+      "DescribeDBClusterSnapshots"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "DBClusterToPointInTime",
+    "operations": [
+      "RestoreDBClusterToPointInTime"
+    ],
+    "tested": [],
+    "untested": [
+      "RestoreDBClusterToPointInTime"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "RestoreDBClusterToPointInTime": "working"
+    },
+    "working_untested": [
+      "RestoreDBClusterToPointInTime"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "DBClusters",
+    "operations": [
+      "DescribeDBClusters"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeDBClusters"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeDBClusters": "working"
+    },
+    "working_untested": [
+      "DescribeDBClusters"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "DBEngineVersions",
+    "operations": [
+      "DescribeDBEngineVersions"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeDBEngineVersions"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeDBEngineVersions": "working"
+    },
+    "working_untested": [
+      "DescribeDBEngineVersions"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "DBInstances",
+    "operations": [
+      "DescribeDBInstances"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeDBInstances"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeDBInstances": "working"
+    },
+    "working_untested": [
+      "DescribeDBInstances"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "DBParameterGroups",
+    "operations": [
+      "DescribeDBParameterGroups"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeDBParameterGroups"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeDBParameterGroups": "working"
+    },
+    "working_untested": [
+      "DescribeDBParameterGroups"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "DBParameters",
+    "operations": [
+      "DescribeDBParameters"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeDBParameters"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeDBParameters": "working"
+    },
+    "working_untested": [
+      "DescribeDBParameters"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "DBSubnetGroups",
+    "operations": [
+      "DescribeDBSubnetGroups"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeDBSubnetGroups"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeDBSubnetGroups": "working"
+    },
+    "working_untested": [
+      "DescribeDBSubnetGroups"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "FromGlobalCluster",
+    "operations": [
+      "RemoveFromGlobalCluster"
+    ],
+    "tested": [],
+    "untested": [
+      "RemoveFromGlobalCluster"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "RemoveFromGlobalCluster": "working"
+    },
+    "working_untested": [
+      "RemoveFromGlobalCluster"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "OrderableDBInstanceOptions",
+    "operations": [
+      "DescribeOrderableDBInstanceOptions"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeOrderableDBInstanceOptions"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeOrderableDBInstanceOptions": "working"
+    },
+    "working_untested": [
+      "DescribeOrderableDBInstanceOptions"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "PromoteReadReplicaDBCluster",
+    "operations": [
+      "PromoteReadReplicaDBCluster"
+    ],
+    "tested": [],
+    "untested": [
+      "PromoteReadReplicaDBCluster"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "PromoteReadReplicaDBCluster": "working"
+    },
+    "working_untested": [
+      "PromoteReadReplicaDBCluster"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "RoleToDBCluster",
+    "operations": [
+      "AddRoleToDBCluster"
+    ],
+    "tested": [],
+    "untested": [
+      "AddRoleToDBCluster"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "AddRoleToDBCluster": "working"
+    },
+    "working_untested": [
+      "AddRoleToDBCluster"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "SourceIdentifierFromSubscription",
+    "operations": [
+      "RemoveSourceIdentifierFromSubscription"
+    ],
+    "tested": [],
+    "untested": [
+      "RemoveSourceIdentifierFromSubscription"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "RemoveSourceIdentifierFromSubscription": "working"
+    },
+    "working_untested": [
+      "RemoveSourceIdentifierFromSubscription"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "SourceIdentifierToSubscription",
+    "operations": [
+      "AddSourceIdentifierToSubscription"
+    ],
+    "tested": [],
+    "untested": [
+      "AddSourceIdentifierToSubscription"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "AddSourceIdentifierToSubscription": "working"
+    },
+    "working_untested": [
+      "AddSourceIdentifierToSubscription"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "SwitchoverGlobalCluster",
+    "operations": [
+      "SwitchoverGlobalCluster"
+    ],
+    "tested": [],
+    "untested": [
+      "SwitchoverGlobalCluster"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "SwitchoverGlobalCluster": "working"
+    },
+    "working_untested": [
+      "SwitchoverGlobalCluster"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "ValidDBInstanceModifications",
+    "operations": [
+      "DescribeValidDBInstanceModifications"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeValidDBInstanceModifications"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeValidDBInstanceModifications": "working"
+    },
+    "working_untested": [
+      "DescribeValidDBInstanceModifications"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "FailoverDBCluster",
+    "operations": [
+      "FailoverDBCluster"
+    ],
+    "tested": [],
+    "untested": [
+      "FailoverDBCluster"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "FailoverDBCluster": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "RoleFromDBCluster",
+    "operations": [
+      "RemoveRoleFromDBCluster"
+    ],
+    "tested": [],
+    "untested": [
+      "RemoveRoleFromDBCluster"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "RemoveRoleFromDBCluster": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/networkmanager.json
+++ b/chunks/networkmanager.json
@@ -1,0 +1,44 @@
+[
+  {
+    "noun": "CoreNetworkPolicyVersion",
+    "operations": [
+      "DeleteCoreNetworkPolicyVersion",
+      "RestoreCoreNetworkPolicyVersion"
+    ],
+    "tested": [
+      "DeleteCoreNetworkPolicyVersion"
+    ],
+    "untested": [
+      "RestoreCoreNetworkPolicyVersion"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "DeleteCoreNetworkPolicyVersion": "working",
+      "RestoreCoreNetworkPolicyVersion": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "CoreNetworkPrefixListAssociation",
+    "operations": [
+      "CreateCoreNetworkPrefixListAssociation",
+      "DeleteCoreNetworkPrefixListAssociation"
+    ],
+    "tested": [
+      "CreateCoreNetworkPrefixListAssociation"
+    ],
+    "untested": [
+      "DeleteCoreNetworkPrefixListAssociation"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateCoreNetworkPrefixListAssociation": "working",
+      "DeleteCoreNetworkPrefixListAssociation": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/opensearch.json
+++ b/chunks/opensearch.json
@@ -1,0 +1,344 @@
+[
+  {
+    "noun": "DataSource",
+    "operations": [
+      "AddDataSource",
+      "DeleteDataSource",
+      "GetDataSource",
+      "UpdateDataSource"
+    ],
+    "tested": [],
+    "untested": [
+      "AddDataSource",
+      "DeleteDataSource",
+      "GetDataSource",
+      "UpdateDataSource"
+    ],
+    "size": 4,
+    "untested_count": 4,
+    "probe_status": {
+      "AddDataSource": "needs_params",
+      "DeleteDataSource": "not_implemented",
+      "GetDataSource": "not_implemented",
+      "UpdateDataSource": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DataSources",
+    "operations": [
+      "ListDataSources"
+    ],
+    "tested": [],
+    "untested": [
+      "ListDataSources"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListDataSources": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DefaultApplicationSetting",
+    "operations": [
+      "GetDefaultApplicationSetting",
+      "PutDefaultApplicationSetting"
+    ],
+    "tested": [
+      "GetDefaultApplicationSetting"
+    ],
+    "untested": [
+      "PutDefaultApplicationSetting"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "GetDefaultApplicationSetting": "working",
+      "PutDefaultApplicationSetting": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DirectQueryDataSource",
+    "operations": [
+      "AddDirectQueryDataSource",
+      "DeleteDirectQueryDataSource",
+      "GetDirectQueryDataSource",
+      "UpdateDirectQueryDataSource"
+    ],
+    "tested": [
+      "DeleteDirectQueryDataSource",
+      "GetDirectQueryDataSource"
+    ],
+    "untested": [
+      "AddDirectQueryDataSource",
+      "UpdateDirectQueryDataSource"
+    ],
+    "size": 4,
+    "untested_count": 2,
+    "probe_status": {
+      "AddDirectQueryDataSource": "needs_params",
+      "DeleteDirectQueryDataSource": "working",
+      "GetDirectQueryDataSource": "working",
+      "UpdateDirectQueryDataSource": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DirectQueryDataSources",
+    "operations": [
+      "ListDirectQueryDataSources"
+    ],
+    "tested": [],
+    "untested": [
+      "ListDirectQueryDataSources"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListDirectQueryDataSources": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DissociatePackages",
+    "operations": [
+      "DissociatePackages"
+    ],
+    "tested": [],
+    "untested": [
+      "DissociatePackages"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DissociatePackages": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DomainConfigChange",
+    "operations": [
+      "CancelDomainConfigChange"
+    ],
+    "tested": [],
+    "untested": [
+      "CancelDomainConfigChange"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "CancelDomainConfigChange": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "InboundConnection",
+    "operations": [
+      "AcceptInboundConnection",
+      "DeleteInboundConnection",
+      "RejectInboundConnection"
+    ],
+    "tested": [
+      "AcceptInboundConnection",
+      "DeleteInboundConnection"
+    ],
+    "untested": [
+      "RejectInboundConnection"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "AcceptInboundConnection": "working",
+      "DeleteInboundConnection": "working",
+      "RejectInboundConnection": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Index",
+    "operations": [
+      "CreateIndex",
+      "DeleteIndex",
+      "GetIndex",
+      "UpdateIndex"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateIndex",
+      "DeleteIndex",
+      "GetIndex",
+      "UpdateIndex"
+    ],
+    "size": 4,
+    "untested_count": 4,
+    "probe_status": {
+      "CreateIndex": "not_implemented",
+      "DeleteIndex": "not_implemented",
+      "GetIndex": "not_implemented",
+      "UpdateIndex": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "PackageScope",
+    "operations": [
+      "UpdatePackageScope"
+    ],
+    "tested": [],
+    "untested": [
+      "UpdatePackageScope"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "UpdatePackageScope": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Packages",
+    "operations": [
+      "AssociatePackages",
+      "DescribePackages"
+    ],
+    "tested": [
+      "DescribePackages"
+    ],
+    "untested": [
+      "AssociatePackages"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "AssociatePackages": "not_implemented",
+      "DescribePackages": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "PurchaseReservedInstanceOffering",
+    "operations": [
+      "PurchaseReservedInstanceOffering"
+    ],
+    "tested": [],
+    "untested": [
+      "PurchaseReservedInstanceOffering"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "PurchaseReservedInstanceOffering": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ServiceSoftwareUpdate",
+    "operations": [
+      "CancelServiceSoftwareUpdate",
+      "StartServiceSoftwareUpdate"
+    ],
+    "tested": [],
+    "untested": [
+      "CancelServiceSoftwareUpdate",
+      "StartServiceSoftwareUpdate"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "CancelServiceSoftwareUpdate": "not_implemented",
+      "StartServiceSoftwareUpdate": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "UpgradeDomain",
+    "operations": [
+      "UpgradeDomain"
+    ],
+    "tested": [],
+    "untested": [
+      "UpgradeDomain"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "UpgradeDomain": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "UpgradeHistory",
+    "operations": [
+      "GetUpgradeHistory"
+    ],
+    "tested": [],
+    "untested": [
+      "GetUpgradeHistory"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetUpgradeHistory": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "UpgradeStatus",
+    "operations": [
+      "GetUpgradeStatus"
+    ],
+    "tested": [],
+    "untested": [
+      "GetUpgradeStatus"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetUpgradeStatus": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "VpcEndpointAccess",
+    "operations": [
+      "AuthorizeVpcEndpointAccess",
+      "ListVpcEndpointAccess",
+      "RevokeVpcEndpointAccess"
+    ],
+    "tested": [
+      "AuthorizeVpcEndpointAccess",
+      "RevokeVpcEndpointAccess"
+    ],
+    "untested": [
+      "ListVpcEndpointAccess"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "AuthorizeVpcEndpointAccess": "working",
+      "ListVpcEndpointAccess": "not_implemented",
+      "RevokeVpcEndpointAccess": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/opensearchserverless.json
+++ b/chunks/opensearchserverless.json
@@ -1,0 +1,214 @@
+[
+  {
+    "noun": "AccessPolicy",
+    "operations": [
+      "CreateAccessPolicy",
+      "DeleteAccessPolicy",
+      "GetAccessPolicy",
+      "UpdateAccessPolicy"
+    ],
+    "tested": [
+      "CreateAccessPolicy",
+      "DeleteAccessPolicy",
+      "GetAccessPolicy"
+    ],
+    "untested": [
+      "UpdateAccessPolicy"
+    ],
+    "size": 4,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateAccessPolicy": "500_error",
+      "DeleteAccessPolicy": "working",
+      "GetAccessPolicy": "working",
+      "UpdateAccessPolicy": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "CollectionGroup",
+    "operations": [
+      "CreateCollectionGroup",
+      "DeleteCollectionGroup",
+      "UpdateCollectionGroup"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateCollectionGroup",
+      "DeleteCollectionGroup",
+      "UpdateCollectionGroup"
+    ],
+    "size": 3,
+    "untested_count": 3,
+    "probe_status": {
+      "CreateCollectionGroup": "not_implemented",
+      "DeleteCollectionGroup": "not_implemented",
+      "UpdateCollectionGroup": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "CollectionGroups",
+    "operations": [
+      "ListCollectionGroups"
+    ],
+    "tested": [],
+    "untested": [
+      "ListCollectionGroups"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListCollectionGroups": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "GetCollectionGroup",
+    "operations": [
+      "BatchGetCollectionGroup"
+    ],
+    "tested": [],
+    "untested": [
+      "BatchGetCollectionGroup"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "BatchGetCollectionGroup": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "GetEffectiveLifecyclePolicy",
+    "operations": [
+      "BatchGetEffectiveLifecyclePolicy"
+    ],
+    "tested": [],
+    "untested": [
+      "BatchGetEffectiveLifecyclePolicy"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "BatchGetEffectiveLifecyclePolicy": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "GetLifecyclePolicy",
+    "operations": [
+      "BatchGetLifecyclePolicy"
+    ],
+    "tested": [],
+    "untested": [
+      "BatchGetLifecyclePolicy"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "BatchGetLifecyclePolicy": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "GetVpcEndpoint",
+    "operations": [
+      "BatchGetVpcEndpoint"
+    ],
+    "tested": [],
+    "untested": [
+      "BatchGetVpcEndpoint"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "BatchGetVpcEndpoint": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Index",
+    "operations": [
+      "CreateIndex",
+      "DeleteIndex",
+      "GetIndex",
+      "UpdateIndex"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateIndex",
+      "DeleteIndex",
+      "GetIndex",
+      "UpdateIndex"
+    ],
+    "size": 4,
+    "untested_count": 4,
+    "probe_status": {
+      "CreateIndex": "not_implemented",
+      "DeleteIndex": "not_implemented",
+      "GetIndex": "not_implemented",
+      "UpdateIndex": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "LifecyclePolicy",
+    "operations": [
+      "CreateLifecyclePolicy",
+      "DeleteLifecyclePolicy",
+      "UpdateLifecyclePolicy"
+    ],
+    "tested": [
+      "CreateLifecyclePolicy",
+      "DeleteLifecyclePolicy"
+    ],
+    "untested": [
+      "UpdateLifecyclePolicy"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateLifecyclePolicy": "500_error",
+      "DeleteLifecyclePolicy": "working",
+      "UpdateLifecyclePolicy": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SecurityConfig",
+    "operations": [
+      "CreateSecurityConfig",
+      "DeleteSecurityConfig",
+      "GetSecurityConfig",
+      "UpdateSecurityConfig"
+    ],
+    "tested": [
+      "CreateSecurityConfig",
+      "DeleteSecurityConfig",
+      "GetSecurityConfig"
+    ],
+    "untested": [
+      "UpdateSecurityConfig"
+    ],
+    "size": 4,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateSecurityConfig": "working",
+      "DeleteSecurityConfig": "working",
+      "GetSecurityConfig": "working",
+      "UpdateSecurityConfig": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/organizations.json
+++ b/chunks/organizations.json
@@ -1,0 +1,254 @@
+[
+  {
+    "noun": "AWSServiceAccess",
+    "operations": [
+      "DisableAWSServiceAccess",
+      "EnableAWSServiceAccess"
+    ],
+    "tested": [],
+    "untested": [
+      "DisableAWSServiceAccess",
+      "EnableAWSServiceAccess"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "DisableAWSServiceAccess": "working",
+      "EnableAWSServiceAccess": "working"
+    },
+    "working_untested": [
+      "DisableAWSServiceAccess",
+      "EnableAWSServiceAccess"
+    ],
+    "working_untested_count": 2
+  },
+  {
+    "noun": "AWSServiceAccessForOrganization",
+    "operations": [
+      "ListAWSServiceAccessForOrganization"
+    ],
+    "tested": [],
+    "untested": [
+      "ListAWSServiceAccessForOrganization"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListAWSServiceAccessForOrganization": "working"
+    },
+    "working_untested": [
+      "ListAWSServiceAccessForOrganization"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "DeclineHandshake",
+    "operations": [
+      "DeclineHandshake"
+    ],
+    "tested": [],
+    "untested": [
+      "DeclineHandshake"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DeclineHandshake": "working"
+    },
+    "working_untested": [
+      "DeclineHandshake"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "Handshake",
+    "operations": [
+      "AcceptHandshake",
+      "CancelHandshake",
+      "DescribeHandshake"
+    ],
+    "tested": [
+      "CancelHandshake",
+      "DescribeHandshake"
+    ],
+    "untested": [
+      "AcceptHandshake"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "AcceptHandshake": "working",
+      "CancelHandshake": "working",
+      "DescribeHandshake": "working"
+    },
+    "working_untested": [
+      "AcceptHandshake"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "AccountsWithInvalidEffectivePolicy",
+    "operations": [
+      "ListAccountsWithInvalidEffectivePolicy"
+    ],
+    "tested": [],
+    "untested": [
+      "ListAccountsWithInvalidEffectivePolicy"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListAccountsWithInvalidEffectivePolicy": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "EffectivePolicyValidationErrors",
+    "operations": [
+      "ListEffectivePolicyValidationErrors"
+    ],
+    "tested": [],
+    "untested": [
+      "ListEffectivePolicyValidationErrors"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListEffectivePolicyValidationErrors": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "GovCloudAccount",
+    "operations": [
+      "CreateGovCloudAccount"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateGovCloudAccount"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateGovCloudAccount": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "InboundResponsibilityTransfers",
+    "operations": [
+      "ListInboundResponsibilityTransfers"
+    ],
+    "tested": [],
+    "untested": [
+      "ListInboundResponsibilityTransfers"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListInboundResponsibilityTransfers": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "InviteOrganizationToTransferResponsibility",
+    "operations": [
+      "InviteOrganizationToTransferResponsibility"
+    ],
+    "tested": [],
+    "untested": [
+      "InviteOrganizationToTransferResponsibility"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "InviteOrganizationToTransferResponsibility": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "LeaveOrganization",
+    "operations": [
+      "LeaveOrganization"
+    ],
+    "tested": [],
+    "untested": [
+      "LeaveOrganization"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "LeaveOrganization": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "OutboundResponsibilityTransfers",
+    "operations": [
+      "ListOutboundResponsibilityTransfers"
+    ],
+    "tested": [],
+    "untested": [
+      "ListOutboundResponsibilityTransfers"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListOutboundResponsibilityTransfers": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ResourcePolicy",
+    "operations": [
+      "DeleteResourcePolicy",
+      "DescribeResourcePolicy",
+      "PutResourcePolicy"
+    ],
+    "tested": [],
+    "untested": [
+      "DeleteResourcePolicy",
+      "DescribeResourcePolicy",
+      "PutResourcePolicy"
+    ],
+    "size": 3,
+    "untested_count": 3,
+    "probe_status": {
+      "DeleteResourcePolicy": "not_implemented",
+      "DescribeResourcePolicy": "not_implemented",
+      "PutResourcePolicy": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ResponsibilityTransfer",
+    "operations": [
+      "DescribeResponsibilityTransfer",
+      "TerminateResponsibilityTransfer",
+      "UpdateResponsibilityTransfer"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeResponsibilityTransfer",
+      "TerminateResponsibilityTransfer",
+      "UpdateResponsibilityTransfer"
+    ],
+    "size": 3,
+    "untested_count": 3,
+    "probe_status": {
+      "DescribeResponsibilityTransfer": "not_implemented",
+      "TerminateResponsibilityTransfer": "not_implemented",
+      "UpdateResponsibilityTransfer": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/osis.json
+++ b/chunks/osis.json
@@ -1,0 +1,153 @@
+[
+  {
+    "noun": "ResourcePolicy",
+    "operations": [
+      "DeleteResourcePolicy",
+      "GetResourcePolicy",
+      "PutResourcePolicy"
+    ],
+    "tested": [
+      "DeleteResourcePolicy",
+      "GetResourcePolicy"
+    ],
+    "untested": [
+      "PutResourcePolicy"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "DeleteResourcePolicy": "working",
+      "GetResourcePolicy": "working",
+      "PutResourcePolicy": "working"
+    },
+    "working_untested": [
+      "PutResourcePolicy"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "PipelineBlueprint",
+    "operations": [
+      "GetPipelineBlueprint"
+    ],
+    "tested": [],
+    "untested": [
+      "GetPipelineBlueprint"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetPipelineBlueprint": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "PipelineBlueprints",
+    "operations": [
+      "ListPipelineBlueprints"
+    ],
+    "tested": [],
+    "untested": [
+      "ListPipelineBlueprints"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListPipelineBlueprints": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "PipelineChangeProgress",
+    "operations": [
+      "GetPipelineChangeProgress"
+    ],
+    "tested": [],
+    "untested": [
+      "GetPipelineChangeProgress"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetPipelineChangeProgress": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "PipelineEndpoint",
+    "operations": [
+      "CreatePipelineEndpoint",
+      "DeletePipelineEndpoint"
+    ],
+    "tested": [],
+    "untested": [
+      "CreatePipelineEndpoint",
+      "DeletePipelineEndpoint"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "CreatePipelineEndpoint": "not_implemented",
+      "DeletePipelineEndpoint": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "PipelineEndpointConnections",
+    "operations": [
+      "ListPipelineEndpointConnections",
+      "RevokePipelineEndpointConnections"
+    ],
+    "tested": [],
+    "untested": [
+      "ListPipelineEndpointConnections",
+      "RevokePipelineEndpointConnections"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "ListPipelineEndpointConnections": "not_implemented",
+      "RevokePipelineEndpointConnections": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "PipelineEndpoints",
+    "operations": [
+      "ListPipelineEndpoints"
+    ],
+    "tested": [],
+    "untested": [
+      "ListPipelineEndpoints"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListPipelineEndpoints": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ValidatePipeline",
+    "operations": [
+      "ValidatePipeline"
+    ],
+    "tested": [],
+    "untested": [
+      "ValidatePipeline"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ValidatePipeline": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/panorama.json
+++ b/chunks/panorama.json
@@ -1,0 +1,205 @@
+[
+  {
+    "noun": "ApplicationInstanceDependencies",
+    "operations": [
+      "ListApplicationInstanceDependencies"
+    ],
+    "tested": [],
+    "untested": [
+      "ListApplicationInstanceDependencies"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListApplicationInstanceDependencies": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ApplicationInstanceNodeInstances",
+    "operations": [
+      "ListApplicationInstanceNodeInstances"
+    ],
+    "tested": [],
+    "untested": [
+      "ListApplicationInstanceNodeInstances"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListApplicationInstanceNodeInstances": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DeviceJob",
+    "operations": [
+      "DescribeDeviceJob"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeDeviceJob"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeDeviceJob": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DeviceMetadata",
+    "operations": [
+      "UpdateDeviceMetadata"
+    ],
+    "tested": [],
+    "untested": [
+      "UpdateDeviceMetadata"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "UpdateDeviceMetadata": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DevicesJobs",
+    "operations": [
+      "ListDevicesJobs"
+    ],
+    "tested": [],
+    "untested": [
+      "ListDevicesJobs"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListDevicesJobs": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "JobForDevices",
+    "operations": [
+      "CreateJobForDevices"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateJobForDevices"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateJobForDevices": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Package",
+    "operations": [
+      "CreatePackage",
+      "DeletePackage",
+      "DescribePackage"
+    ],
+    "tested": [
+      "CreatePackage",
+      "DeletePackage"
+    ],
+    "untested": [
+      "DescribePackage"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "CreatePackage": "working",
+      "DeletePackage": "working",
+      "DescribePackage": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "PackageVersion",
+    "operations": [
+      "DeregisterPackageVersion",
+      "DescribePackageVersion",
+      "RegisterPackageVersion"
+    ],
+    "tested": [],
+    "untested": [
+      "DeregisterPackageVersion",
+      "DescribePackageVersion",
+      "RegisterPackageVersion"
+    ],
+    "size": 3,
+    "untested_count": 3,
+    "probe_status": {
+      "DeregisterPackageVersion": "not_implemented",
+      "DescribePackageVersion": "not_implemented",
+      "RegisterPackageVersion": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Resource",
+    "operations": [
+      "TagResource",
+      "UntagResource"
+    ],
+    "tested": [],
+    "untested": [
+      "TagResource",
+      "UntagResource"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "TagResource": "not_implemented",
+      "UntagResource": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SignalApplicationInstanceNodeInstances",
+    "operations": [
+      "SignalApplicationInstanceNodeInstances"
+    ],
+    "tested": [],
+    "untested": [
+      "SignalApplicationInstanceNodeInstances"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "SignalApplicationInstanceNodeInstances": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TagsForResource",
+    "operations": [
+      "ListTagsForResource"
+    ],
+    "tested": [],
+    "untested": [
+      "ListTagsForResource"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListTagsForResource": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/pinpoint.json
+++ b/chunks/pinpoint.json
@@ -1,0 +1,22 @@
+[
+  {
+    "noun": "OTPMessage",
+    "operations": [
+      "SendOTPMessage",
+      "VerifyOTPMessage"
+    ],
+    "tested": [],
+    "untested": [
+      "SendOTPMessage",
+      "VerifyOTPMessage"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "SendOTPMessage": "not_implemented",
+      "VerifyOTPMessage": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/pipes.json
+++ b/chunks/pipes.json
@@ -1,0 +1,39 @@
+[
+  {
+    "noun": "Pipe",
+    "operations": [
+      "CreatePipe",
+      "DeletePipe",
+      "DescribePipe",
+      "StartPipe",
+      "StopPipe",
+      "UpdatePipe"
+    ],
+    "tested": [
+      "CreatePipe",
+      "DeletePipe",
+      "DescribePipe"
+    ],
+    "untested": [
+      "StartPipe",
+      "StopPipe",
+      "UpdatePipe"
+    ],
+    "size": 6,
+    "untested_count": 3,
+    "probe_status": {
+      "CreatePipe": "working",
+      "DeletePipe": "working",
+      "DescribePipe": "working",
+      "StartPipe": "working",
+      "StopPipe": "working",
+      "UpdatePipe": "working"
+    },
+    "working_untested": [
+      "StartPipe",
+      "StopPipe",
+      "UpdatePipe"
+    ],
+    "working_untested_count": 3
+  }
+]

--- a/chunks/polly.json
+++ b/chunks/polly.json
@@ -1,0 +1,39 @@
+[
+  {
+    "noun": "SpeechSynthesisTask",
+    "operations": [
+      "GetSpeechSynthesisTask",
+      "StartSpeechSynthesisTask"
+    ],
+    "tested": [],
+    "untested": [
+      "GetSpeechSynthesisTask",
+      "StartSpeechSynthesisTask"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "GetSpeechSynthesisTask": "not_implemented",
+      "StartSpeechSynthesisTask": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SpeechSynthesisTasks",
+    "operations": [
+      "ListSpeechSynthesisTasks"
+    ],
+    "tested": [],
+    "untested": [
+      "ListSpeechSynthesisTasks"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListSpeechSynthesisTasks": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/quicksight.json
+++ b/chunks/quicksight.json
@@ -1,0 +1,453 @@
+[
+  {
+    "noun": "IAMPolicyAssignment",
+    "operations": [
+      "CreateIAMPolicyAssignment",
+      "DeleteIAMPolicyAssignment",
+      "DescribeIAMPolicyAssignment",
+      "UpdateIAMPolicyAssignment"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateIAMPolicyAssignment",
+      "DeleteIAMPolicyAssignment",
+      "DescribeIAMPolicyAssignment",
+      "UpdateIAMPolicyAssignment"
+    ],
+    "size": 4,
+    "untested_count": 4,
+    "probe_status": {
+      "CreateIAMPolicyAssignment": "working",
+      "DeleteIAMPolicyAssignment": "working",
+      "DescribeIAMPolicyAssignment": "working",
+      "UpdateIAMPolicyAssignment": "working"
+    },
+    "working_untested": [
+      "CreateIAMPolicyAssignment",
+      "DeleteIAMPolicyAssignment",
+      "DescribeIAMPolicyAssignment",
+      "UpdateIAMPolicyAssignment"
+    ],
+    "working_untested_count": 4
+  },
+  {
+    "noun": "DashboardsQAConfiguration",
+    "operations": [
+      "DescribeDashboardsQAConfiguration",
+      "UpdateDashboardsQAConfiguration"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeDashboardsQAConfiguration",
+      "UpdateDashboardsQAConfiguration"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "DescribeDashboardsQAConfiguration": "working",
+      "UpdateDashboardsQAConfiguration": "working"
+    },
+    "working_untested": [
+      "DescribeDashboardsQAConfiguration",
+      "UpdateDashboardsQAConfiguration"
+    ],
+    "working_untested_count": 2
+  },
+  {
+    "noun": "VPCConnection",
+    "operations": [
+      "CreateVPCConnection",
+      "DeleteVPCConnection",
+      "DescribeVPCConnection",
+      "UpdateVPCConnection"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateVPCConnection",
+      "DeleteVPCConnection",
+      "DescribeVPCConnection",
+      "UpdateVPCConnection"
+    ],
+    "size": 4,
+    "untested_count": 4,
+    "probe_status": {
+      "CreateVPCConnection": "needs_params",
+      "DeleteVPCConnection": "working",
+      "DescribeVPCConnection": "working",
+      "UpdateVPCConnection": "needs_params"
+    },
+    "working_untested": [
+      "DeleteVPCConnection",
+      "DescribeVPCConnection"
+    ],
+    "working_untested_count": 2
+  },
+  {
+    "noun": "IAMPolicyAssignments",
+    "operations": [
+      "ListIAMPolicyAssignments"
+    ],
+    "tested": [],
+    "untested": [
+      "ListIAMPolicyAssignments"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListIAMPolicyAssignments": "working"
+    },
+    "working_untested": [
+      "ListIAMPolicyAssignments"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "IAMPolicyAssignmentsForUser",
+    "operations": [
+      "ListIAMPolicyAssignmentsForUser"
+    ],
+    "tested": [],
+    "untested": [
+      "ListIAMPolicyAssignmentsForUser"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListIAMPolicyAssignmentsForUser": "working"
+    },
+    "working_untested": [
+      "ListIAMPolicyAssignmentsForUser"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "PredictQAResults",
+    "operations": [
+      "PredictQAResults"
+    ],
+    "tested": [],
+    "untested": [
+      "PredictQAResults"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "PredictQAResults": "working"
+    },
+    "working_untested": [
+      "PredictQAResults"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "SPICECapacityConfiguration",
+    "operations": [
+      "UpdateSPICECapacityConfiguration"
+    ],
+    "tested": [],
+    "untested": [
+      "UpdateSPICECapacityConfiguration"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "UpdateSPICECapacityConfiguration": "working"
+    },
+    "working_untested": [
+      "UpdateSPICECapacityConfiguration"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "VPCConnections",
+    "operations": [
+      "ListVPCConnections"
+    ],
+    "tested": [],
+    "untested": [
+      "ListVPCConnections"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListVPCConnections": "working"
+    },
+    "working_untested": [
+      "ListVPCConnections"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "ActionConnector",
+    "operations": [
+      "CreateActionConnector",
+      "DeleteActionConnector",
+      "DescribeActionConnector",
+      "UpdateActionConnector"
+    ],
+    "tested": [
+      "DeleteActionConnector",
+      "DescribeActionConnector"
+    ],
+    "untested": [
+      "CreateActionConnector",
+      "UpdateActionConnector"
+    ],
+    "size": 4,
+    "untested_count": 2,
+    "probe_status": {
+      "CreateActionConnector": "needs_params",
+      "DeleteActionConnector": "working",
+      "DescribeActionConnector": "working",
+      "UpdateActionConnector": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "AssetBundleExportJob",
+    "operations": [
+      "DescribeAssetBundleExportJob",
+      "StartAssetBundleExportJob"
+    ],
+    "tested": [
+      "DescribeAssetBundleExportJob"
+    ],
+    "untested": [
+      "StartAssetBundleExportJob"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeAssetBundleExportJob": "working",
+      "StartAssetBundleExportJob": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DashboardSnapshotJob",
+    "operations": [
+      "DescribeDashboardSnapshotJob",
+      "StartDashboardSnapshotJob"
+    ],
+    "tested": [
+      "DescribeDashboardSnapshotJob"
+    ],
+    "untested": [
+      "StartDashboardSnapshotJob"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeDashboardSnapshotJob": "working",
+      "StartDashboardSnapshotJob": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DashboardSnapshotJobResult",
+    "operations": [
+      "DescribeDashboardSnapshotJobResult"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeDashboardSnapshotJobResult"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeDashboardSnapshotJobResult": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "FolderResolvedPermissions",
+    "operations": [
+      "DescribeFolderResolvedPermissions"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeFolderResolvedPermissions"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeFolderResolvedPermissions": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "FoldersForResource",
+    "operations": [
+      "ListFoldersForResource"
+    ],
+    "tested": [],
+    "untested": [
+      "ListFoldersForResource"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListFoldersForResource": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "IdentityContext",
+    "operations": [
+      "GetIdentityContext"
+    ],
+    "tested": [],
+    "untested": [
+      "GetIdentityContext"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetIdentityContext": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Namespace",
+    "operations": [
+      "CreateNamespace",
+      "DeleteNamespace",
+      "DescribeNamespace"
+    ],
+    "tested": [
+      "DeleteNamespace",
+      "DescribeNamespace"
+    ],
+    "untested": [
+      "CreateNamespace"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateNamespace": "not_implemented",
+      "DeleteNamespace": "working",
+      "DescribeNamespace": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SearchAnalyses",
+    "operations": [
+      "SearchAnalyses"
+    ],
+    "tested": [],
+    "untested": [
+      "SearchAnalyses"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "SearchAnalyses": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SearchDashboards",
+    "operations": [
+      "SearchDashboards"
+    ],
+    "tested": [],
+    "untested": [
+      "SearchDashboards"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "SearchDashboards": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SearchDataSets",
+    "operations": [
+      "SearchDataSets"
+    ],
+    "tested": [],
+    "untested": [
+      "SearchDataSets"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "SearchDataSets": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SearchDataSources",
+    "operations": [
+      "SearchDataSources"
+    ],
+    "tested": [],
+    "untested": [
+      "SearchDataSources"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "SearchDataSources": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SearchTopics",
+    "operations": [
+      "SearchTopics"
+    ],
+    "tested": [],
+    "untested": [
+      "SearchTopics"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "SearchTopics": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Topic",
+    "operations": [
+      "CreateTopic",
+      "DeleteTopic",
+      "DescribeTopic",
+      "UpdateTopic"
+    ],
+    "tested": [
+      "CreateTopic",
+      "DescribeTopic",
+      "UpdateTopic"
+    ],
+    "untested": [
+      "DeleteTopic"
+    ],
+    "size": 4,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateTopic": "working",
+      "DeleteTopic": "unknown",
+      "DescribeTopic": "working",
+      "UpdateTopic": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/ram.json
+++ b/chunks/ram.json
@@ -1,0 +1,21 @@
+[
+  {
+    "noun": "SourceAssociations",
+    "operations": [
+      "ListSourceAssociations"
+    ],
+    "tested": [],
+    "untested": [
+      "ListSourceAssociations"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListSourceAssociations": "working"
+    },
+    "working_untested": [
+      "ListSourceAssociations"
+    ],
+    "working_untested_count": 1
+  }
+]

--- a/chunks/rds.json
+++ b/chunks/rds.json
@@ -1,0 +1,1489 @@
+[
+  {
+    "noun": "DBInstance",
+    "operations": [
+      "CreateDBInstance",
+      "DeleteDBInstance",
+      "ModifyDBInstance",
+      "RebootDBInstance",
+      "StartDBInstance",
+      "StopDBInstance"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateDBInstance",
+      "DeleteDBInstance",
+      "ModifyDBInstance",
+      "RebootDBInstance",
+      "StartDBInstance",
+      "StopDBInstance"
+    ],
+    "size": 6,
+    "untested_count": 6,
+    "probe_status": {
+      "CreateDBInstance": "working",
+      "DeleteDBInstance": "unknown",
+      "ModifyDBInstance": "working",
+      "RebootDBInstance": "working",
+      "StartDBInstance": "working",
+      "StopDBInstance": "working"
+    },
+    "working_untested": [
+      "CreateDBInstance",
+      "ModifyDBInstance",
+      "RebootDBInstance",
+      "StartDBInstance",
+      "StopDBInstance"
+    ],
+    "working_untested_count": 5
+  },
+  {
+    "noun": "DBCluster",
+    "operations": [
+      "CreateDBCluster",
+      "DeleteDBCluster",
+      "ModifyDBCluster",
+      "RebootDBCluster",
+      "StartDBCluster",
+      "StopDBCluster"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateDBCluster",
+      "DeleteDBCluster",
+      "ModifyDBCluster",
+      "RebootDBCluster",
+      "StartDBCluster",
+      "StopDBCluster"
+    ],
+    "size": 6,
+    "untested_count": 6,
+    "probe_status": {
+      "CreateDBCluster": "working",
+      "DeleteDBCluster": "unknown",
+      "ModifyDBCluster": "working",
+      "RebootDBCluster": "not_implemented",
+      "StartDBCluster": "working",
+      "StopDBCluster": "working"
+    },
+    "working_untested": [
+      "CreateDBCluster",
+      "ModifyDBCluster",
+      "StartDBCluster",
+      "StopDBCluster"
+    ],
+    "working_untested_count": 4
+  },
+  {
+    "noun": "DBClusterParameterGroup",
+    "operations": [
+      "CopyDBClusterParameterGroup",
+      "CreateDBClusterParameterGroup",
+      "DeleteDBClusterParameterGroup",
+      "ModifyDBClusterParameterGroup",
+      "ResetDBClusterParameterGroup"
+    ],
+    "tested": [],
+    "untested": [
+      "CopyDBClusterParameterGroup",
+      "CreateDBClusterParameterGroup",
+      "DeleteDBClusterParameterGroup",
+      "ModifyDBClusterParameterGroup",
+      "ResetDBClusterParameterGroup"
+    ],
+    "size": 5,
+    "untested_count": 5,
+    "probe_status": {
+      "CopyDBClusterParameterGroup": "working",
+      "CreateDBClusterParameterGroup": "working",
+      "DeleteDBClusterParameterGroup": "working",
+      "ModifyDBClusterParameterGroup": "working",
+      "ResetDBClusterParameterGroup": "not_implemented"
+    },
+    "working_untested": [
+      "CopyDBClusterParameterGroup",
+      "CreateDBClusterParameterGroup",
+      "DeleteDBClusterParameterGroup",
+      "ModifyDBClusterParameterGroup"
+    ],
+    "working_untested_count": 4
+  },
+  {
+    "noun": "DBParameterGroup",
+    "operations": [
+      "CopyDBParameterGroup",
+      "CreateDBParameterGroup",
+      "DeleteDBParameterGroup",
+      "ModifyDBParameterGroup",
+      "ResetDBParameterGroup"
+    ],
+    "tested": [],
+    "untested": [
+      "CopyDBParameterGroup",
+      "CreateDBParameterGroup",
+      "DeleteDBParameterGroup",
+      "ModifyDBParameterGroup",
+      "ResetDBParameterGroup"
+    ],
+    "size": 5,
+    "untested_count": 5,
+    "probe_status": {
+      "CopyDBParameterGroup": "working",
+      "CreateDBParameterGroup": "working",
+      "DeleteDBParameterGroup": "working",
+      "ModifyDBParameterGroup": "working",
+      "ResetDBParameterGroup": "not_implemented"
+    },
+    "working_untested": [
+      "CopyDBParameterGroup",
+      "CreateDBParameterGroup",
+      "DeleteDBParameterGroup",
+      "ModifyDBParameterGroup"
+    ],
+    "working_untested_count": 4
+  },
+  {
+    "noun": "CustomDBEngineVersion",
+    "operations": [
+      "CreateCustomDBEngineVersion",
+      "DeleteCustomDBEngineVersion",
+      "ModifyCustomDBEngineVersion"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateCustomDBEngineVersion",
+      "DeleteCustomDBEngineVersion",
+      "ModifyCustomDBEngineVersion"
+    ],
+    "size": 3,
+    "untested_count": 3,
+    "probe_status": {
+      "CreateCustomDBEngineVersion": "working",
+      "DeleteCustomDBEngineVersion": "working",
+      "ModifyCustomDBEngineVersion": "working"
+    },
+    "working_untested": [
+      "CreateCustomDBEngineVersion",
+      "DeleteCustomDBEngineVersion",
+      "ModifyCustomDBEngineVersion"
+    ],
+    "working_untested_count": 3
+  },
+  {
+    "noun": "DBClusterEndpoint",
+    "operations": [
+      "CreateDBClusterEndpoint",
+      "DeleteDBClusterEndpoint",
+      "ModifyDBClusterEndpoint"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateDBClusterEndpoint",
+      "DeleteDBClusterEndpoint",
+      "ModifyDBClusterEndpoint"
+    ],
+    "size": 3,
+    "untested_count": 3,
+    "probe_status": {
+      "CreateDBClusterEndpoint": "working",
+      "DeleteDBClusterEndpoint": "working",
+      "ModifyDBClusterEndpoint": "working"
+    },
+    "working_untested": [
+      "CreateDBClusterEndpoint",
+      "DeleteDBClusterEndpoint",
+      "ModifyDBClusterEndpoint"
+    ],
+    "working_untested_count": 3
+  },
+  {
+    "noun": "DBClusterSnapshot",
+    "operations": [
+      "CopyDBClusterSnapshot",
+      "CreateDBClusterSnapshot",
+      "DeleteDBClusterSnapshot"
+    ],
+    "tested": [],
+    "untested": [
+      "CopyDBClusterSnapshot",
+      "CreateDBClusterSnapshot",
+      "DeleteDBClusterSnapshot"
+    ],
+    "size": 3,
+    "untested_count": 3,
+    "probe_status": {
+      "CopyDBClusterSnapshot": "working",
+      "CreateDBClusterSnapshot": "working",
+      "DeleteDBClusterSnapshot": "working"
+    },
+    "working_untested": [
+      "CopyDBClusterSnapshot",
+      "CreateDBClusterSnapshot",
+      "DeleteDBClusterSnapshot"
+    ],
+    "working_untested_count": 3
+  },
+  {
+    "noun": "DBShardGroup",
+    "operations": [
+      "CreateDBShardGroup",
+      "DeleteDBShardGroup",
+      "ModifyDBShardGroup",
+      "RebootDBShardGroup"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateDBShardGroup",
+      "DeleteDBShardGroup",
+      "ModifyDBShardGroup",
+      "RebootDBShardGroup"
+    ],
+    "size": 4,
+    "untested_count": 4,
+    "probe_status": {
+      "CreateDBShardGroup": "needs_params",
+      "DeleteDBShardGroup": "working",
+      "ModifyDBShardGroup": "working",
+      "RebootDBShardGroup": "working"
+    },
+    "working_untested": [
+      "DeleteDBShardGroup",
+      "ModifyDBShardGroup",
+      "RebootDBShardGroup"
+    ],
+    "working_untested_count": 3
+  },
+  {
+    "noun": "DBSnapshot",
+    "operations": [
+      "CopyDBSnapshot",
+      "CreateDBSnapshot",
+      "DeleteDBSnapshot",
+      "ModifyDBSnapshot"
+    ],
+    "tested": [],
+    "untested": [
+      "CopyDBSnapshot",
+      "CreateDBSnapshot",
+      "DeleteDBSnapshot",
+      "ModifyDBSnapshot"
+    ],
+    "size": 4,
+    "untested_count": 4,
+    "probe_status": {
+      "CopyDBSnapshot": "working",
+      "CreateDBSnapshot": "working",
+      "DeleteDBSnapshot": "working",
+      "ModifyDBSnapshot": "not_implemented"
+    },
+    "working_untested": [
+      "CopyDBSnapshot",
+      "CreateDBSnapshot",
+      "DeleteDBSnapshot"
+    ],
+    "working_untested_count": 3
+  },
+  {
+    "noun": "DBSubnetGroup",
+    "operations": [
+      "CreateDBSubnetGroup",
+      "DeleteDBSubnetGroup",
+      "ModifyDBSubnetGroup"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateDBSubnetGroup",
+      "DeleteDBSubnetGroup",
+      "ModifyDBSubnetGroup"
+    ],
+    "size": 3,
+    "untested_count": 3,
+    "probe_status": {
+      "CreateDBSubnetGroup": "working",
+      "DeleteDBSubnetGroup": "working",
+      "ModifyDBSubnetGroup": "working"
+    },
+    "working_untested": [
+      "CreateDBSubnetGroup",
+      "DeleteDBSubnetGroup",
+      "ModifyDBSubnetGroup"
+    ],
+    "working_untested_count": 3
+  },
+  {
+    "noun": "DBProxyEndpoint",
+    "operations": [
+      "CreateDBProxyEndpoint",
+      "DeleteDBProxyEndpoint",
+      "ModifyDBProxyEndpoint"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateDBProxyEndpoint",
+      "DeleteDBProxyEndpoint",
+      "ModifyDBProxyEndpoint"
+    ],
+    "size": 3,
+    "untested_count": 3,
+    "probe_status": {
+      "CreateDBProxyEndpoint": "working",
+      "DeleteDBProxyEndpoint": "working",
+      "ModifyDBProxyEndpoint": "not_implemented"
+    },
+    "working_untested": [
+      "CreateDBProxyEndpoint",
+      "DeleteDBProxyEndpoint"
+    ],
+    "working_untested_count": 2
+  },
+  {
+    "noun": "DBSecurityGroup",
+    "operations": [
+      "CreateDBSecurityGroup",
+      "DeleteDBSecurityGroup"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateDBSecurityGroup",
+      "DeleteDBSecurityGroup"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "CreateDBSecurityGroup": "working",
+      "DeleteDBSecurityGroup": "working"
+    },
+    "working_untested": [
+      "CreateDBSecurityGroup",
+      "DeleteDBSecurityGroup"
+    ],
+    "working_untested_count": 2
+  },
+  {
+    "noun": "DBClusterAutomatedBackups",
+    "operations": [
+      "DescribeDBClusterAutomatedBackups"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeDBClusterAutomatedBackups"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeDBClusterAutomatedBackups": "working"
+    },
+    "working_untested": [
+      "DescribeDBClusterAutomatedBackups"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "DBClusterEndpoints",
+    "operations": [
+      "DescribeDBClusterEndpoints"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeDBClusterEndpoints"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeDBClusterEndpoints": "working"
+    },
+    "working_untested": [
+      "DescribeDBClusterEndpoints"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "DBClusterFromSnapshot",
+    "operations": [
+      "RestoreDBClusterFromSnapshot"
+    ],
+    "tested": [],
+    "untested": [
+      "RestoreDBClusterFromSnapshot"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "RestoreDBClusterFromSnapshot": "working"
+    },
+    "working_untested": [
+      "RestoreDBClusterFromSnapshot"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "DBClusterParameterGroups",
+    "operations": [
+      "DescribeDBClusterParameterGroups"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeDBClusterParameterGroups"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeDBClusterParameterGroups": "working"
+    },
+    "working_untested": [
+      "DescribeDBClusterParameterGroups"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "DBClusterParameters",
+    "operations": [
+      "DescribeDBClusterParameters"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeDBClusterParameters"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeDBClusterParameters": "working"
+    },
+    "working_untested": [
+      "DescribeDBClusterParameters"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "DBClusterSnapshotAttribute",
+    "operations": [
+      "ModifyDBClusterSnapshotAttribute"
+    ],
+    "tested": [],
+    "untested": [
+      "ModifyDBClusterSnapshotAttribute"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ModifyDBClusterSnapshotAttribute": "working"
+    },
+    "working_untested": [
+      "ModifyDBClusterSnapshotAttribute"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "DBClusterSnapshotAttributes",
+    "operations": [
+      "DescribeDBClusterSnapshotAttributes"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeDBClusterSnapshotAttributes"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeDBClusterSnapshotAttributes": "working"
+    },
+    "working_untested": [
+      "DescribeDBClusterSnapshotAttributes"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "DBClusterSnapshots",
+    "operations": [
+      "DescribeDBClusterSnapshots"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeDBClusterSnapshots"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeDBClusterSnapshots": "working"
+    },
+    "working_untested": [
+      "DescribeDBClusterSnapshots"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "DBClusters",
+    "operations": [
+      "DescribeDBClusters"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeDBClusters"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeDBClusters": "working"
+    },
+    "working_untested": [
+      "DescribeDBClusters"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "DBEngineVersions",
+    "operations": [
+      "DescribeDBEngineVersions"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeDBEngineVersions"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeDBEngineVersions": "working"
+    },
+    "working_untested": [
+      "DescribeDBEngineVersions"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "DBInstanceAutomatedBackup",
+    "operations": [
+      "DeleteDBInstanceAutomatedBackup"
+    ],
+    "tested": [],
+    "untested": [
+      "DeleteDBInstanceAutomatedBackup"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DeleteDBInstanceAutomatedBackup": "working"
+    },
+    "working_untested": [
+      "DeleteDBInstanceAutomatedBackup"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "DBInstanceAutomatedBackups",
+    "operations": [
+      "DescribeDBInstanceAutomatedBackups"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeDBInstanceAutomatedBackups"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeDBInstanceAutomatedBackups": "working"
+    },
+    "working_untested": [
+      "DescribeDBInstanceAutomatedBackups"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "DBInstanceFromDBSnapshot",
+    "operations": [
+      "RestoreDBInstanceFromDBSnapshot"
+    ],
+    "tested": [],
+    "untested": [
+      "RestoreDBInstanceFromDBSnapshot"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "RestoreDBInstanceFromDBSnapshot": "working"
+    },
+    "working_untested": [
+      "RestoreDBInstanceFromDBSnapshot"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "DBInstanceToPointInTime",
+    "operations": [
+      "RestoreDBInstanceToPointInTime"
+    ],
+    "tested": [],
+    "untested": [
+      "RestoreDBInstanceToPointInTime"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "RestoreDBInstanceToPointInTime": "working"
+    },
+    "working_untested": [
+      "RestoreDBInstanceToPointInTime"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "DBInstances",
+    "operations": [
+      "DescribeDBInstances"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeDBInstances"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeDBInstances": "working"
+    },
+    "working_untested": [
+      "DescribeDBInstances"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "DBLogFiles",
+    "operations": [
+      "DescribeDBLogFiles"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeDBLogFiles"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeDBLogFiles": "working"
+    },
+    "working_untested": [
+      "DescribeDBLogFiles"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "DBParameterGroups",
+    "operations": [
+      "DescribeDBParameterGroups"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeDBParameterGroups"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeDBParameterGroups": "working"
+    },
+    "working_untested": [
+      "DescribeDBParameterGroups"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "DBParameters",
+    "operations": [
+      "DescribeDBParameters"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeDBParameters"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeDBParameters": "working"
+    },
+    "working_untested": [
+      "DescribeDBParameters"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "DBProxies",
+    "operations": [
+      "DescribeDBProxies"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeDBProxies"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeDBProxies": "working"
+    },
+    "working_untested": [
+      "DescribeDBProxies"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "DBProxy",
+    "operations": [
+      "CreateDBProxy",
+      "DeleteDBProxy",
+      "ModifyDBProxy"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateDBProxy",
+      "DeleteDBProxy",
+      "ModifyDBProxy"
+    ],
+    "size": 3,
+    "untested_count": 3,
+    "probe_status": {
+      "CreateDBProxy": "500_error",
+      "DeleteDBProxy": "working",
+      "ModifyDBProxy": "not_implemented"
+    },
+    "working_untested": [
+      "DeleteDBProxy"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "DBProxyEndpoints",
+    "operations": [
+      "DescribeDBProxyEndpoints"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeDBProxyEndpoints"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeDBProxyEndpoints": "working"
+    },
+    "working_untested": [
+      "DescribeDBProxyEndpoints"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "DBProxyTargetGroups",
+    "operations": [
+      "DescribeDBProxyTargetGroups"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeDBProxyTargetGroups"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeDBProxyTargetGroups": "working"
+    },
+    "working_untested": [
+      "DescribeDBProxyTargetGroups"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "DBProxyTargets",
+    "operations": [
+      "DeregisterDBProxyTargets",
+      "DescribeDBProxyTargets",
+      "RegisterDBProxyTargets"
+    ],
+    "tested": [],
+    "untested": [
+      "DeregisterDBProxyTargets",
+      "DescribeDBProxyTargets",
+      "RegisterDBProxyTargets"
+    ],
+    "size": 3,
+    "untested_count": 3,
+    "probe_status": {
+      "DeregisterDBProxyTargets": "500_error",
+      "DescribeDBProxyTargets": "working",
+      "RegisterDBProxyTargets": "500_error"
+    },
+    "working_untested": [
+      "DescribeDBProxyTargets"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "DBRecommendations",
+    "operations": [
+      "DescribeDBRecommendations"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeDBRecommendations"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeDBRecommendations": "working"
+    },
+    "working_untested": [
+      "DescribeDBRecommendations"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "DBSecurityGroupIngress",
+    "operations": [
+      "AuthorizeDBSecurityGroupIngress",
+      "RevokeDBSecurityGroupIngress"
+    ],
+    "tested": [],
+    "untested": [
+      "AuthorizeDBSecurityGroupIngress",
+      "RevokeDBSecurityGroupIngress"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "AuthorizeDBSecurityGroupIngress": "working",
+      "RevokeDBSecurityGroupIngress": "not_implemented"
+    },
+    "working_untested": [
+      "AuthorizeDBSecurityGroupIngress"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "DBSecurityGroups",
+    "operations": [
+      "DescribeDBSecurityGroups"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeDBSecurityGroups"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeDBSecurityGroups": "working"
+    },
+    "working_untested": [
+      "DescribeDBSecurityGroups"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "DBShardGroups",
+    "operations": [
+      "DescribeDBShardGroups"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeDBShardGroups"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeDBShardGroups": "working"
+    },
+    "working_untested": [
+      "DescribeDBShardGroups"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "DBSnapshotAttribute",
+    "operations": [
+      "ModifyDBSnapshotAttribute"
+    ],
+    "tested": [],
+    "untested": [
+      "ModifyDBSnapshotAttribute"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ModifyDBSnapshotAttribute": "working"
+    },
+    "working_untested": [
+      "ModifyDBSnapshotAttribute"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "DBSnapshotAttributes",
+    "operations": [
+      "DescribeDBSnapshotAttributes"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeDBSnapshotAttributes"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeDBSnapshotAttributes": "working"
+    },
+    "working_untested": [
+      "DescribeDBSnapshotAttributes"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "DBSnapshotTenantDatabases",
+    "operations": [
+      "DescribeDBSnapshotTenantDatabases"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeDBSnapshotTenantDatabases"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeDBSnapshotTenantDatabases": "working"
+    },
+    "working_untested": [
+      "DescribeDBSnapshotTenantDatabases"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "DBSnapshots",
+    "operations": [
+      "DescribeDBSnapshots"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeDBSnapshots"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeDBSnapshots": "working"
+    },
+    "working_untested": [
+      "DescribeDBSnapshots"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "DBSubnetGroups",
+    "operations": [
+      "DescribeDBSubnetGroups"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeDBSubnetGroups"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeDBSubnetGroups": "working"
+    },
+    "working_untested": [
+      "DescribeDBSubnetGroups"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "FailoverDBCluster",
+    "operations": [
+      "FailoverDBCluster"
+    ],
+    "tested": [],
+    "untested": [
+      "FailoverDBCluster"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "FailoverDBCluster": "working"
+    },
+    "working_untested": [
+      "FailoverDBCluster"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "OrderableDBInstanceOptions",
+    "operations": [
+      "DescribeOrderableDBInstanceOptions"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeOrderableDBInstanceOptions"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeOrderableDBInstanceOptions": "working"
+    },
+    "working_untested": [
+      "DescribeOrderableDBInstanceOptions"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "PromoteReadReplicaDBCluster",
+    "operations": [
+      "PromoteReadReplicaDBCluster"
+    ],
+    "tested": [],
+    "untested": [
+      "PromoteReadReplicaDBCluster"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "PromoteReadReplicaDBCluster": "working"
+    },
+    "working_untested": [
+      "PromoteReadReplicaDBCluster"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "PurchaseReservedDBInstancesOffering",
+    "operations": [
+      "PurchaseReservedDBInstancesOffering"
+    ],
+    "tested": [],
+    "untested": [
+      "PurchaseReservedDBInstancesOffering"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "PurchaseReservedDBInstancesOffering": "working"
+    },
+    "working_untested": [
+      "PurchaseReservedDBInstancesOffering"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "ReservedDBInstances",
+    "operations": [
+      "DescribeReservedDBInstances"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeReservedDBInstances"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeReservedDBInstances": "working"
+    },
+    "working_untested": [
+      "DescribeReservedDBInstances"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "ReservedDBInstancesOfferings",
+    "operations": [
+      "DescribeReservedDBInstancesOfferings"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeReservedDBInstancesOfferings"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeReservedDBInstancesOfferings": "working"
+    },
+    "working_untested": [
+      "DescribeReservedDBInstancesOfferings"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "RoleToDBCluster",
+    "operations": [
+      "AddRoleToDBCluster"
+    ],
+    "tested": [],
+    "untested": [
+      "AddRoleToDBCluster"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "AddRoleToDBCluster": "working"
+    },
+    "working_untested": [
+      "AddRoleToDBCluster"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "RoleToDBInstance",
+    "operations": [
+      "AddRoleToDBInstance"
+    ],
+    "tested": [],
+    "untested": [
+      "AddRoleToDBInstance"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "AddRoleToDBInstance": "working"
+    },
+    "working_untested": [
+      "AddRoleToDBInstance"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "ValidDBInstanceModifications",
+    "operations": [
+      "DescribeValidDBInstanceModifications"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeValidDBInstanceModifications"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeValidDBInstanceModifications": "working"
+    },
+    "working_untested": [
+      "DescribeValidDBInstanceModifications"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "BacktrackDBCluster",
+    "operations": [
+      "BacktrackDBCluster"
+    ],
+    "tested": [],
+    "untested": [
+      "BacktrackDBCluster"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "BacktrackDBCluster": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Certificates",
+    "operations": [
+      "DescribeCertificates",
+      "ModifyCertificates"
+    ],
+    "tested": [
+      "DescribeCertificates"
+    ],
+    "untested": [
+      "ModifyCertificates"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeCertificates": "working",
+      "ModifyCertificates": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "CurrentDBClusterCapacity",
+    "operations": [
+      "ModifyCurrentDBClusterCapacity"
+    ],
+    "tested": [],
+    "untested": [
+      "ModifyCurrentDBClusterCapacity"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ModifyCurrentDBClusterCapacity": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DBClusterAutomatedBackup",
+    "operations": [
+      "DeleteDBClusterAutomatedBackup"
+    ],
+    "tested": [],
+    "untested": [
+      "DeleteDBClusterAutomatedBackup"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DeleteDBClusterAutomatedBackup": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DBClusterBacktracks",
+    "operations": [
+      "DescribeDBClusterBacktracks"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeDBClusterBacktracks"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeDBClusterBacktracks": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DBClusterFromS3",
+    "operations": [
+      "RestoreDBClusterFromS3"
+    ],
+    "tested": [],
+    "untested": [
+      "RestoreDBClusterFromS3"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "RestoreDBClusterFromS3": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DBClusterToPointInTime",
+    "operations": [
+      "RestoreDBClusterToPointInTime"
+    ],
+    "tested": [],
+    "untested": [
+      "RestoreDBClusterToPointInTime"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "RestoreDBClusterToPointInTime": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DBInstanceAutomatedBackupsReplication",
+    "operations": [
+      "StartDBInstanceAutomatedBackupsReplication",
+      "StopDBInstanceAutomatedBackupsReplication"
+    ],
+    "tested": [],
+    "untested": [
+      "StartDBInstanceAutomatedBackupsReplication",
+      "StopDBInstanceAutomatedBackupsReplication"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "StartDBInstanceAutomatedBackupsReplication": "not_implemented",
+      "StopDBInstanceAutomatedBackupsReplication": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DBInstanceFromS3",
+    "operations": [
+      "RestoreDBInstanceFromS3"
+    ],
+    "tested": [],
+    "untested": [
+      "RestoreDBInstanceFromS3"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "RestoreDBInstanceFromS3": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DBInstanceReadReplica",
+    "operations": [
+      "CreateDBInstanceReadReplica"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateDBInstanceReadReplica"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateDBInstanceReadReplica": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DBMajorEngineVersions",
+    "operations": [
+      "DescribeDBMajorEngineVersions"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeDBMajorEngineVersions"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeDBMajorEngineVersions": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DBProxyTargetGroup",
+    "operations": [
+      "ModifyDBProxyTargetGroup"
+    ],
+    "tested": [],
+    "untested": [
+      "ModifyDBProxyTargetGroup"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ModifyDBProxyTargetGroup": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DBRecommendation",
+    "operations": [
+      "ModifyDBRecommendation"
+    ],
+    "tested": [],
+    "untested": [
+      "ModifyDBRecommendation"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ModifyDBRecommendation": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DownloadDBLogFilePortion",
+    "operations": [
+      "DownloadDBLogFilePortion"
+    ],
+    "tested": [],
+    "untested": [
+      "DownloadDBLogFilePortion"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DownloadDBLogFilePortion": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "HttpEndpoint",
+    "operations": [
+      "DisableHttpEndpoint",
+      "EnableHttpEndpoint"
+    ],
+    "tested": [],
+    "untested": [
+      "DisableHttpEndpoint",
+      "EnableHttpEndpoint"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "DisableHttpEndpoint": "not_implemented",
+      "EnableHttpEndpoint": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "RoleFromDBCluster",
+    "operations": [
+      "RemoveRoleFromDBCluster"
+    ],
+    "tested": [],
+    "untested": [
+      "RemoveRoleFromDBCluster"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "RemoveRoleFromDBCluster": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "RoleFromDBInstance",
+    "operations": [
+      "RemoveRoleFromDBInstance"
+    ],
+    "tested": [],
+    "untested": [
+      "RemoveRoleFromDBInstance"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "RemoveRoleFromDBInstance": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SourceRegions",
+    "operations": [
+      "DescribeSourceRegions"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeSourceRegions"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeSourceRegions": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SwitchoverReadReplica",
+    "operations": [
+      "SwitchoverReadReplica"
+    ],
+    "tested": [],
+    "untested": [
+      "SwitchoverReadReplica"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "SwitchoverReadReplica": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/redshift.json
+++ b/chunks/redshift.json
@@ -1,0 +1,172 @@
+[
+  {
+    "noun": "ClusterCredentialsWithIAM",
+    "operations": [
+      "GetClusterCredentialsWithIAM"
+    ],
+    "tested": [],
+    "untested": [
+      "GetClusterCredentialsWithIAM"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetClusterCredentialsWithIAM": "working"
+    },
+    "working_untested": [
+      "GetClusterCredentialsWithIAM"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "FailoverPrimaryCompute",
+    "operations": [
+      "FailoverPrimaryCompute"
+    ],
+    "tested": [],
+    "untested": [
+      "FailoverPrimaryCompute"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "FailoverPrimaryCompute": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Integration",
+    "operations": [
+      "CreateIntegration",
+      "DeleteIntegration",
+      "ModifyIntegration"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateIntegration",
+      "DeleteIntegration",
+      "ModifyIntegration"
+    ],
+    "size": 3,
+    "untested_count": 3,
+    "probe_status": {
+      "CreateIntegration": "not_implemented",
+      "DeleteIntegration": "not_implemented",
+      "ModifyIntegration": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "LakehouseConfiguration",
+    "operations": [
+      "ModifyLakehouseConfiguration"
+    ],
+    "tested": [],
+    "untested": [
+      "ModifyLakehouseConfiguration"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ModifyLakehouseConfiguration": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Namespace",
+    "operations": [
+      "DeregisterNamespace",
+      "RegisterNamespace"
+    ],
+    "tested": [],
+    "untested": [
+      "DeregisterNamespace",
+      "RegisterNamespace"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "DeregisterNamespace": "needs_params",
+      "RegisterNamespace": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "PurchaseReservedNodeOffering",
+    "operations": [
+      "PurchaseReservedNodeOffering"
+    ],
+    "tested": [],
+    "untested": [
+      "PurchaseReservedNodeOffering"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "PurchaseReservedNodeOffering": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "RedshiftIdcApplication",
+    "operations": [
+      "CreateRedshiftIdcApplication",
+      "DeleteRedshiftIdcApplication",
+      "ModifyRedshiftIdcApplication"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateRedshiftIdcApplication",
+      "DeleteRedshiftIdcApplication",
+      "ModifyRedshiftIdcApplication"
+    ],
+    "size": 3,
+    "untested_count": 3,
+    "probe_status": {
+      "CreateRedshiftIdcApplication": "not_implemented",
+      "DeleteRedshiftIdcApplication": "not_implemented",
+      "ModifyRedshiftIdcApplication": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ResizeCluster",
+    "operations": [
+      "ResizeCluster"
+    ],
+    "tested": [],
+    "untested": [
+      "ResizeCluster"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ResizeCluster": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TableFromClusterSnapshot",
+    "operations": [
+      "RestoreTableFromClusterSnapshot"
+    ],
+    "tested": [],
+    "untested": [
+      "RestoreTableFromClusterSnapshot"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "RestoreTableFromClusterSnapshot": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/rekognition.json
+++ b/chunks/rekognition.json
@@ -1,0 +1,275 @@
+[
+  {
+    "noun": "DatasetEntries",
+    "operations": [
+      "ListDatasetEntries",
+      "UpdateDatasetEntries"
+    ],
+    "tested": [
+      "ListDatasetEntries"
+    ],
+    "untested": [
+      "UpdateDatasetEntries"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "ListDatasetEntries": "working",
+      "UpdateDatasetEntries": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DistributeDatasetEntries",
+    "operations": [
+      "DistributeDatasetEntries"
+    ],
+    "tested": [],
+    "untested": [
+      "DistributeDatasetEntries"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DistributeDatasetEntries": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Faces",
+    "operations": [
+      "AssociateFaces",
+      "DeleteFaces",
+      "DisassociateFaces",
+      "ListFaces"
+    ],
+    "tested": [
+      "DeleteFaces",
+      "ListFaces"
+    ],
+    "untested": [
+      "AssociateFaces",
+      "DisassociateFaces"
+    ],
+    "size": 4,
+    "untested_count": 2,
+    "probe_status": {
+      "AssociateFaces": "needs_params",
+      "DeleteFaces": "needs_params",
+      "DisassociateFaces": "needs_params",
+      "ListFaces": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "MediaAnalysisJob",
+    "operations": [
+      "GetMediaAnalysisJob",
+      "StartMediaAnalysisJob"
+    ],
+    "tested": [],
+    "untested": [
+      "GetMediaAnalysisJob",
+      "StartMediaAnalysisJob"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "GetMediaAnalysisJob": "not_implemented",
+      "StartMediaAnalysisJob": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "MediaAnalysisJobs",
+    "operations": [
+      "ListMediaAnalysisJobs"
+    ],
+    "tested": [],
+    "untested": [
+      "ListMediaAnalysisJobs"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListMediaAnalysisJobs": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ProjectPolicies",
+    "operations": [
+      "ListProjectPolicies"
+    ],
+    "tested": [],
+    "untested": [
+      "ListProjectPolicies"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListProjectPolicies": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ProjectPolicy",
+    "operations": [
+      "DeleteProjectPolicy",
+      "PutProjectPolicy"
+    ],
+    "tested": [],
+    "untested": [
+      "DeleteProjectPolicy",
+      "PutProjectPolicy"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "DeleteProjectPolicy": "not_implemented",
+      "PutProjectPolicy": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ProjectVersion",
+    "operations": [
+      "CopyProjectVersion",
+      "CreateProjectVersion",
+      "DeleteProjectVersion",
+      "StartProjectVersion",
+      "StopProjectVersion"
+    ],
+    "tested": [
+      "CreateProjectVersion",
+      "DeleteProjectVersion",
+      "StartProjectVersion",
+      "StopProjectVersion"
+    ],
+    "untested": [
+      "CopyProjectVersion"
+    ],
+    "size": 5,
+    "untested_count": 1,
+    "probe_status": {
+      "CopyProjectVersion": "not_implemented",
+      "CreateProjectVersion": "working",
+      "DeleteProjectVersion": "working",
+      "StartProjectVersion": "working",
+      "StopProjectVersion": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SearchUsers",
+    "operations": [
+      "SearchUsers"
+    ],
+    "tested": [],
+    "untested": [
+      "SearchUsers"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "SearchUsers": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SearchUsersByImage",
+    "operations": [
+      "SearchUsersByImage"
+    ],
+    "tested": [],
+    "untested": [
+      "SearchUsersByImage"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "SearchUsersByImage": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "StreamProcessor",
+    "operations": [
+      "CreateStreamProcessor",
+      "DeleteStreamProcessor",
+      "DescribeStreamProcessor",
+      "StartStreamProcessor",
+      "StopStreamProcessor",
+      "UpdateStreamProcessor"
+    ],
+    "tested": [
+      "CreateStreamProcessor",
+      "DeleteStreamProcessor",
+      "DescribeStreamProcessor",
+      "StartStreamProcessor",
+      "StopStreamProcessor"
+    ],
+    "untested": [
+      "UpdateStreamProcessor"
+    ],
+    "size": 6,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateStreamProcessor": "working",
+      "DeleteStreamProcessor": "working",
+      "DescribeStreamProcessor": "working",
+      "StartStreamProcessor": "working",
+      "StopStreamProcessor": "working",
+      "UpdateStreamProcessor": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "User",
+    "operations": [
+      "CreateUser",
+      "DeleteUser"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateUser",
+      "DeleteUser"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "CreateUser": "not_implemented",
+      "DeleteUser": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Users",
+    "operations": [
+      "ListUsers"
+    ],
+    "tested": [],
+    "untested": [
+      "ListUsers"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListUsers": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/resourcegroupstaggingapi.json
+++ b/chunks/resourcegroupstaggingapi.json
@@ -1,0 +1,23 @@
+[
+  {
+    "noun": "ReportCreation",
+    "operations": [
+      "DescribeReportCreation",
+      "StartReportCreation"
+    ],
+    "tested": [
+      "DescribeReportCreation"
+    ],
+    "untested": [
+      "StartReportCreation"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeReportCreation": "working",
+      "StartReportCreation": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/route53.json
+++ b/chunks/route53.json
@@ -1,0 +1,350 @@
+[
+  {
+    "noun": "DNSSEC",
+    "operations": [
+      "GetDNSSEC"
+    ],
+    "tested": [],
+    "untested": [
+      "GetDNSSEC"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetDNSSEC": "working"
+    },
+    "working_untested": [
+      "GetDNSSEC"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "HostedZonesByVPC",
+    "operations": [
+      "ListHostedZonesByVPC"
+    ],
+    "tested": [],
+    "untested": [
+      "ListHostedZonesByVPC"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListHostedZonesByVPC": "working"
+    },
+    "working_untested": [
+      "ListHostedZonesByVPC"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "TestDNSAnswer",
+    "operations": [
+      "TestDNSAnswer"
+    ],
+    "tested": [],
+    "untested": [
+      "TestDNSAnswer"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "TestDNSAnswer": "working"
+    },
+    "working_untested": [
+      "TestDNSAnswer"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "VPCAssociationAuthorizations",
+    "operations": [
+      "ListVPCAssociationAuthorizations"
+    ],
+    "tested": [],
+    "untested": [
+      "ListVPCAssociationAuthorizations"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListVPCAssociationAuthorizations": "working"
+    },
+    "working_untested": [
+      "ListVPCAssociationAuthorizations"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "VPCFromHostedZone",
+    "operations": [
+      "DisassociateVPCFromHostedZone"
+    ],
+    "tested": [],
+    "untested": [
+      "DisassociateVPCFromHostedZone"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DisassociateVPCFromHostedZone": "working"
+    },
+    "working_untested": [
+      "DisassociateVPCFromHostedZone"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "VPCWithHostedZone",
+    "operations": [
+      "AssociateVPCWithHostedZone"
+    ],
+    "tested": [],
+    "untested": [
+      "AssociateVPCWithHostedZone"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "AssociateVPCWithHostedZone": "working"
+    },
+    "working_untested": [
+      "AssociateVPCWithHostedZone"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "ChangeCidrCollection",
+    "operations": [
+      "ChangeCidrCollection"
+    ],
+    "tested": [],
+    "untested": [
+      "ChangeCidrCollection"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ChangeCidrCollection": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "HostedZoneDNSSEC",
+    "operations": [
+      "DisableHostedZoneDNSSEC",
+      "EnableHostedZoneDNSSEC"
+    ],
+    "tested": [],
+    "untested": [
+      "DisableHostedZoneDNSSEC",
+      "EnableHostedZoneDNSSEC"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "DisableHostedZoneDNSSEC": "not_implemented",
+      "EnableHostedZoneDNSSEC": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "HostedZoneFeatures",
+    "operations": [
+      "UpdateHostedZoneFeatures"
+    ],
+    "tested": [],
+    "untested": [
+      "UpdateHostedZoneFeatures"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "UpdateHostedZoneFeatures": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "KeySigningKey",
+    "operations": [
+      "ActivateKeySigningKey",
+      "CreateKeySigningKey",
+      "DeactivateKeySigningKey",
+      "DeleteKeySigningKey"
+    ],
+    "tested": [],
+    "untested": [
+      "ActivateKeySigningKey",
+      "CreateKeySigningKey",
+      "DeactivateKeySigningKey",
+      "DeleteKeySigningKey"
+    ],
+    "size": 4,
+    "untested_count": 4,
+    "probe_status": {
+      "ActivateKeySigningKey": "not_implemented",
+      "CreateKeySigningKey": "not_implemented",
+      "DeactivateKeySigningKey": "not_implemented",
+      "DeleteKeySigningKey": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TrafficPolicy",
+    "operations": [
+      "CreateTrafficPolicy",
+      "DeleteTrafficPolicy",
+      "GetTrafficPolicy"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateTrafficPolicy",
+      "DeleteTrafficPolicy",
+      "GetTrafficPolicy"
+    ],
+    "size": 3,
+    "untested_count": 3,
+    "probe_status": {
+      "CreateTrafficPolicy": "not_implemented",
+      "DeleteTrafficPolicy": "not_implemented",
+      "GetTrafficPolicy": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TrafficPolicyComment",
+    "operations": [
+      "UpdateTrafficPolicyComment"
+    ],
+    "tested": [],
+    "untested": [
+      "UpdateTrafficPolicyComment"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "UpdateTrafficPolicyComment": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TrafficPolicyInstance",
+    "operations": [
+      "CreateTrafficPolicyInstance",
+      "DeleteTrafficPolicyInstance",
+      "GetTrafficPolicyInstance",
+      "UpdateTrafficPolicyInstance"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateTrafficPolicyInstance",
+      "DeleteTrafficPolicyInstance",
+      "GetTrafficPolicyInstance",
+      "UpdateTrafficPolicyInstance"
+    ],
+    "size": 4,
+    "untested_count": 4,
+    "probe_status": {
+      "CreateTrafficPolicyInstance": "not_implemented",
+      "DeleteTrafficPolicyInstance": "not_implemented",
+      "GetTrafficPolicyInstance": "not_implemented",
+      "UpdateTrafficPolicyInstance": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TrafficPolicyInstancesByHostedZone",
+    "operations": [
+      "ListTrafficPolicyInstancesByHostedZone"
+    ],
+    "tested": [],
+    "untested": [
+      "ListTrafficPolicyInstancesByHostedZone"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListTrafficPolicyInstancesByHostedZone": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TrafficPolicyInstancesByPolicy",
+    "operations": [
+      "ListTrafficPolicyInstancesByPolicy"
+    ],
+    "tested": [],
+    "untested": [
+      "ListTrafficPolicyInstancesByPolicy"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListTrafficPolicyInstancesByPolicy": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TrafficPolicyVersion",
+    "operations": [
+      "CreateTrafficPolicyVersion"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateTrafficPolicyVersion"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateTrafficPolicyVersion": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TrafficPolicyVersions",
+    "operations": [
+      "ListTrafficPolicyVersions"
+    ],
+    "tested": [],
+    "untested": [
+      "ListTrafficPolicyVersions"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListTrafficPolicyVersions": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "VPCAssociationAuthorization",
+    "operations": [
+      "CreateVPCAssociationAuthorization",
+      "DeleteVPCAssociationAuthorization"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateVPCAssociationAuthorization",
+      "DeleteVPCAssociationAuthorization"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "CreateVPCAssociationAuthorization": "500_error",
+      "DeleteVPCAssociationAuthorization": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/route53resolver.json
+++ b/chunks/route53resolver.json
@@ -1,0 +1,206 @@
+[
+  {
+    "noun": "FirewallConfig",
+    "operations": [
+      "GetFirewallConfig",
+      "UpdateFirewallConfig"
+    ],
+    "tested": [],
+    "untested": [
+      "GetFirewallConfig",
+      "UpdateFirewallConfig"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "GetFirewallConfig": "not_implemented",
+      "UpdateFirewallConfig": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "FirewallDomains",
+    "operations": [
+      "ImportFirewallDomains",
+      "ListFirewallDomains",
+      "UpdateFirewallDomains"
+    ],
+    "tested": [
+      "ListFirewallDomains",
+      "UpdateFirewallDomains"
+    ],
+    "untested": [
+      "ImportFirewallDomains"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "ImportFirewallDomains": "not_implemented",
+      "ListFirewallDomains": "working",
+      "UpdateFirewallDomains": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "FirewallRuleGroupAssociation",
+    "operations": [
+      "GetFirewallRuleGroupAssociation",
+      "UpdateFirewallRuleGroupAssociation"
+    ],
+    "tested": [
+      "GetFirewallRuleGroupAssociation"
+    ],
+    "untested": [
+      "UpdateFirewallRuleGroupAssociation"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "GetFirewallRuleGroupAssociation": "working",
+      "UpdateFirewallRuleGroupAssociation": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "FirewallRuleGroupPolicy",
+    "operations": [
+      "GetFirewallRuleGroupPolicy",
+      "PutFirewallRuleGroupPolicy"
+    ],
+    "tested": [],
+    "untested": [
+      "GetFirewallRuleGroupPolicy",
+      "PutFirewallRuleGroupPolicy"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "GetFirewallRuleGroupPolicy": "not_implemented",
+      "PutFirewallRuleGroupPolicy": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "OutpostResolver",
+    "operations": [
+      "CreateOutpostResolver",
+      "DeleteOutpostResolver",
+      "GetOutpostResolver",
+      "UpdateOutpostResolver"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateOutpostResolver",
+      "DeleteOutpostResolver",
+      "GetOutpostResolver",
+      "UpdateOutpostResolver"
+    ],
+    "size": 4,
+    "untested_count": 4,
+    "probe_status": {
+      "CreateOutpostResolver": "not_implemented",
+      "DeleteOutpostResolver": "not_implemented",
+      "GetOutpostResolver": "not_implemented",
+      "UpdateOutpostResolver": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ResolverConfig",
+    "operations": [
+      "GetResolverConfig",
+      "UpdateResolverConfig"
+    ],
+    "tested": [],
+    "untested": [
+      "GetResolverConfig",
+      "UpdateResolverConfig"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "GetResolverConfig": "not_implemented",
+      "UpdateResolverConfig": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ResolverQueryLogConfigPolicy",
+    "operations": [
+      "GetResolverQueryLogConfigPolicy",
+      "PutResolverQueryLogConfigPolicy"
+    ],
+    "tested": [],
+    "untested": [
+      "GetResolverQueryLogConfigPolicy",
+      "PutResolverQueryLogConfigPolicy"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "GetResolverQueryLogConfigPolicy": "not_implemented",
+      "PutResolverQueryLogConfigPolicy": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ResolverRule",
+    "operations": [
+      "AssociateResolverRule",
+      "CreateResolverRule",
+      "DeleteResolverRule",
+      "DisassociateResolverRule",
+      "GetResolverRule",
+      "UpdateResolverRule"
+    ],
+    "tested": [
+      "AssociateResolverRule",
+      "CreateResolverRule",
+      "DeleteResolverRule",
+      "DisassociateResolverRule",
+      "GetResolverRule"
+    ],
+    "untested": [
+      "UpdateResolverRule"
+    ],
+    "size": 6,
+    "untested_count": 1,
+    "probe_status": {
+      "AssociateResolverRule": "working",
+      "CreateResolverRule": "500_error",
+      "DeleteResolverRule": "working",
+      "DisassociateResolverRule": "working",
+      "GetResolverRule": "working",
+      "UpdateResolverRule": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ResolverRulePolicy",
+    "operations": [
+      "GetResolverRulePolicy",
+      "PutResolverRulePolicy"
+    ],
+    "tested": [],
+    "untested": [
+      "GetResolverRulePolicy",
+      "PutResolverRulePolicy"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "GetResolverRulePolicy": "not_implemented",
+      "PutResolverRulePolicy": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/s3.json
+++ b/chunks/s3.json
@@ -1,0 +1,19 @@
+[
+  {
+    "noun": "WriteGetObjectResponse",
+    "operations": [
+      "WriteGetObjectResponse"
+    ],
+    "tested": [],
+    "untested": [
+      "WriteGetObjectResponse"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "WriteGetObjectResponse": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/s3control.json
+++ b/chunks/s3control.json
@@ -1,0 +1,234 @@
+[
+  {
+    "noun": "AccessGrantsIdentityCenter",
+    "operations": [
+      "AssociateAccessGrantsIdentityCenter"
+    ],
+    "tested": [],
+    "untested": [
+      "AssociateAccessGrantsIdentityCenter"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "AssociateAccessGrantsIdentityCenter": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "AccessPointConfigurationForObjectLambda",
+    "operations": [
+      "GetAccessPointConfigurationForObjectLambda",
+      "PutAccessPointConfigurationForObjectLambda"
+    ],
+    "tested": [],
+    "untested": [
+      "GetAccessPointConfigurationForObjectLambda",
+      "PutAccessPointConfigurationForObjectLambda"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "GetAccessPointConfigurationForObjectLambda": "not_implemented",
+      "PutAccessPointConfigurationForObjectLambda": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "AccessPointsForDirectoryBuckets",
+    "operations": [
+      "ListAccessPointsForDirectoryBuckets"
+    ],
+    "tested": [],
+    "untested": [
+      "ListAccessPointsForDirectoryBuckets"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListAccessPointsForDirectoryBuckets": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "AccessPointsForObjectLambda",
+    "operations": [
+      "ListAccessPointsForObjectLambda"
+    ],
+    "tested": [],
+    "untested": [
+      "ListAccessPointsForObjectLambda"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListAccessPointsForObjectLambda": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Bucket",
+    "operations": [
+      "CreateBucket",
+      "DeleteBucket",
+      "GetBucket"
+    ],
+    "tested": [
+      "CreateBucket",
+      "DeleteBucket"
+    ],
+    "untested": [
+      "GetBucket"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateBucket": "not_implemented",
+      "DeleteBucket": "unknown",
+      "GetBucket": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "BucketLifecycleConfiguration",
+    "operations": [
+      "DeleteBucketLifecycleConfiguration",
+      "GetBucketLifecycleConfiguration",
+      "PutBucketLifecycleConfiguration"
+    ],
+    "tested": [
+      "DeleteBucketLifecycleConfiguration",
+      "GetBucketLifecycleConfiguration"
+    ],
+    "untested": [
+      "PutBucketLifecycleConfiguration"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "DeleteBucketLifecycleConfiguration": "working",
+      "GetBucketLifecycleConfiguration": "working",
+      "PutBucketLifecycleConfiguration": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "BucketVersioning",
+    "operations": [
+      "GetBucketVersioning",
+      "PutBucketVersioning"
+    ],
+    "tested": [
+      "GetBucketVersioning"
+    ],
+    "untested": [
+      "PutBucketVersioning"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "GetBucketVersioning": "working",
+      "PutBucketVersioning": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "CallerAccessGrants",
+    "operations": [
+      "ListCallerAccessGrants"
+    ],
+    "tested": [],
+    "untested": [
+      "ListCallerAccessGrants"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListCallerAccessGrants": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DataAccess",
+    "operations": [
+      "GetDataAccess"
+    ],
+    "tested": [],
+    "untested": [
+      "GetDataAccess"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetDataAccess": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DissociateAccessGrantsIdentityCenter",
+    "operations": [
+      "DissociateAccessGrantsIdentityCenter"
+    ],
+    "tested": [],
+    "untested": [
+      "DissociateAccessGrantsIdentityCenter"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DissociateAccessGrantsIdentityCenter": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "JobTagging",
+    "operations": [
+      "DeleteJobTagging",
+      "GetJobTagging",
+      "PutJobTagging"
+    ],
+    "tested": [
+      "DeleteJobTagging",
+      "GetJobTagging"
+    ],
+    "untested": [
+      "PutJobTagging"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "DeleteJobTagging": "working",
+      "GetJobTagging": "working",
+      "PutJobTagging": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "RegionalBuckets",
+    "operations": [
+      "ListRegionalBuckets"
+    ],
+    "tested": [],
+    "untested": [
+      "ListRegionalBuckets"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListRegionalBuckets": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/s3tables.json
+++ b/chunks/s3tables.json
@@ -1,0 +1,219 @@
+[
+  {
+    "noun": "TableBucketEncryption",
+    "operations": [
+      "DeleteTableBucketEncryption",
+      "GetTableBucketEncryption",
+      "PutTableBucketEncryption"
+    ],
+    "tested": [
+      "DeleteTableBucketEncryption",
+      "GetTableBucketEncryption"
+    ],
+    "untested": [
+      "PutTableBucketEncryption"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "DeleteTableBucketEncryption": "working",
+      "GetTableBucketEncryption": "working",
+      "PutTableBucketEncryption": "working"
+    },
+    "working_untested": [
+      "PutTableBucketEncryption"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "TableBucketMaintenanceConfiguration",
+    "operations": [
+      "GetTableBucketMaintenanceConfiguration",
+      "PutTableBucketMaintenanceConfiguration"
+    ],
+    "tested": [
+      "GetTableBucketMaintenanceConfiguration"
+    ],
+    "untested": [
+      "PutTableBucketMaintenanceConfiguration"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "GetTableBucketMaintenanceConfiguration": "working",
+      "PutTableBucketMaintenanceConfiguration": "working"
+    },
+    "working_untested": [
+      "PutTableBucketMaintenanceConfiguration"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "TableBucketMetricsConfiguration",
+    "operations": [
+      "DeleteTableBucketMetricsConfiguration",
+      "GetTableBucketMetricsConfiguration",
+      "PutTableBucketMetricsConfiguration"
+    ],
+    "tested": [
+      "DeleteTableBucketMetricsConfiguration",
+      "GetTableBucketMetricsConfiguration"
+    ],
+    "untested": [
+      "PutTableBucketMetricsConfiguration"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "DeleteTableBucketMetricsConfiguration": "working",
+      "GetTableBucketMetricsConfiguration": "working",
+      "PutTableBucketMetricsConfiguration": "working"
+    },
+    "working_untested": [
+      "PutTableBucketMetricsConfiguration"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "TableBucketPolicy",
+    "operations": [
+      "DeleteTableBucketPolicy",
+      "GetTableBucketPolicy",
+      "PutTableBucketPolicy"
+    ],
+    "tested": [
+      "DeleteTableBucketPolicy",
+      "GetTableBucketPolicy"
+    ],
+    "untested": [
+      "PutTableBucketPolicy"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "DeleteTableBucketPolicy": "working",
+      "GetTableBucketPolicy": "working",
+      "PutTableBucketPolicy": "working"
+    },
+    "working_untested": [
+      "PutTableBucketPolicy"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "TableBucketStorageClass",
+    "operations": [
+      "GetTableBucketStorageClass",
+      "PutTableBucketStorageClass"
+    ],
+    "tested": [
+      "GetTableBucketStorageClass"
+    ],
+    "untested": [
+      "PutTableBucketStorageClass"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "GetTableBucketStorageClass": "working",
+      "PutTableBucketStorageClass": "working"
+    },
+    "working_untested": [
+      "PutTableBucketStorageClass"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "Table",
+    "operations": [
+      "CreateTable",
+      "DeleteTable",
+      "GetTable"
+    ],
+    "tested": [
+      "CreateTable",
+      "DeleteTable"
+    ],
+    "untested": [
+      "GetTable"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateTable": "working",
+      "DeleteTable": "unknown",
+      "GetTable": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TableBucketReplication",
+    "operations": [
+      "DeleteTableBucketReplication",
+      "GetTableBucketReplication",
+      "PutTableBucketReplication"
+    ],
+    "tested": [
+      "DeleteTableBucketReplication",
+      "GetTableBucketReplication"
+    ],
+    "untested": [
+      "PutTableBucketReplication"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "DeleteTableBucketReplication": "working",
+      "GetTableBucketReplication": "working",
+      "PutTableBucketReplication": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TableRecordExpirationConfiguration",
+    "operations": [
+      "GetTableRecordExpirationConfiguration",
+      "PutTableRecordExpirationConfiguration"
+    ],
+    "tested": [
+      "GetTableRecordExpirationConfiguration"
+    ],
+    "untested": [
+      "PutTableRecordExpirationConfiguration"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "GetTableRecordExpirationConfiguration": "working",
+      "PutTableRecordExpirationConfiguration": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TableReplication",
+    "operations": [
+      "DeleteTableReplication",
+      "GetTableReplication",
+      "PutTableReplication"
+    ],
+    "tested": [
+      "DeleteTableReplication",
+      "GetTableReplication"
+    ],
+    "untested": [
+      "PutTableReplication"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "DeleteTableReplication": "working",
+      "GetTableReplication": "working",
+      "PutTableReplication": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/s3vectors.json
+++ b/chunks/s3vectors.json
@@ -1,0 +1,83 @@
+[
+  {
+    "noun": "QueryVectors",
+    "operations": [
+      "QueryVectors"
+    ],
+    "tested": [],
+    "untested": [
+      "QueryVectors"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "QueryVectors": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Resource",
+    "operations": [
+      "TagResource",
+      "UntagResource"
+    ],
+    "tested": [],
+    "untested": [
+      "TagResource",
+      "UntagResource"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "TagResource": "not_implemented",
+      "UntagResource": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TagsForResource",
+    "operations": [
+      "ListTagsForResource"
+    ],
+    "tested": [],
+    "untested": [
+      "ListTagsForResource"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListTagsForResource": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Vectors",
+    "operations": [
+      "DeleteVectors",
+      "GetVectors",
+      "ListVectors",
+      "PutVectors"
+    ],
+    "tested": [
+      "ListVectors"
+    ],
+    "untested": [
+      "DeleteVectors",
+      "GetVectors",
+      "PutVectors"
+    ],
+    "size": 4,
+    "untested_count": 3,
+    "probe_status": {
+      "DeleteVectors": "needs_params",
+      "GetVectors": "needs_params",
+      "ListVectors": "working",
+      "PutVectors": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/sagemaker.json
+++ b/chunks/sagemaker.json
@@ -1,0 +1,303 @@
+[
+  {
+    "noun": "AutoMLJob",
+    "operations": [
+      "CreateAutoMLJob",
+      "DescribeAutoMLJob",
+      "StopAutoMLJob"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateAutoMLJob",
+      "DescribeAutoMLJob",
+      "StopAutoMLJob"
+    ],
+    "size": 3,
+    "untested_count": 3,
+    "probe_status": {
+      "CreateAutoMLJob": "needs_params",
+      "DescribeAutoMLJob": "working",
+      "StopAutoMLJob": "working"
+    },
+    "working_untested": [
+      "DescribeAutoMLJob",
+      "StopAutoMLJob"
+    ],
+    "working_untested_count": 2
+  },
+  {
+    "noun": "AutoMLJobV2",
+    "operations": [
+      "CreateAutoMLJobV2",
+      "DescribeAutoMLJobV2"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateAutoMLJobV2",
+      "DescribeAutoMLJobV2"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "CreateAutoMLJobV2": "needs_params",
+      "DescribeAutoMLJobV2": "working"
+    },
+    "working_untested": [
+      "DescribeAutoMLJobV2"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "AutoMLJobs",
+    "operations": [
+      "ListAutoMLJobs"
+    ],
+    "tested": [],
+    "untested": [
+      "ListAutoMLJobs"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListAutoMLJobs": "working"
+    },
+    "working_untested": [
+      "ListAutoMLJobs"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "CandidatesForAutoMLJob",
+    "operations": [
+      "ListCandidatesForAutoMLJob"
+    ],
+    "tested": [],
+    "untested": [
+      "ListCandidatesForAutoMLJob"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListCandidatesForAutoMLJob": "working"
+    },
+    "working_untested": [
+      "ListCandidatesForAutoMLJob"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "Endpoint",
+    "operations": [
+      "CreateEndpoint",
+      "DeleteEndpoint",
+      "DescribeEndpoint",
+      "UpdateEndpoint"
+    ],
+    "tested": [
+      "CreateEndpoint",
+      "DeleteEndpoint",
+      "DescribeEndpoint"
+    ],
+    "untested": [
+      "UpdateEndpoint"
+    ],
+    "size": 4,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateEndpoint": "working",
+      "DeleteEndpoint": "working",
+      "DescribeEndpoint": "working",
+      "UpdateEndpoint": "working"
+    },
+    "working_untested": [
+      "UpdateEndpoint"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "AddClusterNodes",
+    "operations": [
+      "BatchAddClusterNodes"
+    ],
+    "tested": [],
+    "untested": [
+      "BatchAddClusterNodes"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "BatchAddClusterNodes": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Algorithm",
+    "operations": [
+      "CreateAlgorithm",
+      "DeleteAlgorithm",
+      "DescribeAlgorithm"
+    ],
+    "tested": [
+      "DeleteAlgorithm",
+      "DescribeAlgorithm"
+    ],
+    "untested": [
+      "CreateAlgorithm"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateAlgorithm": "needs_params",
+      "DeleteAlgorithm": "working",
+      "DescribeAlgorithm": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DescribeModelPackage",
+    "operations": [
+      "BatchDescribeModelPackage"
+    ],
+    "tested": [],
+    "untested": [
+      "BatchDescribeModelPackage"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "BatchDescribeModelPackage": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "InferenceExperiment",
+    "operations": [
+      "CreateInferenceExperiment",
+      "DeleteInferenceExperiment",
+      "DescribeInferenceExperiment",
+      "StartInferenceExperiment",
+      "StopInferenceExperiment",
+      "UpdateInferenceExperiment"
+    ],
+    "tested": [
+      "DeleteInferenceExperiment",
+      "DescribeInferenceExperiment",
+      "StartInferenceExperiment",
+      "StopInferenceExperiment",
+      "UpdateInferenceExperiment"
+    ],
+    "untested": [
+      "CreateInferenceExperiment"
+    ],
+    "size": 6,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateInferenceExperiment": "needs_params",
+      "DeleteInferenceExperiment": "working",
+      "DescribeInferenceExperiment": "working",
+      "StartInferenceExperiment": "working",
+      "StopInferenceExperiment": "working",
+      "UpdateInferenceExperiment": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "LabelingJob",
+    "operations": [
+      "CreateLabelingJob",
+      "DescribeLabelingJob",
+      "StopLabelingJob"
+    ],
+    "tested": [
+      "DescribeLabelingJob",
+      "StopLabelingJob"
+    ],
+    "untested": [
+      "CreateLabelingJob"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateLabelingJob": "needs_params",
+      "DescribeLabelingJob": "working",
+      "StopLabelingJob": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "PipelineExecution",
+    "operations": [
+      "DescribePipelineExecution",
+      "StartPipelineExecution",
+      "StopPipelineExecution",
+      "UpdatePipelineExecution"
+    ],
+    "tested": [
+      "DescribePipelineExecution",
+      "StartPipelineExecution",
+      "UpdatePipelineExecution"
+    ],
+    "untested": [
+      "StopPipelineExecution"
+    ],
+    "size": 4,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribePipelineExecution": "working",
+      "StartPipelineExecution": "needs_params",
+      "StopPipelineExecution": "needs_params",
+      "UpdatePipelineExecution": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "RetryPipelineExecution",
+    "operations": [
+      "RetryPipelineExecution"
+    ],
+    "tested": [],
+    "untested": [
+      "RetryPipelineExecution"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "RetryPipelineExecution": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Workteam",
+    "operations": [
+      "CreateWorkteam",
+      "DeleteWorkteam",
+      "DescribeWorkteam",
+      "UpdateWorkteam"
+    ],
+    "tested": [
+      "DeleteWorkteam",
+      "DescribeWorkteam",
+      "UpdateWorkteam"
+    ],
+    "untested": [
+      "CreateWorkteam"
+    ],
+    "size": 4,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateWorkteam": "needs_params",
+      "DeleteWorkteam": "working",
+      "DescribeWorkteam": "working",
+      "UpdateWorkteam": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/secretsmanager.json
+++ b/chunks/secretsmanager.json
@@ -1,0 +1,19 @@
+[
+  {
+    "noun": "ReplicationToReplica",
+    "operations": [
+      "StopReplicationToReplica"
+    ],
+    "tested": [],
+    "untested": [
+      "StopReplicationToReplica"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "StopReplicationToReplica": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/securityhub.json
+++ b/chunks/securityhub.json
@@ -1,0 +1,208 @@
+[
+  {
+    "noun": "AutomationRule",
+    "operations": [
+      "CreateAutomationRule"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateAutomationRule"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateAutomationRule": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "AutomationRuleV2",
+    "operations": [
+      "CreateAutomationRuleV2",
+      "DeleteAutomationRuleV2",
+      "GetAutomationRuleV2",
+      "UpdateAutomationRuleV2"
+    ],
+    "tested": [
+      "DeleteAutomationRuleV2",
+      "GetAutomationRuleV2",
+      "UpdateAutomationRuleV2"
+    ],
+    "untested": [
+      "CreateAutomationRuleV2"
+    ],
+    "size": 4,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateAutomationRuleV2": "needs_params",
+      "DeleteAutomationRuleV2": "working",
+      "GetAutomationRuleV2": "working",
+      "UpdateAutomationRuleV2": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ConfigurationPolicy",
+    "operations": [
+      "CreateConfigurationPolicy",
+      "DeleteConfigurationPolicy",
+      "GetConfigurationPolicy",
+      "UpdateConfigurationPolicy"
+    ],
+    "tested": [
+      "DeleteConfigurationPolicy",
+      "GetConfigurationPolicy",
+      "UpdateConfigurationPolicy"
+    ],
+    "untested": [
+      "CreateConfigurationPolicy"
+    ],
+    "size": 4,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateConfigurationPolicy": "needs_params",
+      "DeleteConfigurationPolicy": "working",
+      "GetConfigurationPolicy": "working",
+      "UpdateConfigurationPolicy": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ConfigurationPolicyAssociation",
+    "operations": [
+      "GetConfigurationPolicyAssociation",
+      "StartConfigurationPolicyAssociation"
+    ],
+    "tested": [],
+    "untested": [
+      "GetConfigurationPolicyAssociation",
+      "StartConfigurationPolicyAssociation"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "GetConfigurationPolicyAssociation": "needs_params",
+      "StartConfigurationPolicyAssociation": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ConnectorV2",
+    "operations": [
+      "CreateConnectorV2",
+      "DeleteConnectorV2",
+      "GetConnectorV2",
+      "RegisterConnectorV2",
+      "UpdateConnectorV2"
+    ],
+    "tested": [
+      "DeleteConnectorV2",
+      "GetConnectorV2",
+      "RegisterConnectorV2",
+      "UpdateConnectorV2"
+    ],
+    "untested": [
+      "CreateConnectorV2"
+    ],
+    "size": 5,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateConnectorV2": "needs_params",
+      "DeleteConnectorV2": "working",
+      "GetConnectorV2": "working",
+      "RegisterConnectorV2": "working",
+      "UpdateConnectorV2": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DeleteAutomationRules",
+    "operations": [
+      "BatchDeleteAutomationRules"
+    ],
+    "tested": [],
+    "untested": [
+      "BatchDeleteAutomationRules"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "BatchDeleteAutomationRules": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DisableStandards",
+    "operations": [
+      "BatchDisableStandards"
+    ],
+    "tested": [],
+    "untested": [
+      "BatchDisableStandards"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "BatchDisableStandards": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "EnableStandards",
+    "operations": [
+      "BatchEnableStandards"
+    ],
+    "tested": [],
+    "untested": [
+      "BatchEnableStandards"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "BatchEnableStandards": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "GetAutomationRules",
+    "operations": [
+      "BatchGetAutomationRules"
+    ],
+    "tested": [],
+    "untested": [
+      "BatchGetAutomationRules"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "BatchGetAutomationRules": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "UpdateAutomationRules",
+    "operations": [
+      "BatchUpdateAutomationRules"
+    ],
+    "tested": [],
+    "untested": [
+      "BatchUpdateAutomationRules"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "BatchUpdateAutomationRules": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/servicecatalog.json
+++ b/chunks/servicecatalog.json
@@ -1,0 +1,56 @@
+[
+  {
+    "noun": "AWSOrganizationsAccess",
+    "operations": [
+      "DisableAWSOrganizationsAccess",
+      "EnableAWSOrganizationsAccess"
+    ],
+    "tested": [],
+    "untested": [
+      "DisableAWSOrganizationsAccess",
+      "EnableAWSOrganizationsAccess"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "DisableAWSOrganizationsAccess": "not_implemented",
+      "EnableAWSOrganizationsAccess": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "AWSOrganizationsAccessStatus",
+    "operations": [
+      "GetAWSOrganizationsAccessStatus"
+    ],
+    "tested": [],
+    "untested": [
+      "GetAWSOrganizationsAccessStatus"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetAWSOrganizationsAccessStatus": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SearchProducts",
+    "operations": [
+      "SearchProducts"
+    ],
+    "tested": [],
+    "untested": [
+      "SearchProducts"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "SearchProducts": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/servicediscovery.json
+++ b/chunks/servicediscovery.json
@@ -1,0 +1,25 @@
+[
+  {
+    "noun": "ServiceAttributes",
+    "operations": [
+      "DeleteServiceAttributes",
+      "GetServiceAttributes",
+      "UpdateServiceAttributes"
+    ],
+    "tested": [],
+    "untested": [
+      "DeleteServiceAttributes",
+      "GetServiceAttributes",
+      "UpdateServiceAttributes"
+    ],
+    "size": 3,
+    "untested_count": 3,
+    "probe_status": {
+      "DeleteServiceAttributes": "needs_params",
+      "GetServiceAttributes": "not_implemented",
+      "UpdateServiceAttributes": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/ses.json
+++ b/chunks/ses.json
@@ -1,0 +1,208 @@
+[
+  {
+    "noun": "Bounce",
+    "operations": [
+      "SendBounce"
+    ],
+    "tested": [],
+    "untested": [
+      "SendBounce"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "SendBounce": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ConfigurationSetDeliveryOptions",
+    "operations": [
+      "PutConfigurationSetDeliveryOptions"
+    ],
+    "tested": [],
+    "untested": [
+      "PutConfigurationSetDeliveryOptions"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "PutConfigurationSetDeliveryOptions": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ConfigurationSetEventDestination",
+    "operations": [
+      "CreateConfigurationSetEventDestination",
+      "DeleteConfigurationSetEventDestination",
+      "UpdateConfigurationSetEventDestination"
+    ],
+    "tested": [
+      "CreateConfigurationSetEventDestination"
+    ],
+    "untested": [
+      "DeleteConfigurationSetEventDestination",
+      "UpdateConfigurationSetEventDestination"
+    ],
+    "size": 3,
+    "untested_count": 2,
+    "probe_status": {
+      "CreateConfigurationSetEventDestination": "working",
+      "DeleteConfigurationSetEventDestination": "not_implemented",
+      "UpdateConfigurationSetEventDestination": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ConfigurationSetSendingEnabled",
+    "operations": [
+      "UpdateConfigurationSetSendingEnabled"
+    ],
+    "tested": [],
+    "untested": [
+      "UpdateConfigurationSetSendingEnabled"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "UpdateConfigurationSetSendingEnabled": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ConfigurationSetTrackingOptions",
+    "operations": [
+      "CreateConfigurationSetTrackingOptions",
+      "DeleteConfigurationSetTrackingOptions",
+      "UpdateConfigurationSetTrackingOptions"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateConfigurationSetTrackingOptions",
+      "DeleteConfigurationSetTrackingOptions",
+      "UpdateConfigurationSetTrackingOptions"
+    ],
+    "size": 3,
+    "untested_count": 3,
+    "probe_status": {
+      "CreateConfigurationSetTrackingOptions": "not_implemented",
+      "DeleteConfigurationSetTrackingOptions": "not_implemented",
+      "UpdateConfigurationSetTrackingOptions": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "IdentityHeadersInNotificationsEnabled",
+    "operations": [
+      "SetIdentityHeadersInNotificationsEnabled"
+    ],
+    "tested": [],
+    "untested": [
+      "SetIdentityHeadersInNotificationsEnabled"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "SetIdentityHeadersInNotificationsEnabled": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "IdentityPolicies",
+    "operations": [
+      "GetIdentityPolicies",
+      "ListIdentityPolicies"
+    ],
+    "tested": [],
+    "untested": [
+      "GetIdentityPolicies",
+      "ListIdentityPolicies"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "GetIdentityPolicies": "not_implemented",
+      "ListIdentityPolicies": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "IdentityPolicy",
+    "operations": [
+      "DeleteIdentityPolicy",
+      "PutIdentityPolicy"
+    ],
+    "tested": [],
+    "untested": [
+      "DeleteIdentityPolicy",
+      "PutIdentityPolicy"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "DeleteIdentityPolicy": "not_implemented",
+      "PutIdentityPolicy": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ReceiptRulePosition",
+    "operations": [
+      "SetReceiptRulePosition"
+    ],
+    "tested": [],
+    "untested": [
+      "SetReceiptRulePosition"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "SetReceiptRulePosition": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ReorderReceiptRuleSet",
+    "operations": [
+      "ReorderReceiptRuleSet"
+    ],
+    "tested": [],
+    "untested": [
+      "ReorderReceiptRuleSet"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ReorderReceiptRuleSet": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "VerifiedEmailAddress",
+    "operations": [
+      "DeleteVerifiedEmailAddress"
+    ],
+    "tested": [],
+    "untested": [
+      "DeleteVerifiedEmailAddress"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DeleteVerifiedEmailAddress": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/sesv2.json
+++ b/chunks/sesv2.json
@@ -1,0 +1,36 @@
+[
+  {
+    "noun": "GetMetricData",
+    "operations": [
+      "BatchGetMetricData"
+    ],
+    "tested": [],
+    "untested": [
+      "BatchGetMetricData"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "BatchGetMetricData": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "MessageInsights",
+    "operations": [
+      "GetMessageInsights"
+    ],
+    "tested": [],
+    "untested": [
+      "GetMessageInsights"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetMessageInsights": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/shield.json
+++ b/chunks/shield.json
@@ -1,0 +1,87 @@
+[
+  {
+    "noun": "DRTLogBucket",
+    "operations": [
+      "AssociateDRTLogBucket",
+      "DisassociateDRTLogBucket"
+    ],
+    "tested": [],
+    "untested": [
+      "AssociateDRTLogBucket",
+      "DisassociateDRTLogBucket"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "AssociateDRTLogBucket": "working",
+      "DisassociateDRTLogBucket": "working"
+    },
+    "working_untested": [
+      "AssociateDRTLogBucket",
+      "DisassociateDRTLogBucket"
+    ],
+    "working_untested_count": 2
+  },
+  {
+    "noun": "DRTRole",
+    "operations": [
+      "AssociateDRTRole",
+      "DisassociateDRTRole"
+    ],
+    "tested": [],
+    "untested": [
+      "AssociateDRTRole",
+      "DisassociateDRTRole"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "AssociateDRTRole": "working",
+      "DisassociateDRTRole": "working"
+    },
+    "working_untested": [
+      "AssociateDRTRole",
+      "DisassociateDRTRole"
+    ],
+    "working_untested_count": 2
+  },
+  {
+    "noun": "DRTAccess",
+    "operations": [
+      "DescribeDRTAccess"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeDRTAccess"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeDRTAccess": "working"
+    },
+    "working_untested": [
+      "DescribeDRTAccess"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "HealthCheck",
+    "operations": [
+      "AssociateHealthCheck",
+      "DisassociateHealthCheck"
+    ],
+    "tested": [],
+    "untested": [
+      "AssociateHealthCheck",
+      "DisassociateHealthCheck"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "AssociateHealthCheck": "needs_params",
+      "DisassociateHealthCheck": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/signer.json
+++ b/chunks/signer.json
@@ -1,0 +1,19 @@
+[
+  {
+    "noun": "RevocationStatus",
+    "operations": [
+      "GetRevocationStatus"
+    ],
+    "tested": [],
+    "untested": [
+      "GetRevocationStatus"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetRevocationStatus": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/sns.json
+++ b/chunks/sns.json
@@ -1,0 +1,106 @@
+[
+  {
+    "noun": "SMSAttributes",
+    "operations": [
+      "GetSMSAttributes",
+      "SetSMSAttributes"
+    ],
+    "tested": [],
+    "untested": [
+      "GetSMSAttributes",
+      "SetSMSAttributes"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "GetSMSAttributes": "working",
+      "SetSMSAttributes": "working"
+    },
+    "working_untested": [
+      "GetSMSAttributes",
+      "SetSMSAttributes"
+    ],
+    "working_untested_count": 2
+  },
+  {
+    "noun": "SMSSandboxAccountStatus",
+    "operations": [
+      "GetSMSSandboxAccountStatus"
+    ],
+    "tested": [],
+    "untested": [
+      "GetSMSSandboxAccountStatus"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetSMSSandboxAccountStatus": "working"
+    },
+    "working_untested": [
+      "GetSMSSandboxAccountStatus"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "SMSSandboxPhoneNumbers",
+    "operations": [
+      "ListSMSSandboxPhoneNumbers"
+    ],
+    "tested": [],
+    "untested": [
+      "ListSMSSandboxPhoneNumbers"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListSMSSandboxPhoneNumbers": "working"
+    },
+    "working_untested": [
+      "ListSMSSandboxPhoneNumbers"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "DataProtectionPolicy",
+    "operations": [
+      "GetDataProtectionPolicy",
+      "PutDataProtectionPolicy"
+    ],
+    "tested": [],
+    "untested": [
+      "GetDataProtectionPolicy",
+      "PutDataProtectionPolicy"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "GetDataProtectionPolicy": "not_implemented",
+      "PutDataProtectionPolicy": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SMSSandboxPhoneNumber",
+    "operations": [
+      "CreateSMSSandboxPhoneNumber",
+      "DeleteSMSSandboxPhoneNumber",
+      "VerifySMSSandboxPhoneNumber"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateSMSSandboxPhoneNumber",
+      "DeleteSMSSandboxPhoneNumber",
+      "VerifySMSSandboxPhoneNumber"
+    ],
+    "size": 3,
+    "untested_count": 3,
+    "probe_status": {
+      "CreateSMSSandboxPhoneNumber": "not_implemented",
+      "DeleteSMSSandboxPhoneNumber": "not_implemented",
+      "VerifySMSSandboxPhoneNumber": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/ssm.json
+++ b/chunks/ssm.json
@@ -1,0 +1,169 @@
+[
+  {
+    "noun": "AssociationBatch",
+    "operations": [
+      "CreateAssociationBatch"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateAssociationBatch"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateAssociationBatch": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "DefaultPatchBaseline",
+    "operations": [
+      "GetDefaultPatchBaseline",
+      "RegisterDefaultPatchBaseline"
+    ],
+    "tested": [
+      "GetDefaultPatchBaseline"
+    ],
+    "untested": [
+      "RegisterDefaultPatchBaseline"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "GetDefaultPatchBaseline": "working",
+      "RegisterDefaultPatchBaseline": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "EffectivePatchesForPatchBaseline",
+    "operations": [
+      "DescribeEffectivePatchesForPatchBaseline"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeEffectivePatchesForPatchBaseline"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeEffectivePatchesForPatchBaseline": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Inventory",
+    "operations": [
+      "DeleteInventory",
+      "GetInventory",
+      "PutInventory"
+    ],
+    "tested": [
+      "DeleteInventory",
+      "GetInventory"
+    ],
+    "untested": [
+      "PutInventory"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "DeleteInventory": "working",
+      "GetInventory": "working",
+      "PutInventory": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "MaintenanceWindow",
+    "operations": [
+      "CreateMaintenanceWindow",
+      "DeleteMaintenanceWindow",
+      "GetMaintenanceWindow",
+      "UpdateMaintenanceWindow"
+    ],
+    "tested": [
+      "CreateMaintenanceWindow",
+      "DeleteMaintenanceWindow",
+      "GetMaintenanceWindow"
+    ],
+    "untested": [
+      "UpdateMaintenanceWindow"
+    ],
+    "size": 4,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateMaintenanceWindow": "working",
+      "DeleteMaintenanceWindow": "needs_params",
+      "GetMaintenanceWindow": "needs_params",
+      "UpdateMaintenanceWindow": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "MaintenanceWindowExecutions",
+    "operations": [
+      "DescribeMaintenanceWindowExecutions"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeMaintenanceWindowExecutions"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeMaintenanceWindowExecutions": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "NodesSummary",
+    "operations": [
+      "ListNodesSummary"
+    ],
+    "tested": [],
+    "untested": [
+      "ListNodesSummary"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListNodesSummary": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "PatchBaseline",
+    "operations": [
+      "CreatePatchBaseline",
+      "DeletePatchBaseline",
+      "GetPatchBaseline",
+      "UpdatePatchBaseline"
+    ],
+    "tested": [
+      "CreatePatchBaseline",
+      "DeletePatchBaseline",
+      "GetPatchBaseline"
+    ],
+    "untested": [
+      "UpdatePatchBaseline"
+    ],
+    "size": 4,
+    "untested_count": 1,
+    "probe_status": {
+      "CreatePatchBaseline": "working",
+      "DeletePatchBaseline": "needs_params",
+      "GetPatchBaseline": "needs_params",
+      "UpdatePatchBaseline": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/stepfunctions.json
+++ b/chunks/stepfunctions.json
@@ -1,0 +1,113 @@
+[
+  {
+    "noun": "ActivityTask",
+    "operations": [
+      "GetActivityTask"
+    ],
+    "tested": [],
+    "untested": [
+      "GetActivityTask"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetActivityTask": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "RedriveExecution",
+    "operations": [
+      "RedriveExecution"
+    ],
+    "tested": [],
+    "untested": [
+      "RedriveExecution"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "RedriveExecution": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "StateMachineAlias",
+    "operations": [
+      "CreateStateMachineAlias",
+      "DeleteStateMachineAlias",
+      "DescribeStateMachineAlias",
+      "UpdateStateMachineAlias"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateStateMachineAlias",
+      "DeleteStateMachineAlias",
+      "DescribeStateMachineAlias",
+      "UpdateStateMachineAlias"
+    ],
+    "size": 4,
+    "untested_count": 4,
+    "probe_status": {
+      "CreateStateMachineAlias": "needs_params",
+      "DeleteStateMachineAlias": "not_implemented",
+      "DescribeStateMachineAlias": "not_implemented",
+      "UpdateStateMachineAlias": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "StateMachineAliases",
+    "operations": [
+      "ListStateMachineAliases"
+    ],
+    "tested": [],
+    "untested": [
+      "ListStateMachineAliases"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListStateMachineAliases": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SyncExecution",
+    "operations": [
+      "StartSyncExecution"
+    ],
+    "tested": [],
+    "untested": [
+      "StartSyncExecution"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "StartSyncExecution": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TestState",
+    "operations": [
+      "TestState"
+    ],
+    "tested": [],
+    "untested": [
+      "TestState"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "TestState": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/sts.json
+++ b/chunks/sts.json
@@ -1,0 +1,38 @@
+[
+  {
+    "noun": "AssumeRoleWithSAML",
+    "operations": [
+      "AssumeRoleWithSAML"
+    ],
+    "tested": [],
+    "untested": [
+      "AssumeRoleWithSAML"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "AssumeRoleWithSAML": "working"
+    },
+    "working_untested": [
+      "AssumeRoleWithSAML"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "WebIdentityToken",
+    "operations": [
+      "GetWebIdentityToken"
+    ],
+    "tested": [],
+    "untested": [
+      "GetWebIdentityToken"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetWebIdentityToken": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/support.json
+++ b/chunks/support.json
@@ -1,0 +1,21 @@
+[
+  {
+    "noun": "Attachment",
+    "operations": [
+      "DescribeAttachment"
+    ],
+    "tested": [],
+    "untested": [
+      "DescribeAttachment"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeAttachment": "working"
+    },
+    "working_untested": [
+      "DescribeAttachment"
+    ],
+    "working_untested_count": 1
+  }
+]

--- a/chunks/synthetics.json
+++ b/chunks/synthetics.json
@@ -1,0 +1,19 @@
+[
+  {
+    "noun": "AssociatedGroups",
+    "operations": [
+      "ListAssociatedGroups"
+    ],
+    "tested": [],
+    "untested": [
+      "ListAssociatedGroups"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListAssociatedGroups": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/textract.json
+++ b/chunks/textract.json
@@ -1,0 +1,230 @@
+[
+  {
+    "noun": "Adapter",
+    "operations": [
+      "CreateAdapter",
+      "DeleteAdapter",
+      "GetAdapter",
+      "UpdateAdapter"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateAdapter",
+      "DeleteAdapter",
+      "GetAdapter",
+      "UpdateAdapter"
+    ],
+    "size": 4,
+    "untested_count": 4,
+    "probe_status": {
+      "CreateAdapter": "not_implemented",
+      "DeleteAdapter": "not_implemented",
+      "GetAdapter": "not_implemented",
+      "UpdateAdapter": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "AdapterVersion",
+    "operations": [
+      "CreateAdapterVersion",
+      "DeleteAdapterVersion",
+      "GetAdapterVersion"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateAdapterVersion",
+      "DeleteAdapterVersion",
+      "GetAdapterVersion"
+    ],
+    "size": 3,
+    "untested_count": 3,
+    "probe_status": {
+      "CreateAdapterVersion": "not_implemented",
+      "DeleteAdapterVersion": "not_implemented",
+      "GetAdapterVersion": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "AdapterVersions",
+    "operations": [
+      "ListAdapterVersions"
+    ],
+    "tested": [],
+    "untested": [
+      "ListAdapterVersions"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListAdapterVersions": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Adapters",
+    "operations": [
+      "ListAdapters"
+    ],
+    "tested": [],
+    "untested": [
+      "ListAdapters"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListAdapters": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "AnalyzeDocument",
+    "operations": [
+      "AnalyzeDocument"
+    ],
+    "tested": [],
+    "untested": [
+      "AnalyzeDocument"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "AnalyzeDocument": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "AnalyzeExpense",
+    "operations": [
+      "AnalyzeExpense"
+    ],
+    "tested": [],
+    "untested": [
+      "AnalyzeExpense"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "AnalyzeExpense": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "AnalyzeID",
+    "operations": [
+      "AnalyzeID"
+    ],
+    "tested": [],
+    "untested": [
+      "AnalyzeID"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "AnalyzeID": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ExpenseAnalysis",
+    "operations": [
+      "GetExpenseAnalysis",
+      "StartExpenseAnalysis"
+    ],
+    "tested": [],
+    "untested": [
+      "GetExpenseAnalysis",
+      "StartExpenseAnalysis"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "GetExpenseAnalysis": "not_implemented",
+      "StartExpenseAnalysis": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "LendingAnalysis",
+    "operations": [
+      "GetLendingAnalysis",
+      "StartLendingAnalysis"
+    ],
+    "tested": [],
+    "untested": [
+      "GetLendingAnalysis",
+      "StartLendingAnalysis"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "GetLendingAnalysis": "not_implemented",
+      "StartLendingAnalysis": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "LendingAnalysisSummary",
+    "operations": [
+      "GetLendingAnalysisSummary"
+    ],
+    "tested": [],
+    "untested": [
+      "GetLendingAnalysisSummary"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetLendingAnalysisSummary": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Resource",
+    "operations": [
+      "TagResource",
+      "UntagResource"
+    ],
+    "tested": [],
+    "untested": [
+      "TagResource",
+      "UntagResource"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "TagResource": "not_implemented",
+      "UntagResource": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TagsForResource",
+    "operations": [
+      "ListTagsForResource"
+    ],
+    "tested": [],
+    "untested": [
+      "ListTagsForResource"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListTagsForResource": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/transcribe.json
+++ b/chunks/transcribe.json
@@ -1,0 +1,165 @@
+[
+  {
+    "noun": "CallAnalyticsCategory",
+    "operations": [
+      "CreateCallAnalyticsCategory",
+      "DeleteCallAnalyticsCategory",
+      "GetCallAnalyticsCategory",
+      "UpdateCallAnalyticsCategory"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateCallAnalyticsCategory",
+      "DeleteCallAnalyticsCategory",
+      "GetCallAnalyticsCategory",
+      "UpdateCallAnalyticsCategory"
+    ],
+    "size": 4,
+    "untested_count": 4,
+    "probe_status": {
+      "CreateCallAnalyticsCategory": "needs_params",
+      "DeleteCallAnalyticsCategory": "not_implemented",
+      "GetCallAnalyticsCategory": "not_implemented",
+      "UpdateCallAnalyticsCategory": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "CallAnalyticsJob",
+    "operations": [
+      "DeleteCallAnalyticsJob",
+      "GetCallAnalyticsJob",
+      "StartCallAnalyticsJob"
+    ],
+    "tested": [],
+    "untested": [
+      "DeleteCallAnalyticsJob",
+      "GetCallAnalyticsJob",
+      "StartCallAnalyticsJob"
+    ],
+    "size": 3,
+    "untested_count": 3,
+    "probe_status": {
+      "DeleteCallAnalyticsJob": "not_implemented",
+      "GetCallAnalyticsJob": "not_implemented",
+      "StartCallAnalyticsJob": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "MedicalScribeJob",
+    "operations": [
+      "DeleteMedicalScribeJob",
+      "GetMedicalScribeJob",
+      "StartMedicalScribeJob"
+    ],
+    "tested": [],
+    "untested": [
+      "DeleteMedicalScribeJob",
+      "GetMedicalScribeJob",
+      "StartMedicalScribeJob"
+    ],
+    "size": 3,
+    "untested_count": 3,
+    "probe_status": {
+      "DeleteMedicalScribeJob": "not_implemented",
+      "GetMedicalScribeJob": "not_implemented",
+      "StartMedicalScribeJob": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "MedicalVocabulary",
+    "operations": [
+      "CreateMedicalVocabulary",
+      "DeleteMedicalVocabulary",
+      "GetMedicalVocabulary",
+      "UpdateMedicalVocabulary"
+    ],
+    "tested": [
+      "CreateMedicalVocabulary",
+      "DeleteMedicalVocabulary",
+      "GetMedicalVocabulary"
+    ],
+    "untested": [
+      "UpdateMedicalVocabulary"
+    ],
+    "size": 4,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateMedicalVocabulary": "working",
+      "DeleteMedicalVocabulary": "working",
+      "GetMedicalVocabulary": "working",
+      "UpdateMedicalVocabulary": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Resource",
+    "operations": [
+      "TagResource",
+      "UntagResource"
+    ],
+    "tested": [],
+    "untested": [
+      "TagResource",
+      "UntagResource"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "TagResource": "needs_params",
+      "UntagResource": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TagsForResource",
+    "operations": [
+      "ListTagsForResource"
+    ],
+    "tested": [],
+    "untested": [
+      "ListTagsForResource"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListTagsForResource": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Vocabulary",
+    "operations": [
+      "CreateVocabulary",
+      "DeleteVocabulary",
+      "GetVocabulary",
+      "UpdateVocabulary"
+    ],
+    "tested": [
+      "CreateVocabulary",
+      "DeleteVocabulary",
+      "GetVocabulary"
+    ],
+    "untested": [
+      "UpdateVocabulary"
+    ],
+    "size": 4,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateVocabulary": "working",
+      "DeleteVocabulary": "working",
+      "GetVocabulary": "working",
+      "UpdateVocabulary": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/wafv2.json
+++ b/chunks/wafv2.json
@@ -1,0 +1,223 @@
+[
+  {
+    "noun": "WebACL",
+    "operations": [
+      "AssociateWebACL",
+      "CreateWebACL",
+      "DeleteWebACL",
+      "DisassociateWebACL",
+      "GetWebACL",
+      "UpdateWebACL"
+    ],
+    "tested": [],
+    "untested": [
+      "AssociateWebACL",
+      "CreateWebACL",
+      "DeleteWebACL",
+      "DisassociateWebACL",
+      "GetWebACL",
+      "UpdateWebACL"
+    ],
+    "size": 6,
+    "untested_count": 6,
+    "probe_status": {
+      "AssociateWebACL": "working",
+      "CreateWebACL": "working",
+      "DeleteWebACL": "working",
+      "DisassociateWebACL": "working",
+      "GetWebACL": "working",
+      "UpdateWebACL": "working"
+    },
+    "working_untested": [
+      "AssociateWebACL",
+      "CreateWebACL",
+      "DeleteWebACL",
+      "DisassociateWebACL",
+      "GetWebACL",
+      "UpdateWebACL"
+    ],
+    "working_untested_count": 6
+  },
+  {
+    "noun": "IPSet",
+    "operations": [
+      "CreateIPSet",
+      "DeleteIPSet",
+      "GetIPSet",
+      "UpdateIPSet"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateIPSet",
+      "DeleteIPSet",
+      "GetIPSet",
+      "UpdateIPSet"
+    ],
+    "size": 4,
+    "untested_count": 4,
+    "probe_status": {
+      "CreateIPSet": "working",
+      "DeleteIPSet": "working",
+      "GetIPSet": "working",
+      "UpdateIPSet": "working"
+    },
+    "working_untested": [
+      "CreateIPSet",
+      "DeleteIPSet",
+      "GetIPSet",
+      "UpdateIPSet"
+    ],
+    "working_untested_count": 4
+  },
+  {
+    "noun": "APIKey",
+    "operations": [
+      "CreateAPIKey",
+      "DeleteAPIKey"
+    ],
+    "tested": [],
+    "untested": [
+      "CreateAPIKey",
+      "DeleteAPIKey"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "CreateAPIKey": "needs_params",
+      "DeleteAPIKey": "working"
+    },
+    "working_untested": [
+      "DeleteAPIKey"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "APIKeys",
+    "operations": [
+      "ListAPIKeys"
+    ],
+    "tested": [],
+    "untested": [
+      "ListAPIKeys"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListAPIKeys": "working"
+    },
+    "working_untested": [
+      "ListAPIKeys"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "DecryptedAPIKey",
+    "operations": [
+      "GetDecryptedAPIKey"
+    ],
+    "tested": [],
+    "untested": [
+      "GetDecryptedAPIKey"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetDecryptedAPIKey": "working"
+    },
+    "working_untested": [
+      "GetDecryptedAPIKey"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "IPSets",
+    "operations": [
+      "ListIPSets"
+    ],
+    "tested": [],
+    "untested": [
+      "ListIPSets"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListIPSets": "working"
+    },
+    "working_untested": [
+      "ListIPSets"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "ResourcesForWebACL",
+    "operations": [
+      "ListResourcesForWebACL"
+    ],
+    "tested": [],
+    "untested": [
+      "ListResourcesForWebACL"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListResourcesForWebACL": "working"
+    },
+    "working_untested": [
+      "ListResourcesForWebACL"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "WebACLForResource",
+    "operations": [
+      "GetWebACLForResource"
+    ],
+    "tested": [],
+    "untested": [
+      "GetWebACLForResource"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetWebACLForResource": "working"
+    },
+    "working_untested": [
+      "GetWebACLForResource"
+    ],
+    "working_untested_count": 1
+  },
+  {
+    "noun": "TopPathStatisticsByTraffic",
+    "operations": [
+      "GetTopPathStatisticsByTraffic"
+    ],
+    "tested": [],
+    "untested": [
+      "GetTopPathStatisticsByTraffic"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "GetTopPathStatisticsByTraffic": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "WebACLs",
+    "operations": [
+      "ListWebACLs"
+    ],
+    "tested": [],
+    "untested": [
+      "ListWebACLs"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ListWebACLs": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/workspaces.json
+++ b/chunks/workspaces.json
@@ -1,0 +1,189 @@
+[
+  {
+    "noun": "ClientBranding",
+    "operations": [
+      "DeleteClientBranding",
+      "DescribeClientBranding",
+      "ImportClientBranding"
+    ],
+    "tested": [
+      "DescribeClientBranding",
+      "ImportClientBranding"
+    ],
+    "untested": [
+      "DeleteClientBranding"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "DeleteClientBranding": "needs_params",
+      "DescribeClientBranding": "working",
+      "ImportClientBranding": "working"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ClientProperties",
+    "operations": [
+      "DescribeClientProperties",
+      "ModifyClientProperties"
+    ],
+    "tested": [
+      "DescribeClientProperties"
+    ],
+    "untested": [
+      "ModifyClientProperties"
+    ],
+    "size": 2,
+    "untested_count": 1,
+    "probe_status": {
+      "DescribeClientProperties": "needs_params",
+      "ModifyClientProperties": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "ConnectClientAddIn",
+    "operations": [
+      "CreateConnectClientAddIn",
+      "DeleteConnectClientAddIn",
+      "UpdateConnectClientAddIn"
+    ],
+    "tested": [
+      "CreateConnectClientAddIn"
+    ],
+    "untested": [
+      "DeleteConnectClientAddIn",
+      "UpdateConnectClientAddIn"
+    ],
+    "size": 3,
+    "untested_count": 2,
+    "probe_status": {
+      "CreateConnectClientAddIn": "working",
+      "DeleteConnectClientAddIn": "needs_params",
+      "UpdateConnectClientAddIn": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "CustomWorkspaceImage",
+    "operations": [
+      "ImportCustomWorkspaceImage"
+    ],
+    "tested": [],
+    "untested": [
+      "ImportCustomWorkspaceImage"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ImportCustomWorkspaceImage": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "RebuildWorkspaces",
+    "operations": [
+      "RebuildWorkspaces"
+    ],
+    "tested": [],
+    "untested": [
+      "RebuildWorkspaces"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "RebuildWorkspaces": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SelfservicePermissions",
+    "operations": [
+      "ModifySelfservicePermissions"
+    ],
+    "tested": [],
+    "untested": [
+      "ModifySelfservicePermissions"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "ModifySelfservicePermissions": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "WorkspaceImagePermission",
+    "operations": [
+      "UpdateWorkspaceImagePermission"
+    ],
+    "tested": [],
+    "untested": [
+      "UpdateWorkspaceImagePermission"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "UpdateWorkspaceImagePermission": "500_error"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "Workspaces",
+    "operations": [
+      "CreateWorkspaces",
+      "DescribeWorkspaces",
+      "RebootWorkspaces",
+      "StartWorkspaces",
+      "StopWorkspaces",
+      "TerminateWorkspaces"
+    ],
+    "tested": [
+      "CreateWorkspaces",
+      "DescribeWorkspaces",
+      "TerminateWorkspaces"
+    ],
+    "untested": [
+      "RebootWorkspaces",
+      "StartWorkspaces",
+      "StopWorkspaces"
+    ],
+    "size": 6,
+    "untested_count": 3,
+    "probe_status": {
+      "CreateWorkspaces": "needs_params",
+      "DescribeWorkspaces": "working",
+      "RebootWorkspaces": "needs_params",
+      "StartWorkspaces": "needs_params",
+      "StopWorkspaces": "needs_params",
+      "TerminateWorkspaces": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "WorkspacesPoolSession",
+    "operations": [
+      "TerminateWorkspacesPoolSession"
+    ],
+    "tested": [],
+    "untested": [
+      "TerminateWorkspacesPoolSession"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "TerminateWorkspacesPoolSession": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/chunks/xray.json
+++ b/chunks/xray.json
@@ -1,0 +1,90 @@
+[
+  {
+    "noun": "Group",
+    "operations": [
+      "CreateGroup",
+      "DeleteGroup",
+      "GetGroup",
+      "UpdateGroup"
+    ],
+    "tested": [
+      "CreateGroup",
+      "DeleteGroup",
+      "GetGroup"
+    ],
+    "untested": [
+      "UpdateGroup"
+    ],
+    "size": 4,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateGroup": "working",
+      "DeleteGroup": "working",
+      "GetGroup": "working",
+      "UpdateGroup": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "IndexingRule",
+    "operations": [
+      "UpdateIndexingRule"
+    ],
+    "tested": [],
+    "untested": [
+      "UpdateIndexingRule"
+    ],
+    "size": 1,
+    "untested_count": 1,
+    "probe_status": {
+      "UpdateIndexingRule": "needs_params"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "SamplingRule",
+    "operations": [
+      "CreateSamplingRule",
+      "DeleteSamplingRule",
+      "UpdateSamplingRule"
+    ],
+    "tested": [
+      "CreateSamplingRule",
+      "DeleteSamplingRule"
+    ],
+    "untested": [
+      "UpdateSamplingRule"
+    ],
+    "size": 3,
+    "untested_count": 1,
+    "probe_status": {
+      "CreateSamplingRule": "needs_params",
+      "DeleteSamplingRule": "working",
+      "UpdateSamplingRule": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  },
+  {
+    "noun": "TraceSegmentDestination",
+    "operations": [
+      "GetTraceSegmentDestination",
+      "UpdateTraceSegmentDestination"
+    ],
+    "tested": [],
+    "untested": [
+      "GetTraceSegmentDestination",
+      "UpdateTraceSegmentDestination"
+    ],
+    "size": 2,
+    "untested_count": 2,
+    "probe_status": {
+      "GetTraceSegmentDestination": "not_implemented",
+      "UpdateTraceSegmentDestination": "not_implemented"
+    },
+    "working_untested": [],
+    "working_untested_count": 0
+  }
+]

--- a/probes/account.json
+++ b/probes/account.json
@@ -1,0 +1,86 @@
+{
+  "service": "account",
+  "counts": {
+    "working": 3,
+    "needs_params": 0,
+    "not_implemented": 12,
+    "500_error": 0
+  },
+  "operations": [
+    {
+      "operation": "AcceptPrimaryEmailUpdate",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteAlternateContact",
+      "status": "working",
+      "message": "implemented (AccessDeniedException)"
+    },
+    {
+      "operation": "DisableRegion",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "EnableRegion",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetAccountInformation",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetAlternateContact",
+      "status": "working",
+      "message": "implemented (AccessDeniedException)"
+    },
+    {
+      "operation": "GetContactInformation",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetGovCloudAccountInformation",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetPrimaryEmail",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetRegionOptStatus",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListRegions",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "PutAccountName",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "PutAlternateContact",
+      "status": "working",
+      "message": "implemented (AccessDeniedException)"
+    },
+    {
+      "operation": "PutContactInformation",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StartPrimaryEmailUpdate",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    }
+  ]
+}

--- a/probes/acm.json
+++ b/probes/acm.json
@@ -1,0 +1,91 @@
+{
+  "service": "acm",
+  "counts": {
+    "working": 12,
+    "needs_params": 2,
+    "not_implemented": 2,
+    "500_error": 0
+  },
+  "operations": [
+    {
+      "operation": "AddTagsToCertificate",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DeleteCertificate",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeCertificate",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ExportCertificate",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetAccountConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetCertificate",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ImportCertificate",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "ListCertificates",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTagsForCertificate",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "PutAccountConfiguration",
+      "status": "working",
+      "message": "implemented (MissingParameter)"
+    },
+    {
+      "operation": "RemoveTagsFromCertificate",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "RenewCertificate",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "RequestCertificate",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ResendValidationEmail",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "RevokeCertificate",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateCertificateOptions",
+      "status": "working",
+      "message": "OK"
+    }
+  ]
+}

--- a/probes/amp.json
+++ b/probes/amp.json
@@ -1,0 +1,231 @@
+{
+  "service": "amp",
+  "counts": {
+    "working": 37,
+    "needs_params": 6,
+    "not_implemented": 0,
+    "500_error": 1
+  },
+  "operations": [
+    {
+      "operation": "CreateAlertManagerDefinition",
+      "status": "working",
+      "message": "likely implemented (404: Workspace not found)"
+    },
+    {
+      "operation": "CreateAnomalyDetector",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateLoggingConfiguration",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "CreateQueryLoggingConfiguration",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateRuleGroupsNamespace",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "CreateScraper",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateWorkspace",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteAlertManagerDefinition",
+      "status": "working",
+      "message": "likely implemented (404: Workspace not found)"
+    },
+    {
+      "operation": "DeleteAnomalyDetector",
+      "status": "working",
+      "message": "likely implemented (404: Workspace not found)"
+    },
+    {
+      "operation": "DeleteLoggingConfiguration",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteQueryLoggingConfiguration",
+      "status": "working",
+      "message": "likely implemented (404: Workspace not found)"
+    },
+    {
+      "operation": "DeleteResourcePolicy",
+      "status": "working",
+      "message": "likely implemented (404: Workspace not found)"
+    },
+    {
+      "operation": "DeleteRuleGroupsNamespace",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteScraper",
+      "status": "working",
+      "message": "likely implemented (404: Scraper not found)"
+    },
+    {
+      "operation": "DeleteScraperLoggingConfiguration",
+      "status": "working",
+      "message": "likely implemented (404: Scraper not found)"
+    },
+    {
+      "operation": "DeleteWorkspace",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeAlertManagerDefinition",
+      "status": "working",
+      "message": "likely implemented (404: Workspace not found)"
+    },
+    {
+      "operation": "DescribeAnomalyDetector",
+      "status": "working",
+      "message": "likely implemented (404: Workspace not found)"
+    },
+    {
+      "operation": "DescribeLoggingConfiguration",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeQueryLoggingConfiguration",
+      "status": "working",
+      "message": "likely implemented (404: Workspace not found)"
+    },
+    {
+      "operation": "DescribeResourcePolicy",
+      "status": "working",
+      "message": "likely implemented (404: Workspace not found)"
+    },
+    {
+      "operation": "DescribeRuleGroupsNamespace",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeScraper",
+      "status": "working",
+      "message": "likely implemented (404: Scraper not found)"
+    },
+    {
+      "operation": "DescribeScraperLoggingConfiguration",
+      "status": "working",
+      "message": "likely implemented (404: Scraper not found)"
+    },
+    {
+      "operation": "DescribeWorkspace",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeWorkspaceConfiguration",
+      "status": "working",
+      "message": "likely implemented (404: Workspace not found)"
+    },
+    {
+      "operation": "GetDefaultScraperConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListAnomalyDetectors",
+      "status": "working",
+      "message": "likely implemented (404: Workspace not found)"
+    },
+    {
+      "operation": "ListRuleGroupsNamespaces",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListScrapers",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListWorkspaces",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutAlertManagerDefinition",
+      "status": "working",
+      "message": "likely implemented (404: Workspace not found)"
+    },
+    {
+      "operation": "PutAnomalyDetector",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "PutResourcePolicy",
+      "status": "working",
+      "message": "likely implemented (404: Workspace not found)"
+    },
+    {
+      "operation": "PutRuleGroupsNamespace",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "TagResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateLoggingConfiguration",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateQueryLoggingConfiguration",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UpdateScraper",
+      "status": "working",
+      "message": "likely implemented (404: Scraper not found)"
+    },
+    {
+      "operation": "UpdateScraperLoggingConfiguration",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UpdateWorkspaceAlias",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "UpdateWorkspaceConfiguration",
+      "status": "working",
+      "message": "likely implemented (404: Workspace not found)"
+    }
+  ]
+}

--- a/probes/apigateway.json
+++ b/probes/apigateway.json
@@ -1,0 +1,626 @@
+{
+  "service": "apigateway",
+  "counts": {
+    "working": 91,
+    "needs_params": 0,
+    "not_implemented": 25,
+    "500_error": 7
+  },
+  "operations": [
+    {
+      "operation": "CreateApiKey",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateAuthorizer",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "CreateBasePathMapping",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "CreateDeployment",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "CreateDocumentationPart",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "CreateDocumentationVersion",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "CreateDomainName",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateDomainNameAccessAssociation",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateModel",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "CreateRequestValidator",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "CreateResource",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "CreateRestApi",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateStage",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "CreateUsagePlan",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateUsagePlanKey",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "CreateVpcLink",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteApiKey",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeleteAuthorizer",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeleteBasePathMapping",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "DeleteClientCertificate",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeleteDeployment",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeleteDocumentationPart",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeleteDocumentationVersion",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeleteDomainName",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteDomainNameAccessAssociation",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteGatewayResponse",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeleteIntegration",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeleteIntegrationResponse",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteMethod",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeleteMethodResponse",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteModel",
+      "status": "working",
+      "message": "likely implemented (404: Invalid API identifier specified)"
+    },
+    {
+      "operation": "DeleteRequestValidator",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeleteResource",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeleteStage",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeleteUsagePlan",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "DeleteUsagePlanKey",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "DeleteVpcLink",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "FlushStageAuthorizersCache",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "FlushStageCache",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GenerateClientCertificate",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetAccount",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetApiKey",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetApiKeys",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetAuthorizer",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetAuthorizers",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetBasePathMapping",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetBasePathMappings",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetClientCertificate",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetClientCertificates",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetDeployment",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetDeployments",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetDocumentationPart",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetDocumentationParts",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetDocumentationVersion",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetDocumentationVersions",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetDomainName",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetDomainNameAccessAssociations",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetDomainNames",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetExport",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetGatewayResponse",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetGatewayResponses",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetIntegration",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetIntegrationResponse",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetMethod",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetMethodResponse",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetModel",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetModelTemplate",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetModels",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetRequestValidator",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetRequestValidators",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetResource",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetResources",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetRestApi",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetRestApis",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetSdk",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetSdkType",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetSdkTypes",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetStage",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetStages",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetTags",
+      "status": "working",
+      "message": "likely implemented (404: Invalid resource ARN)"
+    },
+    {
+      "operation": "GetUsage",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetUsagePlan",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetUsagePlanKey",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetUsagePlanKeys",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetUsagePlans",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetVpcLink",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetVpcLinks",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ImportApiKeys",
+      "status": "500_error",
+      "message": "server crash (InternalError: Expecting value: line 1 column 1 (char 0))"
+    },
+    {
+      "operation": "ImportDocumentationParts",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ImportRestApi",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutGatewayResponse",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "PutIntegration",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "PutIntegrationResponse",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "PutMethod",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "PutMethodResponse",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "PutRestApi",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'paths')"
+    },
+    {
+      "operation": "RejectDomainNameAccessAssociation",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "TagResource",
+      "status": "working",
+      "message": "likely implemented (404: Invalid resource ARN)"
+    },
+    {
+      "operation": "TestInvokeAuthorizer",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "TestInvokeMethod",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "working",
+      "message": "likely implemented (404: Invalid resource ARN)"
+    },
+    {
+      "operation": "UpdateAccount",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'NoneType' object is not iterable)"
+    },
+    {
+      "operation": "UpdateApiKey",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UpdateAuthorizer",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UpdateBasePathMapping",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UpdateClientCertificate",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UpdateDeployment",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateDocumentationPart",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UpdateDocumentationVersion",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UpdateDomainName",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateGatewayResponse",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UpdateIntegration",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UpdateIntegrationResponse",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateMethod",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UpdateMethodResponse",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateModel",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateRequestValidator",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UpdateResource",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateRestApi",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'NoneType' object is not iterable)"
+    },
+    {
+      "operation": "UpdateStage",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UpdateUsage",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateUsagePlan",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UpdateVpcLink",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    }
+  ]
+}

--- a/probes/appmesh.json
+++ b/probes/appmesh.json
@@ -1,0 +1,201 @@
+{
+  "service": "appmesh",
+  "counts": {
+    "working": 22,
+    "needs_params": 0,
+    "not_implemented": 16,
+    "500_error": 0
+  },
+  "operations": [
+    {
+      "operation": "CreateGatewayRoute",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateMesh",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateRoute",
+      "status": "working",
+      "message": "likely implemented (VirtualRouterNotFound: The mesh probe-test-value does not have a virtual router nam)"
+    },
+    {
+      "operation": "CreateVirtualGateway",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateVirtualNode",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateVirtualRouter",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateVirtualService",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteGatewayRoute",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteMesh",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteRoute",
+      "status": "working",
+      "message": "likely implemented (MeshNotFound: There are no meshes with the name probe-test-value.)"
+    },
+    {
+      "operation": "DeleteVirtualGateway",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteVirtualNode",
+      "status": "working",
+      "message": "likely implemented (MeshNotFound: There are no meshes with the name probe-test-value.)"
+    },
+    {
+      "operation": "DeleteVirtualRouter",
+      "status": "working",
+      "message": "likely implemented (MeshNotFound: There are no meshes with the name probe-test-value.)"
+    },
+    {
+      "operation": "DeleteVirtualService",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeGatewayRoute",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeMesh",
+      "status": "working",
+      "message": "likely implemented (MeshNotFound: There are no meshes with the name probe-test-value.)"
+    },
+    {
+      "operation": "DescribeRoute",
+      "status": "working",
+      "message": "likely implemented (MeshNotFound: There are no meshes with the name probe-test-value.)"
+    },
+    {
+      "operation": "DescribeVirtualGateway",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeVirtualNode",
+      "status": "working",
+      "message": "likely implemented (MeshNotFound: There are no meshes with the name probe-test-value.)"
+    },
+    {
+      "operation": "DescribeVirtualRouter",
+      "status": "working",
+      "message": "likely implemented (MeshNotFound: There are no meshes with the name probe-test-value.)"
+    },
+    {
+      "operation": "DescribeVirtualService",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListGatewayRoutes",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListMeshes",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListRoutes",
+      "status": "working",
+      "message": "likely implemented (MeshNotFound: There are no meshes with the name probe-test-value.)"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "working",
+      "message": "likely implemented (ResourceNotFound: There are no mesh resources with the arn arn:aws:appmesh:us-)"
+    },
+    {
+      "operation": "ListVirtualGateways",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListVirtualNodes",
+      "status": "working",
+      "message": "likely implemented (MeshNotFound: There are no meshes with the name probe-test-value.)"
+    },
+    {
+      "operation": "ListVirtualRouters",
+      "status": "working",
+      "message": "likely implemented (MeshNotFound: There are no meshes with the name probe-test-value.)"
+    },
+    {
+      "operation": "ListVirtualServices",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "TagResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateGatewayRoute",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateMesh",
+      "status": "working",
+      "message": "likely implemented (MeshNotFound: There are no meshes with the name probe-test-value.)"
+    },
+    {
+      "operation": "UpdateRoute",
+      "status": "working",
+      "message": "likely implemented (MeshNotFound: There are no meshes with the name probe-test-value.)"
+    },
+    {
+      "operation": "UpdateVirtualGateway",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateVirtualNode",
+      "status": "working",
+      "message": "likely implemented (MeshNotFound: There are no meshes with the name probe-test-value.)"
+    },
+    {
+      "operation": "UpdateVirtualRouter",
+      "status": "working",
+      "message": "likely implemented (MeshNotFound: There are no meshes with the name probe-test-value.)"
+    },
+    {
+      "operation": "UpdateVirtualService",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    }
+  ]
+}

--- a/probes/appsync.json
+++ b/probes/appsync.json
@@ -1,0 +1,371 @@
+{
+  "service": "appsync",
+  "counts": {
+    "working": 69,
+    "needs_params": 3,
+    "not_implemented": 0,
+    "500_error": 0
+  },
+  "operations": [
+    {
+      "operation": "AssociateApi",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "AssociateMergedGraphqlApi",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "AssociateSourceGraphqlApi",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateApi",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateApiCache",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "CreateApiKey",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "CreateChannelNamespace",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "CreateDataSource",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "CreateDomainName",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateFunction",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "CreateGraphqlApi",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateResolver",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "CreateType",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeleteApiCache",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeleteApiKey",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeleteChannelNamespace",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeleteDataSource",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeleteDomainName",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteGraphqlApi",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeleteResolver",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeleteType",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DisassociateApi",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DisassociateMergedGraphqlApi",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DisassociateSourceGraphqlApi",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "EvaluateCode",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "EvaluateMappingTemplate",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "FlushApiCache",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetApi",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetApiAssociation",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetApiCache",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetChannelNamespace",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetDataSource",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetDataSourceIntrospection",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetDomainName",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetFunction",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetGraphqlApi",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetGraphqlApiEnvironmentVariables",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetIntrospectionSchema",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetResolver",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetSchemaCreationStatus",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetSourceApiAssociation",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetType",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "ListApiKeys",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "ListApis",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListChannelNamespaces",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "ListDataSources",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "ListDomainNames",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListFunctions",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "ListGraphqlApis",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListResolvers",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "ListResolversByFunction",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "ListSourceApiAssociations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "ListTypes",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "ListTypesByAssociation",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutGraphqlApiEnvironmentVariables",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "StartDataSourceIntrospection",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartSchemaCreation",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "StartSchemaMerge",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "TagResource",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UpdateApi",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UpdateApiCache",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UpdateApiKey",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UpdateChannelNamespace",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UpdateDataSource",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UpdateDomainName",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UpdateFunction",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UpdateGraphqlApi",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UpdateResolver",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UpdateSourceApiAssociation",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateType",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    }
+  ]
+}

--- a/probes/athena.json
+++ b/probes/athena.json
@@ -1,0 +1,361 @@
+{
+  "service": "athena",
+  "counts": {
+    "working": 62,
+    "needs_params": 4,
+    "not_implemented": 0,
+    "500_error": 4
+  },
+  "operations": [
+    {
+      "operation": "BatchGetNamedQuery",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "BatchGetPreparedStatement",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "BatchGetQueryExecution",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CancelCapacityReservation",
+      "status": "working",
+      "message": "likely implemented (InvalidArgumentException: Capacity Reservation does not exist)"
+    },
+    {
+      "operation": "CreateCapacityReservation",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateDataCatalog",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateNamedQuery",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateNotebook",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "CreatePreparedStatement",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "CreatePresignedNotebookUrl",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "CreateWorkGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteCapacityReservation",
+      "status": "working",
+      "message": "likely implemented (InvalidArgumentException: Capacity Reservation does not exist)"
+    },
+    {
+      "operation": "DeleteDataCatalog",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteNamedQuery",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteNotebook",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeletePreparedStatement",
+      "status": "working",
+      "message": "likely implemented (InvalidArgumentException: PreparedStatement probe-test-value was not found)"
+    },
+    {
+      "operation": "DeleteWorkGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ExportNotebook",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "GetCalculationExecution",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "GetCalculationExecutionCode",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "GetCalculationExecutionStatus",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "GetCapacityAssignmentConfiguration",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "GetCapacityReservation",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "GetDataCatalog",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetDatabase",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "GetNamedQuery",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'NoneType' object has no attribute 'name')"
+    },
+    {
+      "operation": "GetNotebookMetadata",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "GetPreparedStatement",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'NoneType' object has no attribute 'statement_name')"
+    },
+    {
+      "operation": "GetQueryExecution",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "GetQueryResults",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetQueryRuntimeStatistics",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "GetResourceDashboard",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetSession",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "GetSessionEndpoint",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "GetSessionStatus",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "GetTableMetadata",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "GetWorkGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ImportNotebook",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "ListApplicationDPUSizes",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListCalculationExecutions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListCapacityReservations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListDataCatalogs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListDatabases",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListEngineVersions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListExecutors",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListNamedQueries",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListNotebookMetadata",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListNotebookSessions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListPreparedStatements",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListQueryExecutions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListSessions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTableMetadata",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "ListWorkGroups",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutCapacityAssignmentConfiguration",
+      "status": "working",
+      "message": "likely implemented (InvalidArgumentException: Capacity Reservation does not exist)"
+    },
+    {
+      "operation": "StartCalculationExecution",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartQueryExecution",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartSession",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "StopCalculationExecution",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "StopQueryExecution",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "TagResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "TerminateSession",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateCapacityReservation",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UpdateDataCatalog",
+      "status": "working",
+      "message": "likely implemented (InvalidArgumentException: DataCatalog probe-test-value is not found)"
+    },
+    {
+      "operation": "UpdateNamedQuery",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateNotebook",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateNotebookMetadata",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdatePreparedStatement",
+      "status": "working",
+      "message": "likely implemented (InvalidArgumentException: PreparedStatement probe-test-value was not found)"
+    },
+    {
+      "operation": "UpdateWorkGroup",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    }
+  ]
+}

--- a/probes/autoscaling.json
+++ b/probes/autoscaling.json
@@ -1,0 +1,341 @@
+{
+  "service": "autoscaling",
+  "counts": {
+    "working": 35,
+    "needs_params": 0,
+    "not_implemented": 9,
+    "500_error": 22
+  },
+  "operations": [
+    {
+      "operation": "AttachInstances",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "AttachLoadBalancerTargetGroups",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "AttachLoadBalancers",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "AttachTrafficSources",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "BatchDeleteScheduledAction",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "BatchPutScheduledUpdateGroupAction",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CancelInstanceRefresh",
+      "status": "working",
+      "message": "implemented (ValidationError)"
+    },
+    {
+      "operation": "CompleteLifecycleAction",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateAutoScalingGroup",
+      "status": "working",
+      "message": "implemented (ValidationError)"
+    },
+    {
+      "operation": "CreateLaunchConfiguration",
+      "status": "working",
+      "message": "implemented (ValidationError)"
+    },
+    {
+      "operation": "CreateOrUpdateTags",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteAutoScalingGroup",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "DeleteLaunchConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteLifecycleHook",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteNotificationConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeletePolicy",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteScheduledAction",
+      "status": "working",
+      "message": "implemented (ValidationError)"
+    },
+    {
+      "operation": "DeleteTags",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteWarmPool",
+      "status": "500_error",
+      "message": "server crash (InternalError: list index out of range)"
+    },
+    {
+      "operation": "DescribeAccountLimits",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeAdjustmentTypes",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeAutoScalingGroups",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeAutoScalingInstances",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeAutoScalingNotificationTypes",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeInstanceRefreshes",
+      "status": "working",
+      "message": "implemented (ValidationError)"
+    },
+    {
+      "operation": "DescribeLaunchConfigurations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeLifecycleHookTypes",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeLifecycleHooks",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeLoadBalancerTargetGroups",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "DescribeLoadBalancers",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "DescribeMetricCollectionTypes",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeNotificationConfigurations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribePolicies",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeScalingActivities",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeScalingProcessTypes",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeScheduledActions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeTags",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeTerminationPolicyTypes",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeTrafficSources",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeWarmPool",
+      "status": "500_error",
+      "message": "server crash (InternalError: list index out of range)"
+    },
+    {
+      "operation": "DetachInstances",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "DetachLoadBalancerTargetGroups",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "DetachLoadBalancers",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "DetachTrafficSources",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DisableMetricsCollection",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "EnableMetricsCollection",
+      "status": "500_error",
+      "message": "server crash (InternalError: list index out of range)"
+    },
+    {
+      "operation": "EnterStandby",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "ExecutePolicy",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "ExitStandby",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "GetPredictiveScalingForecast",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "LaunchInstances",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "PutLifecycleHook",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutNotificationConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutScalingPolicy",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutScheduledUpdateGroupAction",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutWarmPool",
+      "status": "500_error",
+      "message": "server crash (InternalError: list index out of range)"
+    },
+    {
+      "operation": "RecordLifecycleActionHeartbeat",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ResumeProcesses",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "RollbackInstanceRefresh",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "SetDesiredCapacity",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "SetInstanceHealth",
+      "status": "500_error",
+      "message": "server crash (InternalError: Valid instance health states are: [Healthy, Unhealthy])"
+    },
+    {
+      "operation": "SetInstanceProtection",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "StartInstanceRefresh",
+      "status": "working",
+      "message": "implemented (ValidationError)"
+    },
+    {
+      "operation": "SuspendProcesses",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "TerminateInstanceInAutoScalingGroup",
+      "status": "500_error",
+      "message": "exception: Connection was closed before we received a valid response fr"
+    },
+    {
+      "operation": "UpdateAutoScalingGroup",
+      "status": "working",
+      "message": "implemented (ValidationError)"
+    }
+  ]
+}

--- a/probes/backup.json
+++ b/probes/backup.json
@@ -1,0 +1,551 @@
+{
+  "service": "backup",
+  "counts": {
+    "working": 80,
+    "needs_params": 0,
+    "not_implemented": 26,
+    "500_error": 2
+  },
+  "operations": [
+    {
+      "operation": "AssociateBackupVaultMpaApprovalTeam",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CancelLegalHold",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "CreateBackupPlan",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateBackupSelection",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateBackupVault",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateFramework",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateLegalHold",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateLogicallyAirGappedBackupVault",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateReportPlan",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateRestoreAccessBackupVault",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateRestoreTestingPlan",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateRestoreTestingSelection",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateTieringConfiguration",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteBackupPlan",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteBackupSelection",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteBackupVault",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteBackupVaultAccessPolicy",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteBackupVaultLockConfiguration",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteBackupVaultNotifications",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteFramework",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteRecoveryPoint",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteReportPlan",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteRestoreTestingPlan",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteRestoreTestingSelection",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteTieringConfiguration",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeBackupJob",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeBackupVault",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeCopyJob",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeFramework",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeGlobalSettings",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeProtectedResource",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeRecoveryPoint",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeRegionSettings",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeReportJob",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeReportPlan",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeRestoreJob",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeScanJob",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DisassociateBackupVaultMpaApprovalTeam",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DisassociateRecoveryPoint",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DisassociateRecoveryPointFromParent",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ExportBackupPlanTemplate",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetBackupPlan",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetBackupPlanFromJSON",
+      "status": "500_error",
+      "message": "server crash (InternalError: Expecting value: line 1 column 1 (char 0))"
+    },
+    {
+      "operation": "GetBackupPlanFromTemplate",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetBackupSelection",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetBackupVaultAccessPolicy",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetBackupVaultNotifications",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetLegalHold",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetRecoveryPointIndexDetails",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetRecoveryPointRestoreMetadata",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetRestoreJobMetadata",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetRestoreTestingInferredMetadata",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetRestoreTestingPlan",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetRestoreTestingSelection",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetSupportedResourceTypes",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetTieringConfiguration",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListBackupJobSummaries",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListBackupJobs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListBackupPlanTemplates",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListBackupPlanVersions",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListBackupPlans",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListBackupSelections",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListBackupVaults",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListCopyJobSummaries",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListCopyJobs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListFrameworks",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListIndexedRecoveryPoints",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListLegalHolds",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListProtectedResources",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListProtectedResourcesByBackupVault",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListRecoveryPointsByBackupVault",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListRecoveryPointsByLegalHold",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListRecoveryPointsByResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListReportJobs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListReportPlans",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListRestoreAccessBackupVaults",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListRestoreJobSummaries",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListRestoreJobs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListRestoreJobsByProtectedResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListRestoreTestingPlans",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListRestoreTestingSelections",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListScanJobSummaries",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListScanJobs",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListTags",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTieringConfigurations",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "PutBackupVaultAccessPolicy",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "PutBackupVaultLockConfiguration",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "PutBackupVaultNotifications",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "PutRestoreValidationResult",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "RevokeRestoreAccessBackupVault",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StartBackupJob",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "StartCopyJob",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartReportJob",
+      "status": "500_error",
+      "message": "server crash (InternalError: list index out of range)"
+    },
+    {
+      "operation": "StartRestoreJob",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartScanJob",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StopBackupJob",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "TagResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateBackupPlan",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateFramework",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateGlobalSettings",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateRecoveryPointIndexSettings",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateRecoveryPointLifecycle",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateRegionSettings",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateReportPlan",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateRestoreTestingPlan",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateRestoreTestingSelection",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateTieringConfiguration",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    }
+  ]
+}

--- a/probes/bedrock.json
+++ b/probes/bedrock.json
@@ -1,0 +1,501 @@
+{
+  "service": "bedrock",
+  "counts": {
+    "working": 87,
+    "needs_params": 11,
+    "not_implemented": 0,
+    "500_error": 0
+  },
+  "operations": [
+    {
+      "operation": "BatchDeleteEvaluationJob",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CancelAutomatedReasoningPolicyBuildWorkflow",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "CreateAutomatedReasoningPolicy",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateAutomatedReasoningPolicyTestCase",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "CreateAutomatedReasoningPolicyVersion",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateCustomModel",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateCustomModelDeployment",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateEvaluationJob",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateFoundationModelAgreement",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateGuardrail",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateGuardrailVersion",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "CreateInferenceProfile",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateMarketplaceModelEndpoint",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateModelCopyJob",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateModelCustomizationJob",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "CreateModelImportJob",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateModelInvocationJob",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreatePromptRouter",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateProvisionedModelThroughput",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteAutomatedReasoningPolicy",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteAutomatedReasoningPolicyBuildWorkflow",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteAutomatedReasoningPolicyTestCase",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteCustomModel",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteCustomModelDeployment",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteEnforcedGuardrailConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteFoundationModelAgreement",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteGuardrail",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteImportedModel",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteInferenceProfile",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteMarketplaceModelEndpoint",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteModelInvocationLoggingConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeletePromptRouter",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteProvisionedModelThroughput",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeregisterMarketplaceModelEndpoint",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ExportAutomatedReasoningPolicyVersion",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetAutomatedReasoningPolicy",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetAutomatedReasoningPolicyAnnotations",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetAutomatedReasoningPolicyBuildWorkflow",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetAutomatedReasoningPolicyBuildWorkflowResultAssets",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetAutomatedReasoningPolicyNextScenario",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetAutomatedReasoningPolicyTestCase",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetAutomatedReasoningPolicyTestResult",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetCustomModel",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetCustomModelDeployment",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetEvaluationJob",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetFoundationModel",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetFoundationModelAvailability",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetGuardrail",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetImportedModel",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetInferenceProfile",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetMarketplaceModelEndpoint",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetModelCopyJob",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetModelCustomizationJob",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetModelImportJob",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetModelInvocationJob",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetModelInvocationLoggingConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetPromptRouter",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetProvisionedModelThroughput",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetUseCaseForModelAccess",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListAutomatedReasoningPolicies",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListAutomatedReasoningPolicyBuildWorkflows",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListAutomatedReasoningPolicyTestCases",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListAutomatedReasoningPolicyTestResults",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListCustomModelDeployments",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListCustomModels",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListEnforcedGuardrailsConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListEvaluationJobs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListFoundationModelAgreementOffers",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListFoundationModels",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListGuardrails",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListImportedModels",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListInferenceProfiles",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListMarketplaceModelEndpoints",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListModelCopyJobs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListModelCustomizationJobs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListModelImportJobs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListModelInvocationJobs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListPromptRouters",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListProvisionedModelThroughputs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "PutEnforcedGuardrailConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutModelInvocationLoggingConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutUseCaseForModelAccess",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "RegisterMarketplaceModelEndpoint",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "StartAutomatedReasoningPolicyBuildWorkflow",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "StartAutomatedReasoningPolicyTestWorkflow",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "StopEvaluationJob",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "StopModelCustomizationJob",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "StopModelInvocationJob",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "TagResource",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateAutomatedReasoningPolicy",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateAutomatedReasoningPolicyAnnotations",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UpdateAutomatedReasoningPolicyTestCase",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateCustomModelDeployment",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateGuardrail",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateMarketplaceModelEndpoint",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UpdateProvisionedModelThroughput",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    }
+  ]
+}

--- a/probes/budgets.json
+++ b/probes/budgets.json
@@ -1,0 +1,141 @@
+{
+  "service": "budgets",
+  "counts": {
+    "working": 13,
+    "needs_params": 13,
+    "not_implemented": 0,
+    "500_error": 0
+  },
+  "operations": [
+    {
+      "operation": "CreateBudget",
+      "status": "working",
+      "message": "implemented (InvalidParameterException)"
+    },
+    {
+      "operation": "CreateBudgetAction",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateNotification",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateSubscriber",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DeleteBudget",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeleteBudgetAction",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DeleteNotification",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DeleteSubscriber",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DescribeBudget",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DescribeBudgetAction",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DescribeBudgetActionHistories",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DescribeBudgetActionsForAccount",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeBudgetActionsForBudget",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DescribeBudgetNotificationsForAccount",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeBudgetPerformanceHistory",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DescribeBudgets",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeNotificationsForBudget",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DescribeSubscribersForNotification",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "ExecuteBudgetAction",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "TagResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateBudget",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UpdateBudgetAction",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UpdateNotification",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UpdateSubscriber",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    }
+  ]
+}

--- a/probes/ce.json
+++ b/probes/ce.json
@@ -1,0 +1,246 @@
+{
+  "service": "ce",
+  "counts": {
+    "working": 41,
+    "needs_params": 6,
+    "not_implemented": 0,
+    "500_error": 0
+  },
+  "operations": [
+    {
+      "operation": "CreateAnomalyMonitor",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateAnomalySubscription",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateCostCategoryDefinition",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DeleteAnomalyMonitor",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteAnomalySubscription",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteCostCategoryDefinition",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeCostCategoryDefinition",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetAnomalies",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetAnomalyMonitors",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetAnomalySubscriptions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetApproximateUsageRecords",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetCommitmentPurchaseAnalysis",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "GetCostAndUsage",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetCostAndUsageComparisons",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetCostAndUsageWithResources",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetCostCategories",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetCostComparisonDrivers",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetCostForecast",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetDimensionValues",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetReservationCoverage",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetReservationPurchaseRecommendation",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetReservationUtilization",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetRightsizingRecommendation",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetSavingsPlanPurchaseRecommendationDetails",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "GetSavingsPlansCoverage",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetSavingsPlansPurchaseRecommendation",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetSavingsPlansUtilization",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetSavingsPlansUtilizationDetails",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetTags",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetUsageForecast",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListCommitmentPurchaseAnalyses",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListCostAllocationTagBackfillHistory",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListCostAllocationTags",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListCostCategoryDefinitions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListCostCategoryResourceAssociations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListSavingsPlansPurchaseRecommendationGeneration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ProvideAnomalyFeedback",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartCommitmentPurchaseAnalysis",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartCostAllocationTagBackfill",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "StartSavingsPlansPurchaseRecommendationGeneration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "TagResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateAnomalyMonitor",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateAnomalySubscription",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateCostAllocationTagsStatus",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UpdateCostCategoryDefinition",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    }
+  ]
+}

--- a/probes/cloudformation.json
+++ b/probes/cloudformation.json
@@ -1,0 +1,456 @@
+{
+  "service": "cloudformation",
+  "counts": {
+    "working": 82,
+    "needs_params": 1,
+    "not_implemented": 5,
+    "500_error": 1
+  },
+  "operations": [
+    {
+      "operation": "ActivateOrganizationsAccess",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ActivateType",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "BatchDescribeTypeConfigurations",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CancelUpdateStack",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ContinueUpdateRollback",
+      "status": "working",
+      "message": "implemented (ValidationError)"
+    },
+    {
+      "operation": "CreateChangeSet",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateGeneratedTemplate",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateStack",
+      "status": "working",
+      "message": "implemented (ValidationError)"
+    },
+    {
+      "operation": "CreateStackInstances",
+      "status": "working",
+      "message": "likely implemented (StackSetNotFoundException: StackSet probe-test-value not found)"
+    },
+    {
+      "operation": "CreateStackRefactor",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateStackSet",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeactivateOrganizationsAccess",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeactivateType",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteChangeSet",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteGeneratedTemplate",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteStackInstances",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteStackSet",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeregisterType",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeAccountLimits",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeChangeSet",
+      "status": "working",
+      "message": "likely implemented (ChangeSetNotFoundException: ChangeSet [probe-test-value] does not exist)"
+    },
+    {
+      "operation": "DescribeChangeSetHooks",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeEvents",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeGeneratedTemplate",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeOrganizationsAccess",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribePublisher",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeResourceScan",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeStackDriftDetectionStatus",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeStackEvents",
+      "status": "working",
+      "message": "implemented (ValidationError)"
+    },
+    {
+      "operation": "DescribeStackInstance",
+      "status": "working",
+      "message": "likely implemented (StackSetNotFoundException: StackSet probe-test-value not found)"
+    },
+    {
+      "operation": "DescribeStackRefactor",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeStackResource",
+      "status": "working",
+      "message": "implemented (ValidationError)"
+    },
+    {
+      "operation": "DescribeStackResourceDrifts",
+      "status": "working",
+      "message": "implemented (ValidationError)"
+    },
+    {
+      "operation": "DescribeStackResources",
+      "status": "working",
+      "message": "implemented (ValidationError)"
+    },
+    {
+      "operation": "DescribeStackSet",
+      "status": "working",
+      "message": "likely implemented (StackSetNotFoundException: StackSet probe-test-value not found)"
+    },
+    {
+      "operation": "DescribeStackSetOperation",
+      "status": "working",
+      "message": "likely implemented (StackSetNotFoundException: StackSet probe-test-value not found)"
+    },
+    {
+      "operation": "DescribeStacks",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeType",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeTypeRegistration",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DetectStackDrift",
+      "status": "working",
+      "message": "implemented (ValidationError)"
+    },
+    {
+      "operation": "DetectStackResourceDrift",
+      "status": "working",
+      "message": "implemented (ValidationError)"
+    },
+    {
+      "operation": "DetectStackSetDrift",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "EstimateTemplateCost",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ExecuteChangeSet",
+      "status": "working",
+      "message": "likely implemented (ChangeSetNotFoundException: ChangeSet [probe-test-value] does not exist)"
+    },
+    {
+      "operation": "ExecuteStackRefactor",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetGeneratedTemplate",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetHookResult",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetStackPolicy",
+      "status": "working",
+      "message": "implemented (ValidationError)"
+    },
+    {
+      "operation": "GetTemplate",
+      "status": "working",
+      "message": "implemented (ValidationError)"
+    },
+    {
+      "operation": "GetTemplateSummary",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'NoneType' object has no attribute 'read')"
+    },
+    {
+      "operation": "ImportStacksToStackSet",
+      "status": "working",
+      "message": "likely implemented (StackSetNotFoundException: StackSet probe-test-value not found)"
+    },
+    {
+      "operation": "ListChangeSets",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListExports",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListGeneratedTemplates",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListHookResults",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListImports",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListResourceScanRelatedResources",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListResourceScanResources",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListResourceScans",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListStackInstanceResourceDrifts",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListStackInstances",
+      "status": "working",
+      "message": "likely implemented (StackSetNotFoundException: StackSet probe-test-value not found)"
+    },
+    {
+      "operation": "ListStackRefactorActions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListStackRefactors",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListStackResources",
+      "status": "working",
+      "message": "implemented (ValidationError)"
+    },
+    {
+      "operation": "ListStackSetAutoDeploymentTargets",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListStackSetOperationResults",
+      "status": "working",
+      "message": "likely implemented (StackSetNotFoundException: StackSet probe-test-value not found)"
+    },
+    {
+      "operation": "ListStackSetOperations",
+      "status": "working",
+      "message": "likely implemented (StackSetNotFoundException: StackSet probe-test-value not found)"
+    },
+    {
+      "operation": "ListStackSets",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListStacks",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTypeRegistrations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTypeVersions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTypes",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PublishType",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "RecordHandlerProgress",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "RegisterPublisher",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "RegisterType",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "RollbackStack",
+      "status": "working",
+      "message": "implemented (ValidationError)"
+    },
+    {
+      "operation": "SetStackPolicy",
+      "status": "working",
+      "message": "implemented (ValidationError)"
+    },
+    {
+      "operation": "SetTypeConfiguration",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "SetTypeDefaultVersion",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "SignalResource",
+      "status": "working",
+      "message": "implemented (ValidationError)"
+    },
+    {
+      "operation": "StartResourceScan",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StopStackSetOperation",
+      "status": "working",
+      "message": "likely implemented (StackSetNotFoundException: StackSet probe-test-value not found)"
+    },
+    {
+      "operation": "TestType",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateGeneratedTemplate",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateStack",
+      "status": "working",
+      "message": "implemented (ValidationError)"
+    },
+    {
+      "operation": "UpdateStackInstances",
+      "status": "working",
+      "message": "likely implemented (StackSetNotFoundException: StackSet probe-test-value not found)"
+    },
+    {
+      "operation": "UpdateStackSet",
+      "status": "working",
+      "message": "likely implemented (StackSetNotFoundException: StackSet probe-test-value not found)"
+    },
+    {
+      "operation": "UpdateTerminationProtection",
+      "status": "working",
+      "message": "implemented (ValidationError)"
+    },
+    {
+      "operation": "ValidateTemplate",
+      "status": "working",
+      "message": "implemented (ValidationError)"
+    }
+  ]
+}

--- a/probes/cloudfront.json
+++ b/probes/cloudfront.json
@@ -1,0 +1,841 @@
+{
+  "service": "cloudfront",
+  "counts": {
+    "working": 128,
+    "needs_params": 5,
+    "not_implemented": 1,
+    "500_error": 32
+  },
+  "operations": [
+    {
+      "operation": "AssociateAlias",
+      "status": "working",
+      "message": "likely implemented (NoSuchDistribution: The specified distribution does not exist.)"
+    },
+    {
+      "operation": "AssociateDistributionTenantWebACL",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "AssociateDistributionWebACL",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CopyDistribution",
+      "status": "working",
+      "message": "likely implemented (NoSuchDistribution: The specified distribution does not exist.)"
+    },
+    {
+      "operation": "CreateAnycastIpList",
+      "status": "500_error",
+      "message": "server crash (InternalError: Expecting value: line 1 column 1 (char 0))"
+    },
+    {
+      "operation": "CreateCachePolicy",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateCloudFrontOriginAccessIdentity",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateConnectionFunction",
+      "status": "500_error",
+      "message": "server crash (InternalError: Expecting value: line 1 column 1 (char 0))"
+    },
+    {
+      "operation": "CreateConnectionGroup",
+      "status": "500_error",
+      "message": "server crash (InternalError: Expecting value: line 1 column 1 (char 0))"
+    },
+    {
+      "operation": "CreateContinuousDeploymentPolicy",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateDistribution",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateDistributionTenant",
+      "status": "500_error",
+      "message": "server crash (InternalError: Expecting value: line 1 column 1 (char 0))"
+    },
+    {
+      "operation": "CreateDistributionWithTags",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateFieldLevelEncryptionConfig",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateFieldLevelEncryptionProfile",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateFunction",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateInvalidation",
+      "status": "working",
+      "message": "likely implemented (NoSuchDistribution: The specified distribution does not exist.)"
+    },
+    {
+      "operation": "CreateInvalidationForDistributionTenant",
+      "status": "500_error",
+      "message": "exception: Unable to parse response (not well-formed (invalid token): l"
+    },
+    {
+      "operation": "CreateKeyGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateKeyValueStore",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateMonitoringSubscription",
+      "status": "working",
+      "message": "likely implemented (NoSuchDistribution: The specified distribution does not exist.)"
+    },
+    {
+      "operation": "CreateOriginAccessControl",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateOriginRequestPolicy",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreatePublicKey",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateRealtimeLogConfig",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateResponseHeadersPolicy",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateStreamingDistribution",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateStreamingDistributionWithTags",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateTrustStore",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateVpcOrigin",
+      "status": "500_error",
+      "message": "server crash (InternalError: Expecting value: line 1 column 1 (char 0))"
+    },
+    {
+      "operation": "DeleteAnycastIpList",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteCachePolicy",
+      "status": "working",
+      "message": "likely implemented (NoSuchCachePolicy: The specified cache policy does not exist.)"
+    },
+    {
+      "operation": "DeleteCloudFrontOriginAccessIdentity",
+      "status": "working",
+      "message": "likely implemented (NoSuchCloudFrontOriginAccessIdentity: The specified origin access identity does not exist.)"
+    },
+    {
+      "operation": "DeleteConnectionFunction",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteConnectionGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteContinuousDeploymentPolicy",
+      "status": "working",
+      "message": "likely implemented (NoSuchContinuousDeploymentPolicy: The specified continuous deployment policy does not exist.)"
+    },
+    {
+      "operation": "DeleteDistribution",
+      "status": "working",
+      "message": "likely implemented (InvalidIfMatchVersion: The If-Match version is missing or not valid for the resourc)"
+    },
+    {
+      "operation": "DeleteDistributionTenant",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteFieldLevelEncryptionConfig",
+      "status": "working",
+      "message": "likely implemented (NoSuchFieldLevelEncryptionConfig: The specified field-level encryption configuration does not )"
+    },
+    {
+      "operation": "DeleteFieldLevelEncryptionProfile",
+      "status": "working",
+      "message": "likely implemented (NoSuchFieldLevelEncryptionProfile: The specified field-level encryption profile does not exist.)"
+    },
+    {
+      "operation": "DeleteKeyGroup",
+      "status": "working",
+      "message": "likely implemented (NoSuchResource: The specified key group does not exist.)"
+    },
+    {
+      "operation": "DeleteKeyValueStore",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteMonitoringSubscription",
+      "status": "working",
+      "message": "likely implemented (NoSuchMonitoringSubscription: The specified monitoring subscription does not exist.)"
+    },
+    {
+      "operation": "DeleteOriginAccessControl",
+      "status": "working",
+      "message": "likely implemented (NoSuchOriginAccessControl: The specified origin access control does not exist.)"
+    },
+    {
+      "operation": "DeleteOriginRequestPolicy",
+      "status": "working",
+      "message": "likely implemented (NoSuchOriginRequestPolicy: The specified origin request policy does not exist.)"
+    },
+    {
+      "operation": "DeletePublicKey",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteRealtimeLogConfig",
+      "status": "working",
+      "message": "likely implemented (NoSuchRealtimeLogConfig: The specified real-time log configuration does not exist.)"
+    },
+    {
+      "operation": "DeleteResourcePolicy",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteResponseHeadersPolicy",
+      "status": "working",
+      "message": "likely implemented (NoSuchResponseHeadersPolicy: The specified response headers policy does not exist.)"
+    },
+    {
+      "operation": "DeleteStreamingDistribution",
+      "status": "working",
+      "message": "likely implemented (NoSuchStreamingDistribution: The specified streaming distribution does not exist.)"
+    },
+    {
+      "operation": "DeleteTrustStore",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteVpcOrigin",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeConnectionFunction",
+      "status": "500_error",
+      "message": "exception: Unable to parse response (not well-formed (invalid token): l"
+    },
+    {
+      "operation": "DescribeFunction",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeKeyValueStore",
+      "status": "working",
+      "message": "likely implemented (NoSuchResource: The key value store probe-test-value does not exist.)"
+    },
+    {
+      "operation": "DisassociateDistributionTenantWebACL",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DisassociateDistributionWebACL",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetAnycastIpList",
+      "status": "working",
+      "message": "likely implemented (NoSuchResource: The anycast IP list probe-test-value does not exist.)"
+    },
+    {
+      "operation": "GetCachePolicy",
+      "status": "working",
+      "message": "likely implemented (NoSuchCachePolicy: The specified cache policy does not exist.)"
+    },
+    {
+      "operation": "GetCachePolicyConfig",
+      "status": "working",
+      "message": "likely implemented (NoSuchCachePolicy: The specified cache policy does not exist.)"
+    },
+    {
+      "operation": "GetCloudFrontOriginAccessIdentity",
+      "status": "working",
+      "message": "likely implemented (NoSuchCloudFrontOriginAccessIdentity: The specified origin access identity does not exist.)"
+    },
+    {
+      "operation": "GetCloudFrontOriginAccessIdentityConfig",
+      "status": "working",
+      "message": "likely implemented (NoSuchCloudFrontOriginAccessIdentity: The specified origin access identity does not exist.)"
+    },
+    {
+      "operation": "GetConnectionFunction",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetConnectionGroup",
+      "status": "500_error",
+      "message": "exception: Unable to parse response (not well-formed (invalid token): l"
+    },
+    {
+      "operation": "GetConnectionGroupByRoutingEndpoint",
+      "status": "500_error",
+      "message": "exception: Unable to parse response (not well-formed (invalid token): l"
+    },
+    {
+      "operation": "GetContinuousDeploymentPolicy",
+      "status": "working",
+      "message": "likely implemented (NoSuchContinuousDeploymentPolicy: The specified continuous deployment policy does not exist.)"
+    },
+    {
+      "operation": "GetContinuousDeploymentPolicyConfig",
+      "status": "working",
+      "message": "likely implemented (NoSuchContinuousDeploymentPolicy: The specified continuous deployment policy does not exist.)"
+    },
+    {
+      "operation": "GetDistribution",
+      "status": "working",
+      "message": "likely implemented (NoSuchDistribution: The specified distribution does not exist.)"
+    },
+    {
+      "operation": "GetDistributionConfig",
+      "status": "working",
+      "message": "likely implemented (NoSuchDistribution: The specified distribution does not exist.)"
+    },
+    {
+      "operation": "GetDistributionTenant",
+      "status": "500_error",
+      "message": "exception: Unable to parse response (not well-formed (invalid token): l"
+    },
+    {
+      "operation": "GetDistributionTenantByDomain",
+      "status": "500_error",
+      "message": "exception: Unable to parse response (not well-formed (invalid token): l"
+    },
+    {
+      "operation": "GetFieldLevelEncryption",
+      "status": "working",
+      "message": "likely implemented (NoSuchFieldLevelEncryptionConfig: The specified field-level encryption configuration does not )"
+    },
+    {
+      "operation": "GetFieldLevelEncryptionConfig",
+      "status": "working",
+      "message": "likely implemented (NoSuchFieldLevelEncryptionConfig: The specified field-level encryption configuration does not )"
+    },
+    {
+      "operation": "GetFieldLevelEncryptionProfile",
+      "status": "working",
+      "message": "likely implemented (NoSuchFieldLevelEncryptionProfile: The specified field-level encryption profile does not exist.)"
+    },
+    {
+      "operation": "GetFieldLevelEncryptionProfileConfig",
+      "status": "working",
+      "message": "likely implemented (NoSuchFieldLevelEncryptionProfile: The specified field-level encryption profile does not exist.)"
+    },
+    {
+      "operation": "GetFunction",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetInvalidation",
+      "status": "working",
+      "message": "likely implemented (NoSuchDistribution: The specified distribution does not exist.)"
+    },
+    {
+      "operation": "GetInvalidationForDistributionTenant",
+      "status": "500_error",
+      "message": "exception: Unable to parse response (not well-formed (invalid token): l"
+    },
+    {
+      "operation": "GetKeyGroup",
+      "status": "working",
+      "message": "likely implemented (NoSuchResource: The specified key group does not exist.)"
+    },
+    {
+      "operation": "GetKeyGroupConfig",
+      "status": "working",
+      "message": "likely implemented (NoSuchResource: The specified key group does not exist.)"
+    },
+    {
+      "operation": "GetManagedCertificateDetails",
+      "status": "500_error",
+      "message": "exception: Unable to parse response (not well-formed (invalid token): l"
+    },
+    {
+      "operation": "GetMonitoringSubscription",
+      "status": "working",
+      "message": "likely implemented (NoSuchMonitoringSubscription: The specified monitoring subscription does not exist.)"
+    },
+    {
+      "operation": "GetOriginAccessControl",
+      "status": "working",
+      "message": "likely implemented (NoSuchOriginAccessControl: The specified origin access control does not exist.)"
+    },
+    {
+      "operation": "GetOriginAccessControlConfig",
+      "status": "working",
+      "message": "likely implemented (NoSuchOriginAccessControl: The specified origin access control does not exist.)"
+    },
+    {
+      "operation": "GetOriginRequestPolicy",
+      "status": "working",
+      "message": "likely implemented (NoSuchOriginRequestPolicy: The specified origin request policy does not exist.)"
+    },
+    {
+      "operation": "GetOriginRequestPolicyConfig",
+      "status": "working",
+      "message": "likely implemented (NoSuchOriginRequestPolicy: The specified origin request policy does not exist.)"
+    },
+    {
+      "operation": "GetPublicKey",
+      "status": "working",
+      "message": "likely implemented (NoSuchPublicKey: The specified public key does not exist.)"
+    },
+    {
+      "operation": "GetPublicKeyConfig",
+      "status": "working",
+      "message": "likely implemented (NoSuchPublicKey: The specified public key does not exist.)"
+    },
+    {
+      "operation": "GetRealtimeLogConfig",
+      "status": "working",
+      "message": "likely implemented (NoSuchRealtimeLogConfig: The specified real-time log configuration does not exist.)"
+    },
+    {
+      "operation": "GetResourcePolicy",
+      "status": "500_error",
+      "message": "exception: Unable to parse response (not well-formed (invalid token): l"
+    },
+    {
+      "operation": "GetResponseHeadersPolicy",
+      "status": "working",
+      "message": "likely implemented (NoSuchResponseHeadersPolicy: The specified response headers policy does not exist.)"
+    },
+    {
+      "operation": "GetResponseHeadersPolicyConfig",
+      "status": "working",
+      "message": "likely implemented (NoSuchResponseHeadersPolicy: The specified response headers policy does not exist.)"
+    },
+    {
+      "operation": "GetStreamingDistribution",
+      "status": "working",
+      "message": "likely implemented (NoSuchStreamingDistribution: The specified streaming distribution does not exist.)"
+    },
+    {
+      "operation": "GetStreamingDistributionConfig",
+      "status": "working",
+      "message": "likely implemented (NoSuchStreamingDistribution: The specified streaming distribution does not exist.)"
+    },
+    {
+      "operation": "GetTrustStore",
+      "status": "500_error",
+      "message": "exception: Unable to parse response (not well-formed (invalid token): l"
+    },
+    {
+      "operation": "GetVpcOrigin",
+      "status": "working",
+      "message": "likely implemented (NoSuchResource: The VPC origin probe-test-value does not exist.)"
+    },
+    {
+      "operation": "ListAnycastIpLists",
+      "status": "500_error",
+      "message": "exception: Unable to parse response (not well-formed (invalid token): l"
+    },
+    {
+      "operation": "ListCachePolicies",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListCloudFrontOriginAccessIdentities",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListConflictingAliases",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListConnectionFunctions",
+      "status": "500_error",
+      "message": "exception: Unable to parse response (not well-formed (invalid token): l"
+    },
+    {
+      "operation": "ListConnectionGroups",
+      "status": "500_error",
+      "message": "exception: Unable to parse response (not well-formed (invalid token): l"
+    },
+    {
+      "operation": "ListContinuousDeploymentPolicies",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListDistributionTenants",
+      "status": "500_error",
+      "message": "exception: Unable to parse response (not well-formed (invalid token): l"
+    },
+    {
+      "operation": "ListDistributionTenantsByCustomization",
+      "status": "500_error",
+      "message": "exception: Unable to parse response (not well-formed (invalid token): l"
+    },
+    {
+      "operation": "ListDistributions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListDistributionsByAnycastIpListId",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListDistributionsByCachePolicyId",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListDistributionsByConnectionFunction",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListDistributionsByConnectionMode",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListDistributionsByKeyGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListDistributionsByOriginRequestPolicyId",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListDistributionsByOwnedResource",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListDistributionsByRealtimeLogConfig",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListDistributionsByResponseHeadersPolicyId",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListDistributionsByTrustStore",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListDistributionsByVpcOriginId",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListDistributionsByWebACLId",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListDomainConflicts",
+      "status": "500_error",
+      "message": "exception: Unable to parse response (not well-formed (invalid token): l"
+    },
+    {
+      "operation": "ListFieldLevelEncryptionConfigs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListFieldLevelEncryptionProfiles",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListFunctions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListInvalidations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListInvalidationsForDistributionTenant",
+      "status": "500_error",
+      "message": "exception: Unable to parse response (not well-formed (invalid token): l"
+    },
+    {
+      "operation": "ListKeyGroups",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListKeyValueStores",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListOriginAccessControls",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListOriginRequestPolicies",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListPublicKeys",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListRealtimeLogConfigs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListResponseHeadersPolicies",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListStreamingDistributions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTrustStores",
+      "status": "500_error",
+      "message": "exception: Unable to parse response (not well-formed (invalid token): l"
+    },
+    {
+      "operation": "ListVpcOrigins",
+      "status": "500_error",
+      "message": "exception: Unable to parse response (not well-formed (invalid token): l"
+    },
+    {
+      "operation": "PublishConnectionFunction",
+      "status": "500_error",
+      "message": "exception: Unable to parse response (not well-formed (invalid token): l"
+    },
+    {
+      "operation": "PublishFunction",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutResourcePolicy",
+      "status": "500_error",
+      "message": "exception: Unable to parse response (not well-formed (invalid token): l"
+    },
+    {
+      "operation": "TagResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "TestConnectionFunction",
+      "status": "500_error",
+      "message": "exception: Unable to parse response (not well-formed (invalid token): l"
+    },
+    {
+      "operation": "TestFunction",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateAnycastIpList",
+      "status": "working",
+      "message": "likely implemented (NoSuchResource: The anycast IP list probe-test-value does not exist.)"
+    },
+    {
+      "operation": "UpdateCachePolicy",
+      "status": "working",
+      "message": "likely implemented (NoSuchCachePolicy: The specified cache policy does not exist.)"
+    },
+    {
+      "operation": "UpdateCloudFrontOriginAccessIdentity",
+      "status": "working",
+      "message": "likely implemented (NoSuchCloudFrontOriginAccessIdentity: The specified origin access identity does not exist.)"
+    },
+    {
+      "operation": "UpdateConnectionFunction",
+      "status": "500_error",
+      "message": "exception: Unable to parse response (not well-formed (invalid token): l"
+    },
+    {
+      "operation": "UpdateConnectionGroup",
+      "status": "500_error",
+      "message": "exception: Unable to parse response (not well-formed (invalid token): l"
+    },
+    {
+      "operation": "UpdateContinuousDeploymentPolicy",
+      "status": "working",
+      "message": "likely implemented (NoSuchContinuousDeploymentPolicy: The specified continuous deployment policy does not exist.)"
+    },
+    {
+      "operation": "UpdateDistribution",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UpdateDistributionTenant",
+      "status": "500_error",
+      "message": "exception: Unable to parse response (not well-formed (invalid token): l"
+    },
+    {
+      "operation": "UpdateDistributionWithStagingConfig",
+      "status": "working",
+      "message": "likely implemented (NoSuchDistribution: The specified distribution does not exist.)"
+    },
+    {
+      "operation": "UpdateDomainAssociation",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateFieldLevelEncryptionConfig",
+      "status": "working",
+      "message": "likely implemented (NoSuchFieldLevelEncryptionConfig: The specified field-level encryption configuration does not )"
+    },
+    {
+      "operation": "UpdateFieldLevelEncryptionProfile",
+      "status": "working",
+      "message": "likely implemented (NoSuchFieldLevelEncryptionProfile: The specified field-level encryption profile does not exist.)"
+    },
+    {
+      "operation": "UpdateFunction",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateKeyGroup",
+      "status": "working",
+      "message": "likely implemented (NoSuchResource: The specified key group does not exist.)"
+    },
+    {
+      "operation": "UpdateKeyValueStore",
+      "status": "working",
+      "message": "likely implemented (NoSuchResource: The key value store probe-test-value does not exist.)"
+    },
+    {
+      "operation": "UpdateOriginAccessControl",
+      "status": "working",
+      "message": "likely implemented (NoSuchOriginAccessControl: The specified origin access control does not exist.)"
+    },
+    {
+      "operation": "UpdateOriginRequestPolicy",
+      "status": "working",
+      "message": "likely implemented (NoSuchOriginRequestPolicy: The specified origin request policy does not exist.)"
+    },
+    {
+      "operation": "UpdatePublicKey",
+      "status": "working",
+      "message": "likely implemented (NoSuchPublicKey: The specified public key does not exist.)"
+    },
+    {
+      "operation": "UpdateRealtimeLogConfig",
+      "status": "working",
+      "message": "likely implemented (NoSuchRealtimeLogConfig: The specified real-time log configuration does not exist.)"
+    },
+    {
+      "operation": "UpdateResponseHeadersPolicy",
+      "status": "working",
+      "message": "likely implemented (NoSuchResponseHeadersPolicy: The specified response headers policy does not exist.)"
+    },
+    {
+      "operation": "UpdateStreamingDistribution",
+      "status": "working",
+      "message": "likely implemented (NoSuchStreamingDistribution: The specified streaming distribution does not exist.)"
+    },
+    {
+      "operation": "UpdateTrustStore",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UpdateVpcOrigin",
+      "status": "500_error",
+      "message": "server crash (InternalError: Expecting value: line 1 column 1 (char 0))"
+    },
+    {
+      "operation": "VerifyDnsConfiguration",
+      "status": "500_error",
+      "message": "exception: Unable to parse response (not well-formed (invalid token): l"
+    }
+  ]
+}

--- a/probes/cloudtrail.json
+++ b/probes/cloudtrail.json
@@ -1,0 +1,311 @@
+{
+  "service": "cloudtrail",
+  "counts": {
+    "working": 30,
+    "needs_params": 7,
+    "not_implemented": 19,
+    "500_error": 4
+  },
+  "operations": [
+    {
+      "operation": "AddTags",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CancelQuery",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateChannel",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateDashboard",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateEventDataStore",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateTrail",
+      "status": "working",
+      "message": "likely implemented (S3BucketDoesNotExistException: S3 bucket probe-test-value does not exist!)"
+    },
+    {
+      "operation": "DeleteChannel",
+      "status": "working",
+      "message": "likely implemented (ChannelNotFoundException: The channel probe-test-value was not found.)"
+    },
+    {
+      "operation": "DeleteDashboard",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteEventDataStore",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteResourcePolicy",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteTrail",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeregisterOrganizationDelegatedAdmin",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeQuery",
+      "status": "working",
+      "message": "likely implemented (QueryIdNotFoundException: The query ID None was not found.)"
+    },
+    {
+      "operation": "DescribeTrails",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DisableFederation",
+      "status": "working",
+      "message": "likely implemented (EventDataStoreNotFoundException: The event data store probe-test-value was not found.)"
+    },
+    {
+      "operation": "EnableFederation",
+      "status": "working",
+      "message": "likely implemented (EventDataStoreNotFoundException: The event data store probe-test-value was not found.)"
+    },
+    {
+      "operation": "GenerateQuery",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "GetChannel",
+      "status": "working",
+      "message": "likely implemented (ChannelNotFoundException: The channel probe-test-value was not found.)"
+    },
+    {
+      "operation": "GetDashboard",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetEventConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetEventDataStore",
+      "status": "working",
+      "message": "likely implemented (EventDataStoreNotFoundException: The event data store probe-test-value was not found.)"
+    },
+    {
+      "operation": "GetEventSelectors",
+      "status": "not_implemented",
+      "message": "not implemented (TrailNotFoundException)"
+    },
+    {
+      "operation": "GetImport",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "GetInsightSelectors",
+      "status": "500_error",
+      "message": "server crash (InternalError: object of type 'NoneType' has no len())"
+    },
+    {
+      "operation": "GetQueryResults",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "GetResourcePolicy",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetTrail",
+      "status": "not_implemented",
+      "message": "not implemented (TrailNotFoundException)"
+    },
+    {
+      "operation": "GetTrailStatus",
+      "status": "not_implemented",
+      "message": "not implemented (TrailNotFoundException)"
+    },
+    {
+      "operation": "ListChannels",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListDashboards",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListEventDataStores",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListImportFailures",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "ListImports",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListInsightsData",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListInsightsMetricData",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListPublicKeys",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListQueries",
+      "status": "working",
+      "message": "likely implemented (EventDataStoreNotFoundException: The event data store probe-test-value was not found.)"
+    },
+    {
+      "operation": "ListTags",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTrails",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "LookupEvents",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "PutEventConfiguration",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "PutEventSelectors",
+      "status": "not_implemented",
+      "message": "not implemented (TrailNotFoundException)"
+    },
+    {
+      "operation": "PutInsightSelectors",
+      "status": "500_error",
+      "message": "server crash (InternalError: object of type 'NoneType' has no len())"
+    },
+    {
+      "operation": "PutResourcePolicy",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "RegisterOrganizationDelegatedAdmin",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "RemoveTags",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "RestoreEventDataStore",
+      "status": "working",
+      "message": "likely implemented (EventDataStoreNotFoundException: The event data store probe-test-value was not found.)"
+    },
+    {
+      "operation": "SearchSampleQueries",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StartDashboardRefresh",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StartEventDataStoreIngestion",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StartImport",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartLogging",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "StartQuery",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StopEventDataStoreIngestion",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StopImport",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "StopLogging",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "UpdateChannel",
+      "status": "working",
+      "message": "likely implemented (ChannelNotFoundException: The channel probe-test-value was not found.)"
+    },
+    {
+      "operation": "UpdateDashboard",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateEventDataStore",
+      "status": "working",
+      "message": "likely implemented (EventDataStoreNotFoundException: The event data store probe-test-value was not found.)"
+    },
+    {
+      "operation": "UpdateTrail",
+      "status": "not_implemented",
+      "message": "not implemented (TrailNotFoundException)"
+    }
+  ]
+}

--- a/probes/cloudwatch.json
+++ b/probes/cloudwatch.json
@@ -1,0 +1,226 @@
+{
+  "service": "cloudwatch",
+  "counts": {
+    "working": 31,
+    "needs_params": 0,
+    "not_implemented": 12,
+    "500_error": 0
+  },
+  "operations": [
+    {
+      "operation": "DeleteAlarmMuteRule",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteAlarms",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteAnomalyDetector",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteDashboards",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteInsightRules",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteMetricStream",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeAlarmContributors",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeAlarmHistory",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeAlarms",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeAlarmsForMetric",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeAnomalyDetectors",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeInsightRules",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DisableAlarmActions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DisableInsightRules",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "EnableAlarmActions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "EnableInsightRules",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetAlarmMuteRule",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetDashboard",
+      "status": "working",
+      "message": "likely implemented (ResourceNotFound: Dashboard probe-test-value does not exist)"
+    },
+    {
+      "operation": "GetInsightRuleReport",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetMetricData",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetMetricStatistics",
+      "status": "working",
+      "message": "likely implemented (InvalidParameterCombination: Must specify either Statistics or ExtendedStatistics)"
+    },
+    {
+      "operation": "GetMetricStream",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetMetricWidgetImage",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListAlarmMuteRules",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListDashboards",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListManagedInsightRules",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListMetricStreams",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListMetrics",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutAlarmMuteRule",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "PutAnomalyDetector",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutCompositeAlarm",
+      "status": "working",
+      "message": "implemented (InvalidParameterValue)"
+    },
+    {
+      "operation": "PutDashboard",
+      "status": "working",
+      "message": "likely implemented (InvalidParameterInput: Invalid JSON in DashboardBody: Expecting value: line 1 colum)"
+    },
+    {
+      "operation": "PutInsightRule",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutManagedInsightRules",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "PutMetricAlarm",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutMetricData",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutMetricStream",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "SetAlarmState",
+      "status": "working",
+      "message": "implemented (ValidationError)"
+    },
+    {
+      "operation": "StartMetricStreams",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StopMetricStreams",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "TagResource",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    }
+  ]
+}

--- a/probes/codepipeline.json
+++ b/probes/codepipeline.json
@@ -1,0 +1,231 @@
+{
+  "service": "codepipeline",
+  "counts": {
+    "working": 41,
+    "needs_params": 0,
+    "not_implemented": 3,
+    "500_error": 0
+  },
+  "operations": [
+    {
+      "operation": "AcknowledgeJob",
+      "status": "working",
+      "message": "likely implemented (JobNotFoundException: Job with id 'probe-test-value' not found)"
+    },
+    {
+      "operation": "AcknowledgeThirdPartyJob",
+      "status": "working",
+      "message": "likely implemented (JobNotFoundException: Job with id 'probe-test-value' not found)"
+    },
+    {
+      "operation": "CreateCustomActionType",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreatePipeline",
+      "status": "working",
+      "message": "likely implemented (InvalidStructureException: CodePipeline is not authorized to perform AssumeRole on role)"
+    },
+    {
+      "operation": "DeleteCustomActionType",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeletePipeline",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteWebhook",
+      "status": "working",
+      "message": "likely implemented (WebhookNotFoundException: Webhook with name 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "DeregisterWebhookWithThirdParty",
+      "status": "working",
+      "message": "likely implemented (WebhookNotFoundException: Webhook with name 'None' does not exist)"
+    },
+    {
+      "operation": "DisableStageTransition",
+      "status": "working",
+      "message": "likely implemented (PipelineNotFoundException: Account '123456789012' does not have a pipeline with name 'p)"
+    },
+    {
+      "operation": "EnableStageTransition",
+      "status": "working",
+      "message": "likely implemented (PipelineNotFoundException: Account '123456789012' does not have a pipeline with name 'p)"
+    },
+    {
+      "operation": "GetActionType",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetJobDetails",
+      "status": "working",
+      "message": "likely implemented (JobNotFoundException: Job with id 'probe-test-value' not found)"
+    },
+    {
+      "operation": "GetPipeline",
+      "status": "working",
+      "message": "likely implemented (PipelineNotFoundException: Account '123456789012' does not have a pipeline with name 'p)"
+    },
+    {
+      "operation": "GetPipelineExecution",
+      "status": "working",
+      "message": "likely implemented (PipelineNotFoundException: Account '123456789012' does not have a pipeline with name 'p)"
+    },
+    {
+      "operation": "GetPipelineState",
+      "status": "working",
+      "message": "likely implemented (PipelineNotFoundException: Account '123456789012' does not have a pipeline with name 'p)"
+    },
+    {
+      "operation": "GetThirdPartyJobDetails",
+      "status": "working",
+      "message": "likely implemented (JobNotFoundException: Job with id 'probe-test-value' not found)"
+    },
+    {
+      "operation": "ListActionExecutions",
+      "status": "working",
+      "message": "likely implemented (PipelineNotFoundException: Account '123456789012' does not have a pipeline with name 'p)"
+    },
+    {
+      "operation": "ListActionTypes",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListDeployActionExecutionTargets",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListPipelineExecutions",
+      "status": "working",
+      "message": "likely implemented (PipelineNotFoundException: Account '123456789012' does not have a pipeline with name 'p)"
+    },
+    {
+      "operation": "ListPipelines",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListRuleExecutions",
+      "status": "working",
+      "message": "likely implemented (PipelineNotFoundException: Account '123456789012' does not have a pipeline with name 'p)"
+    },
+    {
+      "operation": "ListRuleTypes",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListWebhooks",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "OverrideStageCondition",
+      "status": "working",
+      "message": "likely implemented (PipelineNotFoundException: Account '123456789012' does not have a pipeline with name 'p)"
+    },
+    {
+      "operation": "PollForJobs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PollForThirdPartyJobs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutActionRevision",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "PutApprovalResult",
+      "status": "working",
+      "message": "likely implemented (PipelineNotFoundException: Account '123456789012' does not have a pipeline with name 'p)"
+    },
+    {
+      "operation": "PutJobFailureResult",
+      "status": "working",
+      "message": "likely implemented (JobNotFoundException: Job with id 'probe-test-value' not found)"
+    },
+    {
+      "operation": "PutJobSuccessResult",
+      "status": "working",
+      "message": "likely implemented (JobNotFoundException: Job with id 'probe-test-value' not found)"
+    },
+    {
+      "operation": "PutThirdPartyJobFailureResult",
+      "status": "working",
+      "message": "likely implemented (JobNotFoundException: Job with id 'probe-test-value' not found)"
+    },
+    {
+      "operation": "PutThirdPartyJobSuccessResult",
+      "status": "working",
+      "message": "likely implemented (JobNotFoundException: Job with id 'probe-test-value' not found)"
+    },
+    {
+      "operation": "PutWebhook",
+      "status": "working",
+      "message": "likely implemented (PipelineNotFoundException: Account '123456789012' does not have a pipeline with name 'p)"
+    },
+    {
+      "operation": "RegisterWebhookWithThirdParty",
+      "status": "working",
+      "message": "likely implemented (WebhookNotFoundException: Webhook with name 'None' does not exist)"
+    },
+    {
+      "operation": "RetryStageExecution",
+      "status": "working",
+      "message": "likely implemented (PipelineNotFoundException: Account '123456789012' does not have a pipeline with name 'p)"
+    },
+    {
+      "operation": "RollbackStage",
+      "status": "working",
+      "message": "likely implemented (PipelineNotFoundException: Account '123456789012' does not have a pipeline with name 'p)"
+    },
+    {
+      "operation": "StartPipelineExecution",
+      "status": "working",
+      "message": "likely implemented (PipelineNotFoundException: Account '123456789012' does not have a pipeline with name 'p)"
+    },
+    {
+      "operation": "StopPipelineExecution",
+      "status": "working",
+      "message": "likely implemented (PipelineNotFoundException: Account '123456789012' does not have a pipeline with name 'p)"
+    },
+    {
+      "operation": "TagResource",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateActionType",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdatePipeline",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    }
+  ]
+}

--- a/probes/comprehend.json
+++ b/probes/comprehend.json
@@ -1,0 +1,436 @@
+{
+  "service": "comprehend",
+  "counts": {
+    "working": 77,
+    "needs_params": 8,
+    "not_implemented": 0,
+    "500_error": 0
+  },
+  "operations": [
+    {
+      "operation": "BatchDetectDominantLanguage",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "BatchDetectEntities",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "BatchDetectKeyPhrases",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "BatchDetectSentiment",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "BatchDetectSyntax",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "BatchDetectTargetedSentiment",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "ClassifyDocument",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ContainsPiiEntities",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "CreateDataset",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "CreateDocumentClassifier",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateEndpoint",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateEntityRecognizer",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateFlywheel",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteDocumentClassifier",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteEndpoint",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteEntityRecognizer",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteFlywheel",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteResourcePolicy",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeDataset",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeDocumentClassificationJob",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeDocumentClassifier",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeDominantLanguageDetectionJob",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeEndpoint",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeEntitiesDetectionJob",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeEntityRecognizer",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeEventsDetectionJob",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeFlywheel",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeFlywheelIteration",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeKeyPhrasesDetectionJob",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribePiiEntitiesDetectionJob",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeResourcePolicy",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeSentimentDetectionJob",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeTargetedSentimentDetectionJob",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeTopicsDetectionJob",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DetectDominantLanguage",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DetectEntities",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DetectKeyPhrases",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DetectPiiEntities",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DetectSentiment",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DetectSyntax",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DetectTargetedSentiment",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DetectToxicContent",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "ImportModel",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListDatasets",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListDocumentClassificationJobs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListDocumentClassifierSummaries",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListDocumentClassifiers",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListDominantLanguageDetectionJobs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListEndpoints",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListEntitiesDetectionJobs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListEntityRecognizerSummaries",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListEntityRecognizers",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListEventsDetectionJobs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListFlywheelIterationHistory",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListFlywheels",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListKeyPhrasesDetectionJobs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListPiiEntitiesDetectionJobs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListSentimentDetectionJobs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTargetedSentimentDetectionJobs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTopicsDetectionJobs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutResourcePolicy",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartDocumentClassificationJob",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartDominantLanguageDetectionJob",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartEntitiesDetectionJob",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartEventsDetectionJob",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "StartFlywheelIteration",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "StartKeyPhrasesDetectionJob",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartPiiEntitiesDetectionJob",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartSentimentDetectionJob",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartTargetedSentimentDetectionJob",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartTopicsDetectionJob",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StopDominantLanguageDetectionJob",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "StopEntitiesDetectionJob",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "StopEventsDetectionJob",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "StopKeyPhrasesDetectionJob",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "StopPiiEntitiesDetectionJob",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "StopSentimentDetectionJob",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "StopTargetedSentimentDetectionJob",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "StopTrainingDocumentClassifier",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "StopTrainingEntityRecognizer",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "TagResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateEndpoint",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateFlywheel",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    }
+  ]
+}

--- a/probes/config.json
+++ b/probes/config.json
@@ -1,0 +1,496 @@
+{
+  "service": "config",
+  "counts": {
+    "working": 77,
+    "needs_params": 9,
+    "not_implemented": 10,
+    "500_error": 1
+  },
+  "operations": [
+    {
+      "operation": "AssociateResourceTypes",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "BatchGetAggregateResourceConfig",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "BatchGetResourceConfig",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DeleteAggregationAuthorization",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteConfigRule",
+      "status": "working",
+      "message": "likely implemented (NoSuchConfigRuleException: The ConfigRule provided in the request is invalid. Please ch)"
+    },
+    {
+      "operation": "DeleteConfigurationAggregator",
+      "status": "working",
+      "message": "likely implemented (NoSuchConfigurationAggregatorException: The configuration aggregator does not exist. Check the confi)"
+    },
+    {
+      "operation": "DeleteConfigurationRecorder",
+      "status": "working",
+      "message": "likely implemented (NoSuchConfigurationRecorderException: Cannot find configuration recorder with the specified name ')"
+    },
+    {
+      "operation": "DeleteConformancePack",
+      "status": "working",
+      "message": "likely implemented (NoSuchConformancePackException: One or more conformance packs with specified names are not p)"
+    },
+    {
+      "operation": "DeleteDeliveryChannel",
+      "status": "working",
+      "message": "likely implemented (NoSuchDeliveryChannelException: Cannot find delivery channel with specified name 'probe-test)"
+    },
+    {
+      "operation": "DeleteEvaluationResults",
+      "status": "working",
+      "message": "likely implemented (NoSuchConfigRuleException: The ConfigRule 'probe-test-value' provided in the request is)"
+    },
+    {
+      "operation": "DeleteOrganizationConfigRule",
+      "status": "working",
+      "message": "likely implemented (NoSuchOrganizationConfigRuleException: Could not find an OrganizationConfigRule for given request w)"
+    },
+    {
+      "operation": "DeleteOrganizationConformancePack",
+      "status": "working",
+      "message": "likely implemented (NoSuchOrganizationConformancePackException: Could not find an OrganizationConformancePack for given requ)"
+    },
+    {
+      "operation": "DeletePendingAggregationRequest",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteRemediationConfiguration",
+      "status": "working",
+      "message": "likely implemented (NoSuchRemediationConfigurationException: No remediation configuration found for the config rule: 'pro)"
+    },
+    {
+      "operation": "DeleteRemediationExceptions",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DeleteResourceConfig",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteRetentionConfiguration",
+      "status": "working",
+      "message": "likely implemented (NoSuchRetentionConfigurationException: Cannot find retention configuration with the specified name )"
+    },
+    {
+      "operation": "DeleteServiceLinkedConfigurationRecorder",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteStoredQuery",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeliverConfigSnapshot",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeAggregateComplianceByConfigRules",
+      "status": "working",
+      "message": "likely implemented (NoSuchConfigurationAggregatorException: The configuration aggregator does not exist. Check the confi)"
+    },
+    {
+      "operation": "DescribeAggregateComplianceByConformancePacks",
+      "status": "working",
+      "message": "likely implemented (NoSuchConfigurationAggregatorException: The configuration aggregator does not exist. Check the confi)"
+    },
+    {
+      "operation": "DescribeAggregationAuthorizations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeComplianceByConfigRule",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeComplianceByResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeConfigRuleEvaluationStatus",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeConfigRules",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeConfigurationAggregatorSourcesStatus",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeConfigurationAggregators",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeConfigurationRecorderStatus",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeConfigurationRecorders",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeConformancePackCompliance",
+      "status": "working",
+      "message": "likely implemented (NoSuchConformancePackException: One or more conformance packs with specified names are not p)"
+    },
+    {
+      "operation": "DescribeConformancePackStatus",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeConformancePacks",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeDeliveryChannelStatus",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeDeliveryChannels",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeOrganizationConfigRuleStatuses",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeOrganizationConfigRules",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeOrganizationConformancePackStatuses",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeOrganizationConformancePacks",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribePendingAggregationRequests",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeRemediationConfigurations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeRemediationExceptions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeRemediationExecutionStatus",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeRetentionConfigurations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DisassociateResourceTypes",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetAggregateComplianceDetailsByConfigRule",
+      "status": "working",
+      "message": "likely implemented (NoSuchConfigurationAggregatorException: The configuration aggregator does not exist. Check the confi)"
+    },
+    {
+      "operation": "GetAggregateConfigRuleComplianceSummary",
+      "status": "working",
+      "message": "likely implemented (NoSuchConfigurationAggregatorException: The configuration aggregator does not exist. Check the confi)"
+    },
+    {
+      "operation": "GetAggregateConformancePackComplianceSummary",
+      "status": "working",
+      "message": "likely implemented (NoSuchConfigurationAggregatorException: The configuration aggregator does not exist. Check the confi)"
+    },
+    {
+      "operation": "GetAggregateDiscoveredResourceCounts",
+      "status": "working",
+      "message": "likely implemented (NoSuchConfigurationAggregatorException: The configuration aggregator does not exist. Check the confi)"
+    },
+    {
+      "operation": "GetAggregateResourceConfig",
+      "status": "working",
+      "message": "likely implemented (NoSuchConfigurationAggregatorException: The configuration aggregator does not exist. Check the confi)"
+    },
+    {
+      "operation": "GetComplianceDetailsByConfigRule",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetComplianceDetailsByResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetComplianceSummaryByConfigRule",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetComplianceSummaryByResourceType",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetConformancePackComplianceDetails",
+      "status": "working",
+      "message": "likely implemented (NoSuchConformancePackException: One or more conformance packs with specified names are not p)"
+    },
+    {
+      "operation": "GetConformancePackComplianceSummary",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "GetCustomRulePolicy",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetDiscoveredResourceCounts",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetOrganizationConfigRuleDetailedStatus",
+      "status": "working",
+      "message": "likely implemented (NoSuchOrganizationConfigRuleException: One or more organization config rules with specified names a)"
+    },
+    {
+      "operation": "GetOrganizationConformancePackDetailedStatus",
+      "status": "working",
+      "message": "likely implemented (NoSuchOrganizationConformancePackException: One or more organization conformance packs with specified na)"
+    },
+    {
+      "operation": "GetOrganizationCustomRulePolicy",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetResourceConfigHistory",
+      "status": "not_implemented",
+      "message": "not implemented (ResourceNotDiscoveredException)"
+    },
+    {
+      "operation": "GetResourceEvaluationSummary",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetStoredQuery",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListAggregateDiscoveredResources",
+      "status": "working",
+      "message": "likely implemented (NoSuchConfigurationAggregatorException: The configuration aggregator does not exist. Check the confi)"
+    },
+    {
+      "operation": "ListConfigurationRecorders",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListConformancePackComplianceScores",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListDiscoveredResources",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListResourceEvaluations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListStoredQueries",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "PutAggregationAuthorization",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutConfigRule",
+      "status": "500_error",
+      "message": "server crash (InternalError: 400 Bad Request: {\"__type\": \"InvalidParameterValueException\")"
+    },
+    {
+      "operation": "PutConfigurationAggregator",
+      "status": "working",
+      "message": "implemented (InvalidParameterValueException)"
+    },
+    {
+      "operation": "PutConfigurationRecorder",
+      "status": "working",
+      "message": "likely implemented (InvalidConfigurationRecorderNameException: The configuration recorder name 'None' is not valid, blank s)"
+    },
+    {
+      "operation": "PutConformancePack",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "PutDeliveryChannel",
+      "status": "working",
+      "message": "likely implemented (NoAvailableConfigurationRecorderException: Configuration recorder is not available to put delivery chan)"
+    },
+    {
+      "operation": "PutEvaluations",
+      "status": "working",
+      "message": "implemented (InvalidParameterValueException)"
+    },
+    {
+      "operation": "PutExternalEvaluation",
+      "status": "working",
+      "message": "likely implemented (NoSuchConfigRuleException: The ConfigRule 'probe-test-value' provided in the request is)"
+    },
+    {
+      "operation": "PutOrganizationConfigRule",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutOrganizationConformancePack",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "PutRemediationConfigurations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutRemediationExceptions",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "PutResourceConfig",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutRetentionConfiguration",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "PutServiceLinkedConfigurationRecorder",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "PutStoredQuery",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "SelectAggregateResourceConfig",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "SelectResourceConfig",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartConfigRulesEvaluation",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartConfigurationRecorder",
+      "status": "working",
+      "message": "likely implemented (NoSuchConfigurationRecorderException: Cannot find configuration recorder with the specified name ')"
+    },
+    {
+      "operation": "StartRemediationExecution",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "StartResourceEvaluation",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StopConfigurationRecorder",
+      "status": "working",
+      "message": "likely implemented (NoSuchConfigurationRecorderException: Cannot find configuration recorder with the specified name ')"
+    },
+    {
+      "operation": "TagResource",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    }
+  ]
+}

--- a/probes/connect.json
+++ b/probes/connect.json
@@ -1,0 +1,1841 @@
+{
+  "service": "connect",
+  "counts": {
+    "working": 170,
+    "needs_params": 22,
+    "not_implemented": 167,
+    "500_error": 7
+  },
+  "operations": [
+    {
+      "operation": "ActivateEvaluationForm",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "AssociateAnalyticsDataSet",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "AssociateApprovedOrigin",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "AssociateBot",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "AssociateContactWithUser",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "AssociateDefaultVocabulary",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "AssociateEmailAddressAlias",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "AssociateFlow",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "AssociateHoursOfOperations",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "AssociateInstanceStorageConfig",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "AssociateLambdaFunction",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "AssociateLexBot",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "AssociatePhoneNumberContactFlow",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "AssociateQueueEmailAddresses",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "AssociateQueueQuickConnects",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "AssociateRoutingProfileQueues",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'QueueConfigs')"
+    },
+    {
+      "operation": "AssociateSecurityKey",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "AssociateSecurityProfiles",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "AssociateTrafficDistributionGroupUser",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "AssociateUserProficiencies",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "AssociateWorkspace",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "BatchAssociateAnalyticsDataSet",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "BatchCreateDataTableValue",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "BatchDeleteDataTableValue",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "BatchDescribeDataTableValue",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "BatchDisassociateAnalyticsDataSet",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "BatchGetAttachedFileMetadata",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "BatchGetFlowAssociation",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "BatchPutContact",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "BatchUpdateDataTableValue",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "ClaimPhoneNumber",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "CompleteAttachedFileUpload",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateAgentStatus",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "CreateContact",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "CreateContactFlow",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "CreateContactFlowModule",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "CreateContactFlowModuleAlias",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateContactFlowModuleVersion",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateContactFlowVersion",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateDataTable",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateDataTableAttribute",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateEmailAddress",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateEvaluationForm",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "CreateHoursOfOperation",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "CreateHoursOfOperationOverride",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "CreateInstance",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateIntegrationAssociation",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "CreateNotification",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateParticipant",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreatePersistentContactAssociation",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreatePredefinedAttribute",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'Values')"
+    },
+    {
+      "operation": "CreatePrompt",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "CreatePushNotificationRegistration",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateQueue",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "CreateQuickConnect",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "CreateRoutingProfile",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "CreateRule",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "CreateSecurityProfile",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "CreateTaskTemplate",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "CreateTestCase",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateTrafficDistributionGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateUseCase",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "CreateUser",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateUserHierarchyGroup",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "CreateView",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "CreateViewVersion",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateVocabulary",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "CreateWorkspace",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateWorkspacePage",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeactivateEvaluationForm",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteAttachedFile",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteContactEvaluation",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteContactFlow",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteContactFlowModule",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteContactFlowModuleAlias",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteContactFlowModuleVersion",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteContactFlowVersion",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteDataTable",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteDataTableAttribute",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteEmailAddress",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteEvaluationForm",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteHoursOfOperation",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteHoursOfOperationOverride",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteInstance",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteIntegrationAssociation",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteNotification",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeletePredefinedAttribute",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeletePrompt",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeletePushNotificationRegistration",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteQuickConnect",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteRoutingProfile",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteRule",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteSecurityProfile",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteTaskTemplate",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteTestCase",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteTrafficDistributionGroup",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteUseCase",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteUser",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteUserHierarchyGroup",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteView",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteViewVersion",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteVocabulary",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteWorkspace",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteWorkspaceMedia",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteWorkspacePage",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeAgentStatus",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeAuthenticationProfile",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeContact",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeContactEvaluation",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeContactFlow",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeContactFlowModule",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeContactFlowModuleAlias",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeDataTable",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeDataTableAttribute",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeEmailAddress",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeEvaluationForm",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeHoursOfOperation",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeHoursOfOperationOverride",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeInstance",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeInstanceAttribute",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeInstanceStorageConfig",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeNotification",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribePhoneNumber",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribePredefinedAttribute",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribePrompt",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeQueue",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeQuickConnect",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeRoutingProfile",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeRule",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeSecurityProfile",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeTestCase",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeTrafficDistributionGroup",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeUser",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeUserHierarchyGroup",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeUserHierarchyStructure",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeView",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeVocabulary",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeWorkspace",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DisassociateAnalyticsDataSet",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DisassociateApprovedOrigin",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DisassociateBot",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DisassociateEmailAddressAlias",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DisassociateFlow",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DisassociateHoursOfOperations",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DisassociateInstanceStorageConfig",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DisassociateLambdaFunction",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DisassociateLexBot",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DisassociatePhoneNumberContactFlow",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DisassociateQueueEmailAddresses",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DisassociateQueueQuickConnects",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DisassociateRoutingProfileQueues",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'QueueReferences')"
+    },
+    {
+      "operation": "DisassociateSecurityKey",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DisassociateSecurityProfiles",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DisassociateTrafficDistributionGroupUser",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DisassociateUserProficiencies",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DisassociateWorkspace",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DismissUserContact",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "EvaluateDataTableValues",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetAttachedFile",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetContactAttributes",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetContactMetrics",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "GetCurrentMetricData",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetCurrentUserData",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetEffectiveHoursOfOperations",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetFederationToken",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetFlowAssociation",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetMetricData",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetMetricDataV2",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "GetPromptFile",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetTaskTemplate",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetTestCaseExecutionSummary",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetTrafficDistribution",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ImportPhoneNumber",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ImportWorkspaceMedia",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListAgentStatuses",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListAnalyticsDataAssociations",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListAnalyticsDataLakeDataSets",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListApprovedOrigins",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListAssociatedContacts",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListAuthenticationProfiles",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListBots",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListChildHoursOfOperations",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListContactEvaluations",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListContactFlowModuleAliases",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListContactFlowModuleVersions",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListContactFlowModules",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListContactFlowVersions",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListContactFlows",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListContactReferences",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListDataTableAttributes",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListDataTablePrimaryValues",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListDataTableValues",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListDataTables",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListDefaultVocabularies",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListEntitySecurityProfiles",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListEvaluationFormVersions",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListEvaluationForms",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListFlowAssociations",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListHoursOfOperationOverrides",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListHoursOfOperations",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListInstanceAttributes",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListInstanceStorageConfigs",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListInstances",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListIntegrationAssociations",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListLambdaFunctions",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListLexBots",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListNotifications",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListPhoneNumbers",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListPhoneNumbersV2",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListPredefinedAttributes",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListPrompts",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListQueueEmailAddresses",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListQueueQuickConnects",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListQueues",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListQuickConnects",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListRealtimeContactAnalysisSegmentsV2",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListRoutingProfileManualAssignmentQueues",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListRoutingProfileQueues",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListRoutingProfiles",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListRules",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListSecurityKeys",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListSecurityProfileApplications",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListSecurityProfileFlowModules",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListSecurityProfilePermissions",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListSecurityProfiles",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTaskTemplates",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListTestCaseExecutionRecords",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListTestCaseExecutions",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListTestCases",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListTrafficDistributionGroupUsers",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListTrafficDistributionGroups",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListUseCases",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListUserHierarchyGroups",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListUserNotifications",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListUserProficiencies",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListUsers",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListViewVersions",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListViews",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListWorkspaceMedia",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListWorkspacePages",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListWorkspaces",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "MonitorContact",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "PauseContact",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "PutUserStatus",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ReleasePhoneNumber",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ReplicateInstance",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ResumeContact",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ResumeContactRecording",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "SearchAgentStatuses",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "SearchAvailablePhoneNumbers",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'TargetArn')"
+    },
+    {
+      "operation": "SearchContactEvaluations",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "SearchContactFlowModules",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "SearchContactFlows",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "SearchContacts",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "SearchDataTables",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "SearchEmailAddresses",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "SearchEvaluationForms",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "SearchHoursOfOperationOverrides",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "SearchHoursOfOperations",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "SearchNotifications",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "SearchPredefinedAttributes",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "SearchPrompts",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "SearchQueues",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "SearchQuickConnects",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "SearchResourceTags",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "SearchRoutingProfiles",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "SearchSecurityProfiles",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "SearchTestCases",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "SearchUserHierarchyGroups",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "SearchUsers",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "SearchViews",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "SearchVocabularies",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "SearchWorkspaceAssociations",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "SearchWorkspaces",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "SendChatIntegrationEvent",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "SendOutboundEmail",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StartAttachedFileUpload",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StartChatContact",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StartContactEvaluation",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StartContactMediaProcessing",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StartContactRecording",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StartContactStreaming",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StartEmailContact",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StartOutboundChatContact",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StartOutboundEmailContact",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StartOutboundVoiceContact",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StartScreenSharing",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StartTaskContact",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StartTestCaseExecution",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StartWebRTCContact",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StopContact",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "StopContactMediaProcessing",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StopContactRecording",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StopContactStreaming",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StopTestCaseExecution",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "SubmitContactEvaluation",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "SuspendContactRecording",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "TagContact",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "TagResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "TransferContact",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UntagContact",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UpdateAgentStatus",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateAuthenticationProfile",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateContact",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateContactAttributes",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateContactEvaluation",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateContactFlowContent",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateContactFlowMetadata",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateContactFlowModuleAlias",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateContactFlowModuleContent",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'Content')"
+    },
+    {
+      "operation": "UpdateContactFlowModuleMetadata",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateContactFlowName",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateContactRoutingData",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateContactSchedule",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateDataTableAttribute",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateDataTableMetadata",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateDataTablePrimaryValues",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateEmailAddressMetadata",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateEvaluationForm",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateHoursOfOperation",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateHoursOfOperationOverride",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateInstanceAttribute",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateInstanceStorageConfig",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateNotificationContent",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateParticipantAuthentication",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateParticipantRoleConfig",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UpdatePhoneNumber",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdatePhoneNumberMetadata",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdatePredefinedAttribute",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'Values')"
+    },
+    {
+      "operation": "UpdatePrompt",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateQueueHoursOfOperation",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateQueueMaxContacts",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'MaxContacts')"
+    },
+    {
+      "operation": "UpdateQueueName",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateQueueOutboundCallerConfig",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateQueueOutboundEmailConfig",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateQueueStatus",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateQuickConnectConfig",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateQuickConnectName",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateRoutingProfileAgentAvailabilityTimer",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateRoutingProfileConcurrency",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateRoutingProfileDefaultOutboundQueue",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateRoutingProfileName",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateRoutingProfileQueues",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UpdateRule",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateSecurityProfile",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateTaskTemplate",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateTestCase",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateTrafficDistribution",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateUserConfig",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateUserHierarchy",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateUserHierarchyGroupName",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateUserHierarchyStructure",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateUserIdentityInfo",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateUserNotificationStatus",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateUserPhoneConfig",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateUserProficiencies",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateUserRoutingProfile",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateUserSecurityProfiles",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UpdateViewContent",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateViewMetadata",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateWorkspaceMetadata",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateWorkspacePage",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateWorkspaceTheme",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateWorkspaceVisibility",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    }
+  ]
+}

--- a/probes/connectcampaigns.json
+++ b/probes/connectcampaigns.json
@@ -1,0 +1,121 @@
+{
+  "service": "connectcampaigns",
+  "counts": {
+    "working": 12,
+    "needs_params": 4,
+    "not_implemented": 5,
+    "500_error": 1
+  },
+  "operations": [
+    {
+      "operation": "CreateCampaign",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DeleteCampaign",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "DeleteConnectInstanceConfig",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteInstanceOnboardingJob",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeCampaign",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetCampaignState",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetCampaignStateBatch",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "GetConnectInstanceConfig",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetInstanceOnboardingJobStatus",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListCampaigns",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "PauseCampaign",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "PutDialRequestBatch",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "ResumeCampaign",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "StartCampaign",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "StartInstanceOnboardingJob",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StopCampaign",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "TagResource",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateCampaignDialerConfig",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UpdateCampaignName",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateCampaignOutboundCallConfig",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    }
+  ]
+}

--- a/probes/databrew.json
+++ b/probes/databrew.json
@@ -1,0 +1,231 @@
+{
+  "service": "databrew",
+  "counts": {
+    "working": 22,
+    "needs_params": 4,
+    "not_implemented": 18,
+    "500_error": 0
+  },
+  "operations": [
+    {
+      "operation": "BatchDeleteRecipeVersion",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateDataset",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateProfileJob",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateProject",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateRecipe",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateRecipeJob",
+      "status": "working",
+      "message": "implemented (ConflictException)"
+    },
+    {
+      "operation": "CreateRuleset",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateSchedule",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteDataset",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteJob",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteProject",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteRecipeVersion",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DeleteRuleset",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Ruleset probe-test-value not found.)"
+    },
+    {
+      "operation": "DeleteSchedule",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeDataset",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeJob",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeJobRun",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeProject",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeRecipe",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeRuleset",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Ruleset probe-test-value not found.)"
+    },
+    {
+      "operation": "DescribeSchedule",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListDatasets",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListJobRuns",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListJobs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListProjects",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListRecipeVersions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListRecipes",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListRulesets",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListSchedules",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "PublishRecipe",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "SendProjectSessionAction",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StartJobRun",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StartProjectSession",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StopJobRun",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "TagResource",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UpdateDataset",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateProfileJob",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateProject",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateRecipe",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateRecipeJob",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateRuleset",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UpdateSchedule",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    }
+  ]
+}

--- a/probes/datapipeline.json
+++ b/probes/datapipeline.json
@@ -1,0 +1,106 @@
+{
+  "service": "datapipeline",
+  "counts": {
+    "working": 8,
+    "needs_params": 0,
+    "not_implemented": 0,
+    "500_error": 11
+  },
+  "operations": [
+    {
+      "operation": "ActivatePipeline",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "AddTags",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "CreatePipeline",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeactivatePipeline",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "DeletePipeline",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeObjects",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "DescribePipelines",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "EvaluateExpression",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "GetPipelineDefinition",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "ListPipelines",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PollForTask",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutPipelineDefinition",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "QueryObjects",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "RemoveTags",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "ReportTaskProgress",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ReportTaskRunnerHeartbeat",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "SetStatus",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "SetTaskStatus",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ValidatePipelineDefinition",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    }
+  ]
+}

--- a/probes/datasync.json
+++ b/probes/datasync.json
@@ -1,0 +1,276 @@
+{
+  "service": "datasync",
+  "counts": {
+    "working": 27,
+    "needs_params": 9,
+    "not_implemented": 17,
+    "500_error": 0
+  },
+  "operations": [
+    {
+      "operation": "CancelTaskExecution",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "CreateAgent",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateLocationAzureBlob",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateLocationEfs",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateLocationFsxLustre",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateLocationFsxOntap",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateLocationFsxOpenZfs",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateLocationFsxWindows",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateLocationHdfs",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateLocationNfs",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateLocationObjectStorage",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateLocationS3",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateLocationSmb",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateTask",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "DeleteAgent",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteLocation",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "DeleteTask",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "DescribeAgent",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "DescribeLocationAzureBlob",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "DescribeLocationEfs",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "DescribeLocationFsxLustre",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "DescribeLocationFsxOntap",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "DescribeLocationFsxOpenZfs",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "DescribeLocationFsxWindows",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "DescribeLocationHdfs",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "DescribeLocationNfs",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "DescribeLocationObjectStorage",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "DescribeLocationS3",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "DescribeLocationSmb",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "DescribeTask",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "DescribeTaskExecution",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "ListAgents",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListLocations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListTaskExecutions",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListTasks",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartTaskExecution",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "TagResource",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UpdateAgent",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateLocationAzureBlob",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateLocationEfs",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateLocationFsxLustre",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateLocationFsxOntap",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateLocationFsxOpenZfs",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateLocationFsxWindows",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateLocationHdfs",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateLocationNfs",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateLocationObjectStorage",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateLocationS3",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateLocationSmb",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateTask",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "UpdateTaskExecution",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    }
+  ]
+}

--- a/probes/dms.json
+++ b/probes/dms.json
@@ -1,0 +1,606 @@
+{
+  "service": "dms",
+  "counts": {
+    "working": 114,
+    "needs_params": 2,
+    "not_implemented": 0,
+    "500_error": 3
+  },
+  "operations": [
+    {
+      "operation": "AddTagsToResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ApplyPendingMaintenanceAction",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundFault)"
+    },
+    {
+      "operation": "BatchStartRecommendations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CancelMetadataModelConversion",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CancelMetadataModelCreation",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CancelReplicationTaskAssessmentRun",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateDataMigration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateDataProvider",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateEndpoint",
+      "status": "working",
+      "message": "implemented (ValidationError)"
+    },
+    {
+      "operation": "CreateEventSubscription",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateFleetAdvisorCollector",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateInstanceProfile",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateMigrationProject",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateReplicationConfig",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateReplicationInstance",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateReplicationSubnetGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateReplicationTask",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteCertificate",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundFault)"
+    },
+    {
+      "operation": "DeleteConnection",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundFault)"
+    },
+    {
+      "operation": "DeleteDataMigration",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundFault)"
+    },
+    {
+      "operation": "DeleteDataProvider",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundFault)"
+    },
+    {
+      "operation": "DeleteEndpoint",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundFault)"
+    },
+    {
+      "operation": "DeleteEventSubscription",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteFleetAdvisorCollector",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteFleetAdvisorDatabases",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteInstanceProfile",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundFault)"
+    },
+    {
+      "operation": "DeleteMigrationProject",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundFault)"
+    },
+    {
+      "operation": "DeleteReplicationConfig",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundFault)"
+    },
+    {
+      "operation": "DeleteReplicationInstance",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundFault)"
+    },
+    {
+      "operation": "DeleteReplicationSubnetGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteReplicationTask",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundFault)"
+    },
+    {
+      "operation": "DeleteReplicationTaskAssessmentRun",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeAccountAttributes",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeApplicableIndividualAssessments",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeCertificates",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeConnections",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeConversionConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeDataMigrations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeDataProviders",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeEndpointSettings",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeEndpointTypes",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeEndpoints",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeEngineVersions",
+      "status": "500_error",
+      "message": "exception: Invalid timestamp \"\": String does not contain a date: "
+    },
+    {
+      "operation": "DescribeEventCategories",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeEventSubscriptions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeEvents",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeExtensionPackAssociations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeFleetAdvisorCollectors",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeFleetAdvisorDatabases",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeFleetAdvisorLsaAnalysis",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeFleetAdvisorSchemaObjectSummary",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeFleetAdvisorSchemas",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeInstanceProfiles",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeMetadataModel",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeMetadataModelAssessments",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeMetadataModelChildren",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeMetadataModelConversions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeMetadataModelCreations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeMetadataModelExportsAsScript",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeMetadataModelExportsToTarget",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeMetadataModelImports",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeMigrationProjects",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeOrderableReplicationInstances",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribePendingMaintenanceActions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeRecommendationLimitations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeRecommendations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeRefreshSchemasStatus",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeReplicationConfigs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeReplicationInstanceTaskLogs",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundFault)"
+    },
+    {
+      "operation": "DescribeReplicationInstances",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeReplicationSubnetGroups",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeReplicationTableStatistics",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeReplicationTaskAssessmentResults",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeReplicationTaskAssessmentRuns",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeReplicationTaskIndividualAssessments",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeReplicationTasks",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'NoneType' object is not iterable)"
+    },
+    {
+      "operation": "DescribeReplications",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeSchemas",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeTableStatistics",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundFault)"
+    },
+    {
+      "operation": "ExportMetadataModelAssessment",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetTargetSelectionRules",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ImportCertificate",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "500_error",
+      "message": "server crash (InternalError: Either ResourceArn or ResourceArnList should be specified.)"
+    },
+    {
+      "operation": "ModifyConversionConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ModifyDataMigration",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundFault)"
+    },
+    {
+      "operation": "ModifyDataProvider",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundFault)"
+    },
+    {
+      "operation": "ModifyEndpoint",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundFault)"
+    },
+    {
+      "operation": "ModifyEventSubscription",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundFault)"
+    },
+    {
+      "operation": "ModifyInstanceProfile",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundFault)"
+    },
+    {
+      "operation": "ModifyMigrationProject",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundFault)"
+    },
+    {
+      "operation": "ModifyReplicationConfig",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundFault)"
+    },
+    {
+      "operation": "ModifyReplicationInstance",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundFault)"
+    },
+    {
+      "operation": "ModifyReplicationSubnetGroup",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundFault)"
+    },
+    {
+      "operation": "ModifyReplicationTask",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundFault)"
+    },
+    {
+      "operation": "MoveReplicationTask",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundFault)"
+    },
+    {
+      "operation": "RebootReplicationInstance",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundFault)"
+    },
+    {
+      "operation": "RefreshSchemas",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ReloadReplicationTables",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ReloadTables",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundFault)"
+    },
+    {
+      "operation": "RemoveTagsFromResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "RunFleetAdvisorLsaAnalysis",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartDataMigration",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundFault)"
+    },
+    {
+      "operation": "StartExtensionPackAssociation",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartMetadataModelAssessment",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartMetadataModelConversion",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartMetadataModelCreation",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "StartMetadataModelExportAsScript",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartMetadataModelExportToTarget",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartMetadataModelImport",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartRecommendations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartReplication",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundFault)"
+    },
+    {
+      "operation": "StartReplicationTask",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundFault)"
+    },
+    {
+      "operation": "StartReplicationTaskAssessment",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundFault)"
+    },
+    {
+      "operation": "StartReplicationTaskAssessmentRun",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundFault)"
+    },
+    {
+      "operation": "StopDataMigration",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundFault)"
+    },
+    {
+      "operation": "StopReplication",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundFault)"
+    },
+    {
+      "operation": "StopReplicationTask",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundFault)"
+    },
+    {
+      "operation": "TestConnection",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundFault)"
+    },
+    {
+      "operation": "UpdateSubscriptionsToEventBridge",
+      "status": "working",
+      "message": "OK"
+    }
+  ]
+}

--- a/probes/ds.json
+++ b/probes/ds.json
@@ -1,0 +1,411 @@
+{
+  "service": "ds",
+  "counts": {
+    "working": 72,
+    "needs_params": 1,
+    "not_implemented": 5,
+    "500_error": 2
+  },
+  "operations": [
+    {
+      "operation": "AcceptSharedDirectory",
+      "status": "working",
+      "message": "likely implemented (EntityDoesNotExistException: Shared directory probe-test-value does not exist)"
+    },
+    {
+      "operation": "AddIpRoutes",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "AddRegion",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "AddTagsToResource",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "CancelSchemaExtension",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "ConnectDirectory",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'CustomerDnsIps')"
+    },
+    {
+      "operation": "CreateAlias",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "CreateComputer",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "CreateConditionalForwarder",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "CreateDirectory",
+      "status": "working",
+      "message": "implemented (InvalidParameterException)"
+    },
+    {
+      "operation": "CreateHybridAD",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateLogSubscription",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "CreateMicrosoftAD",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "CreateSnapshot",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "CreateTrust",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DeleteADAssessment",
+      "status": "working",
+      "message": "likely implemented (EntityDoesNotExistException: Assessment probe-test-value does not exist)"
+    },
+    {
+      "operation": "DeleteConditionalForwarder",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DeleteDirectory",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DeleteLogSubscription",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DeleteSnapshot",
+      "status": "working",
+      "message": "likely implemented (EntityDoesNotExistException: Snapshot probe-test-value does not exist)"
+    },
+    {
+      "operation": "DeleteTrust",
+      "status": "working",
+      "message": "likely implemented (EntityDoesNotExistException: Trust probe-test-value does not exist)"
+    },
+    {
+      "operation": "DeregisterCertificate",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DeregisterEventTopic",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DescribeADAssessment",
+      "status": "working",
+      "message": "likely implemented (EntityDoesNotExistException: Assessment probe-test-value does not exist)"
+    },
+    {
+      "operation": "DescribeCAEnrollmentPolicy",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DescribeCertificate",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DescribeClientAuthenticationSettings",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DescribeConditionalForwarders",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DescribeDirectories",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeDirectoryDataAccess",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DescribeDomainControllers",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DescribeEventTopics",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeHybridADUpdate",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeLDAPSSettings",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DescribeRegions",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DescribeSettings",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DescribeSharedDirectories",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DescribeSnapshots",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeTrusts",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeUpdateDirectory",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DisableCAEnrollmentPolicy",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DisableClientAuthentication",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DisableDirectoryDataAccess",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DisableLDAPS",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DisableRadius",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DisableSso",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "EnableCAEnrollmentPolicy",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "EnableClientAuthentication",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "EnableDirectoryDataAccess",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "EnableLDAPS",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "EnableRadius",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "EnableSso",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "GetDirectoryLimits",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetSnapshotLimits",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "ListADAssessments",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListCertificates",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "ListIpRoutes",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "ListLogSubscriptions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListSchemaExtensions",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "RegisterCertificate",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "RegisterEventTopic",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "RejectSharedDirectory",
+      "status": "working",
+      "message": "likely implemented (EntityDoesNotExistException: Shared directory probe-test-value does not exist)"
+    },
+    {
+      "operation": "RemoveIpRoutes",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "RemoveRegion",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "RemoveTagsFromResource",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "ResetUserPassword",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "RestoreFromSnapshot",
+      "status": "working",
+      "message": "likely implemented (EntityDoesNotExistException: Snapshot probe-test-value does not exist)"
+    },
+    {
+      "operation": "ShareDirectory",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "StartADAssessment",
+      "status": "500_error",
+      "message": "server crash (InternalError: expected string or bytes-like object, got 'NoneType')"
+    },
+    {
+      "operation": "StartSchemaExtension",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "UnshareDirectory",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "UpdateConditionalForwarder",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "UpdateDirectorySetup",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "UpdateHybridAD",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateNumberOfDomainControllers",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UpdateRadius",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "UpdateSettings",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "UpdateTrust",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "VerifyTrust",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    }
+  ]
+}

--- a/probes/dsql.json
+++ b/probes/dsql.json
@@ -1,0 +1,66 @@
+{
+  "service": "dsql",
+  "counts": {
+    "working": 4,
+    "needs_params": 0,
+    "not_implemented": 7,
+    "500_error": 0
+  },
+  "operations": [
+    {
+      "operation": "CreateCluster",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteClusterPolicy",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetCluster",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetClusterPolicy",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetVpcEndpointServiceName",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListClusters",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "PutClusterPolicy",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "TagResource",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateCluster",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    }
+  ]
+}

--- a/probes/dynamodb.json
+++ b/probes/dynamodb.json
@@ -1,0 +1,291 @@
+{
+  "service": "dynamodb",
+  "counts": {
+    "working": 37,
+    "needs_params": 5,
+    "not_implemented": 9,
+    "500_error": 5
+  },
+  "operations": [
+    {
+      "operation": "BatchExecuteStatement",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "BatchGetItem",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "BatchWriteItem",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateBackup",
+      "status": "working",
+      "message": "implemented (TableNotFoundException)"
+    },
+    {
+      "operation": "CreateGlobalTable",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateTable",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'KeySchema')"
+    },
+    {
+      "operation": "DeleteBackup",
+      "status": "working",
+      "message": "likely implemented (BackupNotFoundException: Backup not found: arn:aws:dynamodb:us-east-1:123456789012:th)"
+    },
+    {
+      "operation": "DeleteItem",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteResourcePolicy",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeBackup",
+      "status": "working",
+      "message": "likely implemented (BackupNotFoundException: Backup not found: arn:aws:dynamodb:us-east-1:123456789012:th)"
+    },
+    {
+      "operation": "DescribeContinuousBackups",
+      "status": "working",
+      "message": "implemented (TableNotFoundException)"
+    },
+    {
+      "operation": "DescribeContributorInsights",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeEndpoints",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeExport",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'arn:aws:dynamodb:us-east-1:123456789012:thing/probe-test')"
+    },
+    {
+      "operation": "DescribeGlobalTable",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeGlobalTableSettings",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeImport",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'arn:aws:dynamodb:us-east-1:123456789012:thing/probe-test')"
+    },
+    {
+      "operation": "DescribeKinesisStreamingDestination",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeLimits",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeTable",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeTableReplicaAutoScaling",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeTimeToLive",
+      "status": "working",
+      "message": "likely implemented (ResourceNotFound: Table not found)"
+    },
+    {
+      "operation": "DisableKinesisStreamingDestination",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "EnableKinesisStreamingDestination",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ExecuteStatement",
+      "status": "500_error",
+      "message": "server crash (InternalError: cannot unpack non-iterable NoneType object)"
+    },
+    {
+      "operation": "ExecuteTransaction",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "ExportTableToPointInTime",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'S3Prefix')"
+    },
+    {
+      "operation": "GetItem",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetResourcePolicy",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ImportTable",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "ListBackups",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListContributorInsights",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListExports",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListGlobalTables",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListImports",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTables",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTagsOfResource",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "PutItem",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "PutResourcePolicy",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "Query",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "RestoreTableFromBackup",
+      "status": "working",
+      "message": "likely implemented (BackupNotFoundException: Backup not found: arn:aws:dynamodb:us-east-1:123456789012:th)"
+    },
+    {
+      "operation": "RestoreTableToPointInTime",
+      "status": "working",
+      "message": "likely implemented (SourceTableNotFoundException: Source table not found: None)"
+    },
+    {
+      "operation": "Scan",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "TagResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "TransactGetItems",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "TransactWriteItems",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateContinuousBackups",
+      "status": "working",
+      "message": "implemented (TableNotFoundException)"
+    },
+    {
+      "operation": "UpdateContributorInsights",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateGlobalTable",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateGlobalTableSettings",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateItem",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateKinesisStreamingDestination",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateTable",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateTableReplicaAutoScaling",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateTimeToLive",
+      "status": "working",
+      "message": "likely implemented (ResourceNotFound: Table not found)"
+    }
+  ]
+}

--- a/probes/ec2.json
+++ b/probes/ec2.json
@@ -1,0 +1,3771 @@
+{
+  "service": "ec2",
+  "counts": {
+    "working": 449,
+    "needs_params": 6,
+    "not_implemented": 278,
+    "500_error": 19
+  },
+  "operations": [
+    {
+      "operation": "AcceptAddressTransfer",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "AcceptCapacityReservationBillingOwnership",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "AcceptReservedInstancesExchangeQuote",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "AcceptTransitGatewayMulticastDomainAssociations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "AcceptTransitGatewayPeeringAttachment",
+      "status": "working",
+      "message": "likely implemented (InvalidTransitGatewayAttachmentID.NotFound: The transitGatewayAttachment ID 'probe-test-value' does not )"
+    },
+    {
+      "operation": "AcceptTransitGatewayVpcAttachment",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "AcceptVpcEndpointConnections",
+      "status": "working",
+      "message": "likely implemented (InvalidVpcEndpointServiceId.NotFound: The VpcEndpointService Id 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "AcceptVpcPeeringConnection",
+      "status": "working",
+      "message": "likely implemented (InvalidVpcPeeringConnectionId.NotFound: VpcPeeringConnectionID probe-test-value does not exist.)"
+    },
+    {
+      "operation": "AdvertiseByoipCidr",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "AllocateAddress",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "AllocateHosts",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'NoneType' object cannot be interpreted as an integer)"
+    },
+    {
+      "operation": "AllocateIpamPoolCidr",
+      "status": "500_error",
+      "message": "server crash (InternalError: cannot import name 'InvalidIpamPoolIdError' from 'moto.ec2.e)"
+    },
+    {
+      "operation": "ApplySecurityGroupsToClientVpnTargetNetwork",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "AssignIpv6Addresses",
+      "status": "working",
+      "message": "likely implemented (InvalidNetworkInterfaceID.NotFound: The networkInterface ID 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "AssignPrivateIpAddresses",
+      "status": "working",
+      "message": "likely implemented (InvalidNetworkInterfaceID.NotFound: The networkInterface ID 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "AssignPrivateNatGatewayAddress",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "AssociateAddress",
+      "status": "working",
+      "message": "implemented (MissingParameter)"
+    },
+    {
+      "operation": "AssociateCapacityReservationBillingOwner",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "AssociateClientVpnTargetNetwork",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "AssociateDhcpOptions",
+      "status": "working",
+      "message": "likely implemented (InvalidVpcID.NotFound: VpcID probe-test-value does not exist.)"
+    },
+    {
+      "operation": "AssociateEnclaveCertificateIamRole",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "AssociateIamInstanceProfile",
+      "status": "working",
+      "message": "likely implemented (InvalidInstanceID.NotFound: The instance ID 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "AssociateInstanceEventWindow",
+      "status": "working",
+      "message": "likely implemented (InvalidInstanceEventWindowId.NotFound: The instance event window ID 'probe-test-value' does not exi)"
+    },
+    {
+      "operation": "AssociateIpamByoasn",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "AssociateIpamResourceDiscovery",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "AssociateNatGatewayAddress",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "AssociateRouteServer",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "AssociateRouteTable",
+      "status": "working",
+      "message": "likely implemented (InvalidRouteTableID.NotFound: The routeTable ID 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "AssociateSecurityGroupVpc",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "AssociateSubnetCidrBlock",
+      "status": "working",
+      "message": "likely implemented (InvalidSubnetID.NotFound: The subnet ID 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "AssociateTransitGatewayMulticastDomain",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "AssociateTransitGatewayPolicyTable",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "AssociateTransitGatewayRouteTable",
+      "status": "working",
+      "message": "likely implemented (InvalidTransitGatewayAttachmentID.NotFound: The transitGatewayAttachment ID 'probe-test-value' does not )"
+    },
+    {
+      "operation": "AssociateTrunkInterface",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "AssociateVpcCidrBlock",
+      "status": "working",
+      "message": "likely implemented (InvalidVpcID.NotFound: VpcID probe-test-value does not exist.)"
+    },
+    {
+      "operation": "AttachClassicLinkVpc",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "AttachInternetGateway",
+      "status": "working",
+      "message": "likely implemented (InvalidInternetGatewayID.NotFound: InternetGatewayID probe-test-value does not exist.)"
+    },
+    {
+      "operation": "AttachNetworkInterface",
+      "status": "working",
+      "message": "likely implemented (InvalidNetworkInterfaceID.NotFound: The networkInterface ID 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "AttachVerifiedAccessTrustProvider",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "AttachVolume",
+      "status": "working",
+      "message": "likely implemented (InvalidVolume.NotFound: The volume 'probe-test-value' does not exist.)"
+    },
+    {
+      "operation": "AttachVpnGateway",
+      "status": "working",
+      "message": "likely implemented (InvalidVpnGatewayID.NotFound: The virtual private gateway ID 'probe-test-value' does not e)"
+    },
+    {
+      "operation": "AuthorizeClientVpnIngress",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "AuthorizeSecurityGroupEgress",
+      "status": "working",
+      "message": "likely implemented (InvalidGroup.NotFound: The security group 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "AuthorizeSecurityGroupIngress",
+      "status": "working",
+      "message": "likely implemented (InvalidGroup.NotFound: The security group 'None' does not exist)"
+    },
+    {
+      "operation": "BundleInstance",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CancelBundleTask",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CancelCapacityReservation",
+      "status": "working",
+      "message": "likely implemented (InvalidCapacityReservationId.NotFound: The capacity reservation ID 'probe-test-value' does not exis)"
+    },
+    {
+      "operation": "CancelCapacityReservationFleets",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CancelConversionTask",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CancelDeclarativePoliciesReport",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CancelExportTask",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CancelImageLaunchPermission",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CancelImportTask",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CancelReservedInstancesListing",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CancelSpotFleetRequests",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CancelSpotInstanceRequests",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ConfirmProductInstance",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CopyFpgaImage",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CopyImage",
+      "status": "working",
+      "message": "likely implemented (InvalidAMIID.Malformed: Invalid id: \"probe-test-value\" (expecting \"ami-...\"))"
+    },
+    {
+      "operation": "CopySnapshot",
+      "status": "working",
+      "message": "likely implemented (InvalidSnapshot.NotFound: )"
+    },
+    {
+      "operation": "CopyVolumes",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateCapacityManagerDataExport",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateCapacityReservation",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateCapacityReservationBySplitting",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateCapacityReservationFleet",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateCarrierGateway",
+      "status": "working",
+      "message": "likely implemented (InvalidVpcID.NotFound: VpcID probe-test-value does not exist.)"
+    },
+    {
+      "operation": "CreateClientVpnEndpoint",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateClientVpnRoute",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateCoipCidr",
+      "status": "working",
+      "message": "likely implemented (InvalidCoipPoolId.NotFound: The coip pool ID 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "CreateCoipPool",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateCustomerGateway",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateDefaultSubnet",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateDefaultVpc",
+      "status": "working",
+      "message": "likely implemented (DefaultVpcAlreadyExists: A Default VPC already exists for this account in this region)"
+    },
+    {
+      "operation": "CreateDelegateMacVolumeOwnershipTask",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateDhcpOptions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateEgressOnlyInternetGateway",
+      "status": "working",
+      "message": "likely implemented (InvalidVpcID.NotFound: VpcID probe-test-value does not exist.)"
+    },
+    {
+      "operation": "CreateFleet",
+      "status": "500_error",
+      "message": "server crash (InternalError: list index out of range)"
+    },
+    {
+      "operation": "CreateFlowLogs",
+      "status": "working",
+      "message": "implemented (MissingParameter)"
+    },
+    {
+      "operation": "CreateFpgaImage",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateImage",
+      "status": "working",
+      "message": "likely implemented (InvalidInstanceID.NotFound: The instance ID 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "CreateImageUsageReport",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateInstanceConnectEndpoint",
+      "status": "working",
+      "message": "likely implemented (InvalidSubnetID.NotFound: The subnet ID 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "CreateInstanceEventWindow",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateInstanceExportTask",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateInternetGateway",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateInterruptibleCapacityReservationAllocation",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateIpam",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateIpamExternalResourceVerificationToken",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateIpamPolicy",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateIpamPool",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateIpamPrefixListResolver",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateIpamPrefixListResolverTarget",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateIpamResourceDiscovery",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateIpamScope",
+      "status": "working",
+      "message": "likely implemented (InvalidIpamId.NotFound: The IPAM ID 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "CreateKeyPair",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateLaunchTemplate",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateLaunchTemplateVersion",
+      "status": "500_error",
+      "message": "server crash (InternalError: cannot access local variable 'template' where it is not asso)"
+    },
+    {
+      "operation": "CreateLocalGatewayRoute",
+      "status": "working",
+      "message": "likely implemented (InvalidLocalGatewayRouteTableId.NotFound: The local gateway route table ID 'probe-test-value' does not)"
+    },
+    {
+      "operation": "CreateLocalGatewayRouteTable",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateLocalGatewayRouteTableVirtualInterfaceGroupAssociation",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateLocalGatewayRouteTableVpcAssociation",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateLocalGatewayVirtualInterface",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateLocalGatewayVirtualInterfaceGroup",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateMacSystemIntegrityProtectionModificationTask",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateManagedPrefixList",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateNatGateway",
+      "status": "working",
+      "message": "likely implemented (InvalidSubnetID.NotFound: The subnet ID 'None' does not exist)"
+    },
+    {
+      "operation": "CreateNetworkAcl",
+      "status": "working",
+      "message": "likely implemented (InvalidVpcID.NotFound: VpcID probe-test-value does not exist.)"
+    },
+    {
+      "operation": "CreateNetworkAclEntry",
+      "status": "working",
+      "message": "likely implemented (InvalidNetworkAclID.NotFound: The network acl ID 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "CreateNetworkInsightsAccessScope",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateNetworkInsightsPath",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateNetworkInterface",
+      "status": "working",
+      "message": "likely implemented (InvalidSubnetID.NotFound: The subnet ID 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "CreateNetworkInterfacePermission",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreatePlacementGroup",
+      "status": "working",
+      "message": "implemented (MissingParameter)"
+    },
+    {
+      "operation": "CreatePublicIpv4Pool",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateReplaceRootVolumeTask",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateReservedInstancesListing",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateRestoreImageTask",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateRoute",
+      "status": "working",
+      "message": "likely implemented (InvalidRouteTableID.NotFound: The routeTable ID 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "CreateRouteServer",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateRouteServerEndpoint",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateRouteServerPeer",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateRouteTable",
+      "status": "working",
+      "message": "likely implemented (InvalidVpcID.NotFound: VpcID probe-test-value does not exist.)"
+    },
+    {
+      "operation": "CreateSecondaryNetwork",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateSecondarySubnet",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateSecurityGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateSnapshot",
+      "status": "working",
+      "message": "likely implemented (InvalidVolume.NotFound: The volume 'probe-test-value' does not exist.)"
+    },
+    {
+      "operation": "CreateSnapshots",
+      "status": "working",
+      "message": "likely implemented (InvalidInstanceID.NotFound: The instance ID 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "CreateSpotDatafeedSubscription",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateStoreImageTask",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateSubnet",
+      "status": "working",
+      "message": "likely implemented (InvalidVpcID.NotFound: VpcID probe-test-value does not exist.)"
+    },
+    {
+      "operation": "CreateSubnetCidrReservation",
+      "status": "working",
+      "message": "implemented (InvalidParameterValue)"
+    },
+    {
+      "operation": "CreateTags",
+      "status": "working",
+      "message": "implemented (MissingParameter)"
+    },
+    {
+      "operation": "CreateTrafficMirrorFilter",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateTrafficMirrorFilterRule",
+      "status": "working",
+      "message": "likely implemented (InvalidTrafficMirrorFilterId.NotFound: The traffic mirror filter ID 'probe-test-value' does not exi)"
+    },
+    {
+      "operation": "CreateTrafficMirrorSession",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateTrafficMirrorTarget",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateTransitGateway",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateTransitGatewayConnect",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateTransitGatewayConnectPeer",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateTransitGatewayMeteringPolicy",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateTransitGatewayMeteringPolicyEntry",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateTransitGatewayMulticastDomain",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateTransitGatewayPeeringAttachment",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "CreateTransitGatewayPolicyTable",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateTransitGatewayPrefixListReference",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateTransitGatewayRoute",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "CreateTransitGatewayRouteTable",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateTransitGatewayRouteTableAnnouncement",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateTransitGatewayVpcAttachment",
+      "status": "working",
+      "message": "likely implemented (InvalidTransitGatewayID.NotFound: Transit Gateway probe-test-value was deleted or does not exi)"
+    },
+    {
+      "operation": "CreateVerifiedAccessEndpoint",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateVerifiedAccessGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateVerifiedAccessInstance",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateVerifiedAccessTrustProvider",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateVolume",
+      "status": "working",
+      "message": "implemented (MissingParameter)"
+    },
+    {
+      "operation": "CreateVpc",
+      "status": "working",
+      "message": "implemented (InvalidParameterValue)"
+    },
+    {
+      "operation": "CreateVpcBlockPublicAccessExclusion",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateVpcEncryptionControl",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateVpcEndpoint",
+      "status": "working",
+      "message": "likely implemented (InvalidVpcID.NotFound: VpcID probe-test-value does not exist.)"
+    },
+    {
+      "operation": "CreateVpcEndpointConnectionNotification",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateVpcEndpointServiceConfiguration",
+      "status": "working",
+      "message": "implemented (InvalidParameter)"
+    },
+    {
+      "operation": "CreateVpcPeeringConnection",
+      "status": "working",
+      "message": "likely implemented (InvalidVpcID.NotFound: VpcID probe-test-value does not exist.)"
+    },
+    {
+      "operation": "CreateVpnConcentrator",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateVpnConnection",
+      "status": "working",
+      "message": "likely implemented (InvalidCustomerGatewayID.NotFound: The customerGateway ID 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "CreateVpnConnectionRoute",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateVpnGateway",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteCapacityManagerDataExport",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteCarrierGateway",
+      "status": "working",
+      "message": "likely implemented (InvalidCarrierGatewayID.NotFound: The CarrierGateway ID 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "DeleteClientVpnEndpoint",
+      "status": "working",
+      "message": "likely implemented (InvalidClientVpnEndpointId.NotFound: The Client VPN endpoint ID 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "DeleteClientVpnRoute",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteCoipCidr",
+      "status": "working",
+      "message": "likely implemented (InvalidCoipPoolId.NotFound: The coip pool ID 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "DeleteCoipPool",
+      "status": "working",
+      "message": "likely implemented (InvalidCoipPoolId.NotFound: The coip pool ID 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "DeleteCustomerGateway",
+      "status": "working",
+      "message": "likely implemented (InvalidCustomerGatewayID.NotFound: The customerGateway ID 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "DeleteDhcpOptions",
+      "status": "working",
+      "message": "likely implemented (InvalidDhcpOptionsId.Malformed: Invalid id: \"probe-test-value\" (expecting \"dopt-...\"))"
+    },
+    {
+      "operation": "DeleteEgressOnlyInternetGateway",
+      "status": "working",
+      "message": "likely implemented (InvalidGatewayID.NotFound: The eigw ID 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "DeleteFleets",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteFlowLogs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteFpgaImage",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteImageUsageReport",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteInstanceConnectEndpoint",
+      "status": "working",
+      "message": "likely implemented (InvalidInstanceConnectEndpointId.NotFound: The instance connect endpoint ID 'probe-test-value' does not)"
+    },
+    {
+      "operation": "DeleteInstanceEventWindow",
+      "status": "working",
+      "message": "likely implemented (InvalidInstanceEventWindowId.NotFound: The instance event window ID 'probe-test-value' does not exi)"
+    },
+    {
+      "operation": "DeleteInternetGateway",
+      "status": "working",
+      "message": "likely implemented (InvalidInternetGatewayID.NotFound: InternetGatewayID probe-test-value does not exist.)"
+    },
+    {
+      "operation": "DeleteIpam",
+      "status": "working",
+      "message": "likely implemented (InvalidIpamId.NotFound: The IPAM ID 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "DeleteIpamExternalResourceVerificationToken",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteIpamPolicy",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteIpamPool",
+      "status": "500_error",
+      "message": "server crash (InternalError: cannot import name 'InvalidIpamPoolIdError' from 'moto.ec2.e)"
+    },
+    {
+      "operation": "DeleteIpamPrefixListResolver",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteIpamPrefixListResolverTarget",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteIpamResourceDiscovery",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteIpamScope",
+      "status": "working",
+      "message": "likely implemented (InvalidIpamScopeId.NotFound: The IPAM scope ID 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "DeleteKeyPair",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteLaunchTemplate",
+      "status": "working",
+      "message": "implemented (MissingParameter)"
+    },
+    {
+      "operation": "DeleteLaunchTemplateVersions",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteLocalGatewayRoute",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteLocalGatewayRouteTable",
+      "status": "working",
+      "message": "likely implemented (InvalidLocalGatewayRouteTableId.NotFound: The local gateway route table ID 'probe-test-value' does not)"
+    },
+    {
+      "operation": "DeleteLocalGatewayRouteTableVirtualInterfaceGroupAssociation",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteLocalGatewayRouteTableVpcAssociation",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteLocalGatewayVirtualInterface",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteLocalGatewayVirtualInterfaceGroup",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteManagedPrefixList",
+      "status": "working",
+      "message": "likely implemented (InvalidPrefixListID.NotFound: The prefix list ID 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "DeleteNatGateway",
+      "status": "working",
+      "message": "likely implemented (NatGatewayNotFound: The natGateway ID 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "DeleteNetworkAcl",
+      "status": "working",
+      "message": "likely implemented (InvalidNetworkAclID.NotFound: The network acl ID 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "DeleteNetworkAclEntry",
+      "status": "working",
+      "message": "likely implemented (InvalidNetworkAclID.NotFound: The network acl ID 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "DeleteNetworkInsightsAccessScope",
+      "status": "working",
+      "message": "likely implemented (InvalidNetworkInsightsAccessScopeId.NotFound: The network insights access scope ID 'probe-test-value' does)"
+    },
+    {
+      "operation": "DeleteNetworkInsightsAccessScopeAnalysis",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteNetworkInsightsAnalysis",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteNetworkInsightsPath",
+      "status": "working",
+      "message": "likely implemented (InvalidNetworkInsightsPathId.NotFound: The network insights path ID 'probe-test-value' does not exi)"
+    },
+    {
+      "operation": "DeleteNetworkInterface",
+      "status": "working",
+      "message": "likely implemented (InvalidNetworkInterfaceID.NotFound: The networkInterface ID 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "DeleteNetworkInterfacePermission",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeletePlacementGroup",
+      "status": "not_implemented",
+      "message": "not implemented (InvalidPlacementGroup.Unknown)"
+    },
+    {
+      "operation": "DeletePublicIpv4Pool",
+      "status": "working",
+      "message": "likely implemented (InvalidPublicIpv4PoolID.NotFound: The public IPv4 pool ID 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "DeleteQueuedReservedInstances",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DeleteRoute",
+      "status": "working",
+      "message": "likely implemented (InvalidRouteTableID.NotFound: The routeTable ID 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "DeleteRouteServer",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteRouteServerEndpoint",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteRouteServerPeer",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteRouteTable",
+      "status": "working",
+      "message": "likely implemented (InvalidRouteTableID.NotFound: The routeTable ID 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "DeleteSecondaryNetwork",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteSecondarySubnet",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteSnapshot",
+      "status": "working",
+      "message": "likely implemented (InvalidSnapshot.NotFound: )"
+    },
+    {
+      "operation": "DeleteSpotDatafeedSubscription",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteSubnetCidrReservation",
+      "status": "working",
+      "message": "likely implemented (InvalidSubnetCidrReservationID.NotFound: The subnet-cidr-reservation ID 'probe-test-value' does not e)"
+    },
+    {
+      "operation": "DeleteTags",
+      "status": "working",
+      "message": "implemented (MissingParameter)"
+    },
+    {
+      "operation": "DeleteTrafficMirrorFilter",
+      "status": "working",
+      "message": "likely implemented (InvalidTrafficMirrorFilterId.NotFound: The traffic mirror filter ID 'probe-test-value' does not exi)"
+    },
+    {
+      "operation": "DeleteTrafficMirrorFilterRule",
+      "status": "working",
+      "message": "likely implemented (InvalidTrafficMirrorFilterRuleId.NotFound: The traffic mirror filter rule ID 'probe-test-value' does no)"
+    },
+    {
+      "operation": "DeleteTrafficMirrorSession",
+      "status": "working",
+      "message": "likely implemented (InvalidTrafficMirrorSessionId.NotFound: The traffic mirror session ID 'probe-test-value' does not ex)"
+    },
+    {
+      "operation": "DeleteTrafficMirrorTarget",
+      "status": "working",
+      "message": "likely implemented (InvalidTrafficMirrorTargetId.NotFound: The traffic mirror target ID 'probe-test-value' does not exi)"
+    },
+    {
+      "operation": "DeleteTransitGateway",
+      "status": "working",
+      "message": "likely implemented (InvalidTransitGatewayID.NotFound: The transitGateway ID 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "DeleteTransitGatewayConnect",
+      "status": "working",
+      "message": "likely implemented (InvalidTransitGatewayAttachmentID.NotFound: The transitGatewayAttachment ID 'probe-test-value' does not )"
+    },
+    {
+      "operation": "DeleteTransitGatewayConnectPeer",
+      "status": "working",
+      "message": "likely implemented (InvalidTransitGatewayConnectPeerId.NotFound: The transitGatewayConnectPeer ID 'probe-test-value' does not)"
+    },
+    {
+      "operation": "DeleteTransitGatewayMeteringPolicy",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteTransitGatewayMeteringPolicyEntry",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteTransitGatewayMulticastDomain",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteTransitGatewayPeeringAttachment",
+      "status": "working",
+      "message": "likely implemented (InvalidTransitGatewayAttachmentID.NotFound: The transitGatewayAttachment ID 'probe-test-value' does not )"
+    },
+    {
+      "operation": "DeleteTransitGatewayPolicyTable",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteTransitGatewayPrefixListReference",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteTransitGatewayRoute",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "DeleteTransitGatewayRouteTable",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "DeleteTransitGatewayRouteTableAnnouncement",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteTransitGatewayVpcAttachment",
+      "status": "working",
+      "message": "likely implemented (InvalidTransitGatewayAttachmentID.NotFound: The transitGatewayAttachment ID 'probe-test-value' does not )"
+    },
+    {
+      "operation": "DeleteVerifiedAccessEndpoint",
+      "status": "working",
+      "message": "likely implemented (InvalidVerifiedAccessEndpointId.NotFound: The verified access endpoint ID 'probe-test-value' does not )"
+    },
+    {
+      "operation": "DeleteVerifiedAccessGroup",
+      "status": "working",
+      "message": "likely implemented (InvalidVerifiedAccessGroupId.NotFound: The verified access group ID 'probe-test-value' does not exi)"
+    },
+    {
+      "operation": "DeleteVerifiedAccessInstance",
+      "status": "working",
+      "message": "likely implemented (InvalidVerifiedAccessInstanceId.NotFound: The verified access instance ID 'probe-test-value' does not )"
+    },
+    {
+      "operation": "DeleteVerifiedAccessTrustProvider",
+      "status": "working",
+      "message": "likely implemented (InvalidVerifiedAccessTrustProviderId.NotFound: The verified access trust provider ID 'probe-test-value' doe)"
+    },
+    {
+      "operation": "DeleteVolume",
+      "status": "working",
+      "message": "likely implemented (InvalidVolume.NotFound: The volume 'probe-test-value' does not exist.)"
+    },
+    {
+      "operation": "DeleteVpcBlockPublicAccessExclusion",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteVpcEncryptionControl",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteVpcEndpointConnectionNotifications",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteVpcEndpointServiceConfigurations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteVpcEndpoints",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteVpcPeeringConnection",
+      "status": "working",
+      "message": "likely implemented (InvalidVpcPeeringConnectionId.NotFound: VpcPeeringConnectionID probe-test-value does not exist.)"
+    },
+    {
+      "operation": "DeleteVpnConcentrator",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteVpnConnection",
+      "status": "working",
+      "message": "likely implemented (InvalidVpnConnectionID.NotFound: The vpnConnection ID 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "DeleteVpnConnectionRoute",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteVpnGateway",
+      "status": "working",
+      "message": "likely implemented (InvalidVpnGatewayID.NotFound: The virtual private gateway ID 'probe-test-value' does not e)"
+    },
+    {
+      "operation": "DeprovisionByoipCidr",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeprovisionIpamByoasn",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeprovisionIpamPoolCidr",
+      "status": "500_error",
+      "message": "server crash (InternalError: cannot import name 'InvalidIpamPoolIdError' from 'moto.ec2.e)"
+    },
+    {
+      "operation": "DeprovisionPublicIpv4PoolCidr",
+      "status": "working",
+      "message": "likely implemented (InvalidPublicIpv4PoolID.NotFound: The public IPv4 pool ID 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "DeregisterImage",
+      "status": "working",
+      "message": "likely implemented (InvalidAMIID.NotFound: The image id '[probe-test-value]' does not exist)"
+    },
+    {
+      "operation": "DeregisterInstanceEventNotificationAttributes",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeregisterTransitGatewayMulticastGroupMembers",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeregisterTransitGatewayMulticastGroupSources",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeAccountAttributes",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeAddressTransfers",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeAddresses",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeAddressesAttribute",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeAggregateIdFormat",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeAvailabilityZones",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeAwsNetworkPerformanceMetricSubscriptions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeBundleTasks",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeByoipCidrs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeCapacityBlockExtensionHistory",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeCapacityBlockExtensionOfferings",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeCapacityBlockOfferings",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeCapacityBlockStatus",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeCapacityBlocks",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeCapacityManagerDataExports",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeCapacityReservationBillingRequests",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeCapacityReservationFleets",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeCapacityReservationTopology",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeCapacityReservations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeCarrierGateways",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeClassicLinkInstances",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeClientVpnAuthorizationRules",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeClientVpnConnections",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeClientVpnEndpoints",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeClientVpnRoutes",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeClientVpnTargetNetworks",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeCoipPools",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeConversionTasks",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeCustomerGateways",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeDeclarativePoliciesReports",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeDhcpOptions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeEgressOnlyInternetGateways",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeElasticGpus",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeExportImageTasks",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeExportTasks",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeFastLaunchImages",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeFastSnapshotRestores",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeFleetHistory",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeFleetInstances",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeFleets",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeFlowLogs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeFpgaImageAttribute",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeFpgaImages",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeHostReservationOfferings",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeHostReservations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeHosts",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeIamInstanceProfileAssociations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeIdFormat",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeIdentityIdFormat",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeImageAttribute",
+      "status": "working",
+      "message": "likely implemented (InvalidRequest: The request received was invalid)"
+    },
+    {
+      "operation": "DescribeImageReferences",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DescribeImageUsageReportEntries",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeImageUsageReports",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeImages",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeImportImageTasks",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeImportSnapshotTasks",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeInstanceAttribute",
+      "status": "working",
+      "message": "implemented (InvalidParameterValue)"
+    },
+    {
+      "operation": "DescribeInstanceConnectEndpoints",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeInstanceCreditSpecifications",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeInstanceEventNotificationAttributes",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeInstanceEventWindows",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeInstanceImageMetadata",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeInstanceSqlHaHistoryStates",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeInstanceSqlHaStates",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeInstanceStatus",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeInstanceTopology",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeInstanceTypeOfferings",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeInstanceTypes",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeInstances",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeInternetGateways",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeIpamByoasn",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeIpamExternalResourceVerificationTokens",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeIpamPolicies",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeIpamPools",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeIpamPrefixListResolverTargets",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeIpamPrefixListResolvers",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeIpamResourceDiscoveries",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeIpamResourceDiscoveryAssociations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeIpamScopes",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeIpams",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeIpv6Pools",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeKeyPairs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeLaunchTemplateVersions",
+      "status": "working",
+      "message": "implemented (MissingParameter)"
+    },
+    {
+      "operation": "DescribeLaunchTemplates",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeLocalGatewayRouteTableVirtualInterfaceGroupAssociations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeLocalGatewayRouteTableVpcAssociations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeLocalGatewayRouteTables",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeLocalGatewayVirtualInterfaceGroups",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeLocalGatewayVirtualInterfaces",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeLocalGateways",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeLockedSnapshots",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeMacHosts",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeMacModificationTasks",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeManagedPrefixLists",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeMovingAddresses",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeNatGateways",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeNetworkAcls",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeNetworkInsightsAccessScopeAnalyses",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeNetworkInsightsAccessScopes",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeNetworkInsightsAnalyses",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeNetworkInsightsPaths",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeNetworkInterfaceAttribute",
+      "status": "working",
+      "message": "likely implemented (InvalidNetworkInterfaceID.NotFound: The networkInterface ID 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "DescribeNetworkInterfacePermissions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeNetworkInterfaces",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeOutpostLags",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribePlacementGroups",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribePrefixLists",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribePrincipalIdFormat",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribePublicIpv4Pools",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeRegions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeReplaceRootVolumeTasks",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeReservedInstances",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeReservedInstancesListings",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeReservedInstancesModifications",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeReservedInstancesOfferings",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeRouteServerEndpoints",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeRouteServerPeers",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeRouteServers",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeRouteTables",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeScheduledInstanceAvailability",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeScheduledInstances",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeSecondaryInterfaces",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeSecondaryNetworks",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeSecondarySubnets",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeSecurityGroupReferences",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeSecurityGroupRules",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeSecurityGroupVpcAssociations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeSecurityGroups",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeServiceLinkVirtualInterfaces",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeSnapshotAttribute",
+      "status": "working",
+      "message": "likely implemented (InvalidSnapshot.NotFound: )"
+    },
+    {
+      "operation": "DescribeSnapshotTierStatus",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeSnapshots",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeSpotDatafeedSubscription",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeSpotFleetInstances",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeSpotFleetRequestHistory",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeSpotFleetRequests",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeSpotInstanceRequests",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeSpotPriceHistory",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeStaleSecurityGroups",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeStoreImageTasks",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeSubnets",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeTags",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeTrafficMirrorFilterRules",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeTrafficMirrorFilters",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeTrafficMirrorSessions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeTrafficMirrorTargets",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeTransitGatewayAttachments",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeTransitGatewayConnectPeers",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeTransitGatewayConnects",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeTransitGatewayMeteringPolicies",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeTransitGatewayMulticastDomains",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeTransitGatewayPeeringAttachments",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeTransitGatewayPolicyTables",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeTransitGatewayRouteTableAnnouncements",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeTransitGatewayRouteTables",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeTransitGatewayVpcAttachments",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeTransitGateways",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeTrunkInterfaceAssociations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeVerifiedAccessEndpoints",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeVerifiedAccessGroups",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeVerifiedAccessInstanceLoggingConfigurations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeVerifiedAccessInstances",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeVerifiedAccessTrustProviders",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeVolumeAttribute",
+      "status": "working",
+      "message": "likely implemented (InvalidVolume.NotFound: The volume 'probe-test-value' does not exist.)"
+    },
+    {
+      "operation": "DescribeVolumeStatus",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeVolumes",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeVolumesModifications",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeVpcAttribute",
+      "status": "working",
+      "message": "likely implemented (InvalidVpcID.NotFound: VpcID probe-test-value does not exist.)"
+    },
+    {
+      "operation": "DescribeVpcBlockPublicAccessExclusions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeVpcBlockPublicAccessOptions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeVpcClassicLink",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeVpcClassicLinkDnsSupport",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeVpcEncryptionControls",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeVpcEndpointAssociations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeVpcEndpointConnectionNotifications",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeVpcEndpointConnections",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeVpcEndpointServiceConfigurations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeVpcEndpointServicePermissions",
+      "status": "working",
+      "message": "likely implemented (InvalidVpcEndpointServiceId.NotFound: The VpcEndpointService Id 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "DescribeVpcEndpointServices",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeVpcEndpoints",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeVpcPeeringConnections",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeVpcs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeVpnConcentrators",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeVpnConnections",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeVpnGateways",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DetachClassicLinkVpc",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DetachInternetGateway",
+      "status": "working",
+      "message": "likely implemented (InvalidInternetGatewayID.NotFound: InternetGatewayID probe-test-value does not exist.)"
+    },
+    {
+      "operation": "DetachNetworkInterface",
+      "status": "working",
+      "message": "likely implemented (InvalidAttachmentID.NotFound: The network interface attachment ID 'probe-test-value' does )"
+    },
+    {
+      "operation": "DetachVerifiedAccessTrustProvider",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DetachVolume",
+      "status": "500_error",
+      "message": "server crash (InternalError: InvalidVolume.NotFound: The volume 'probe-test-value' does n)"
+    },
+    {
+      "operation": "DetachVpnGateway",
+      "status": "working",
+      "message": "likely implemented (InvalidVpnGatewayID.NotFound: The virtual private gateway ID 'probe-test-value' does not e)"
+    },
+    {
+      "operation": "DisableAddressTransfer",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DisableAllowedImagesSettings",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DisableAwsNetworkPerformanceMetricSubscription",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DisableCapacityManager",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DisableEbsEncryptionByDefault",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DisableFastLaunch",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DisableFastSnapshotRestores",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DisableImage",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DisableImageBlockPublicAccess",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DisableImageDeprecation",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DisableImageDeregistrationProtection",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DisableInstanceSqlHaStandbyDetections",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DisableIpamOrganizationAdminAccount",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DisableIpamPolicy",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DisableRouteServerPropagation",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DisableSerialConsoleAccess",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DisableSnapshotBlockPublicAccess",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DisableTransitGatewayRouteTablePropagation",
+      "status": "working",
+      "message": "likely implemented (InvalidTransitGatewayAttachmentID.NotFound: The transitGatewayAttachment ID 'None' does not exist)"
+    },
+    {
+      "operation": "DisableVgwRoutePropagation",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DisableVpcClassicLink",
+      "status": "working",
+      "message": "likely implemented (InvalidVpcID.NotFound: VpcID probe-test-value does not exist.)"
+    },
+    {
+      "operation": "DisableVpcClassicLinkDnsSupport",
+      "status": "working",
+      "message": "likely implemented (InvalidVpcID.NotFound: VpcID None does not exist.)"
+    },
+    {
+      "operation": "DisassociateAddress",
+      "status": "working",
+      "message": "implemented (MissingParameter)"
+    },
+    {
+      "operation": "DisassociateCapacityReservationBillingOwner",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DisassociateClientVpnTargetNetwork",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DisassociateEnclaveCertificateIamRole",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DisassociateIamInstanceProfile",
+      "status": "working",
+      "message": "likely implemented (InvalidAssociationID.NotFound: An invalid association-id of 'probe-test-value' was given)"
+    },
+    {
+      "operation": "DisassociateInstanceEventWindow",
+      "status": "working",
+      "message": "likely implemented (InvalidInstanceEventWindowId.NotFound: The instance event window ID 'probe-test-value' does not exi)"
+    },
+    {
+      "operation": "DisassociateIpamByoasn",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DisassociateIpamResourceDiscovery",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DisassociateNatGatewayAddress",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DisassociateRouteServer",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DisassociateRouteTable",
+      "status": "working",
+      "message": "likely implemented (InvalidAssociationID.NotFound: Association ID 'probe-test-value' not found.)"
+    },
+    {
+      "operation": "DisassociateSecurityGroupVpc",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DisassociateSubnetCidrBlock",
+      "status": "working",
+      "message": "likely implemented (InvalidSubnetCidrBlockAssociationID.NotFound: The subnet CIDR block with association ID 'probe-test-value')"
+    },
+    {
+      "operation": "DisassociateTransitGatewayMulticastDomain",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DisassociateTransitGatewayPolicyTable",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DisassociateTransitGatewayRouteTable",
+      "status": "working",
+      "message": "likely implemented (InvalidTransitGatewayAttachmentID.NotFound: The transitGatewayAttachment ID 'probe-test-value' does not )"
+    },
+    {
+      "operation": "DisassociateTrunkInterface",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DisassociateVpcCidrBlock",
+      "status": "working",
+      "message": "likely implemented (InvalidVpcCidrBlockAssociationIdError.NotFound: The vpc CIDR block association ID 'probe-test-value' does no)"
+    },
+    {
+      "operation": "EnableAddressTransfer",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "EnableAllowedImagesSettings",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "EnableAwsNetworkPerformanceMetricSubscription",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "EnableCapacityManager",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "EnableEbsEncryptionByDefault",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "EnableFastLaunch",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "EnableFastSnapshotRestores",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "EnableImage",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "EnableImageBlockPublicAccess",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "EnableImageDeprecation",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "EnableImageDeregistrationProtection",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "EnableInstanceSqlHaStandbyDetections",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "EnableIpamOrganizationAdminAccount",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "EnableIpamPolicy",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "EnableReachabilityAnalyzerOrganizationSharing",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "EnableRouteServerPropagation",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "EnableSerialConsoleAccess",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "EnableSnapshotBlockPublicAccess",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "EnableTransitGatewayRouteTablePropagation",
+      "status": "working",
+      "message": "likely implemented (InvalidTransitGatewayAttachmentID.NotFound: The transitGatewayAttachment ID 'None' does not exist)"
+    },
+    {
+      "operation": "EnableVgwRoutePropagation",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "EnableVolumeIO",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "EnableVpcClassicLink",
+      "status": "working",
+      "message": "likely implemented (InvalidVpcID.NotFound: VpcID probe-test-value does not exist.)"
+    },
+    {
+      "operation": "EnableVpcClassicLinkDnsSupport",
+      "status": "working",
+      "message": "likely implemented (InvalidVpcID.NotFound: VpcID None does not exist.)"
+    },
+    {
+      "operation": "ExportClientVpnClientCertificateRevocationList",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ExportClientVpnClientConfiguration",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ExportImage",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ExportTransitGatewayRoutes",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ExportVerifiedAccessInstanceClientConfiguration",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetActiveVpnTunnelStatus",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetAllowedImagesSettings",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetAssociatedEnclaveCertificateIamRoles",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetAssociatedIpv6PoolCidrs",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetAwsNetworkPerformanceData",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetCapacityManagerAttributes",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetCapacityManagerMetricData",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "GetCapacityManagerMetricDimensions",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetCapacityReservationUsage",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetCoipPoolUsage",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetConsoleOutput",
+      "status": "working",
+      "message": "likely implemented (InvalidInstanceID.NotFound: The instance ID 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "GetConsoleScreenshot",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetDeclarativePoliciesReportSummary",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetDefaultCreditSpecification",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetEbsDefaultKmsKeyId",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetEbsEncryptionByDefault",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetEnabledIpamPolicy",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetFlowLogsIntegrationTemplate",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetGroupsForCapacityReservation",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetHostReservationPurchasePreview",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetImageAncestry",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetImageBlockPublicAccessState",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetInstanceMetadataDefaults",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetInstanceTpmEkPub",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetInstanceTypesFromInstanceRequirements",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetInstanceUefiData",
+      "status": "working",
+      "message": "likely implemented (InvalidInstanceID.NotFound: The instance ID 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "GetIpamAddressHistory",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetIpamDiscoveredAccounts",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetIpamDiscoveredPublicAddresses",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetIpamDiscoveredResourceCidrs",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetIpamPolicyAllocationRules",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetIpamPolicyOrganizationTargets",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetIpamPoolAllocations",
+      "status": "500_error",
+      "message": "server crash (InternalError: cannot import name 'InvalidIpamPoolIdError' from 'moto.ec2.e)"
+    },
+    {
+      "operation": "GetIpamPoolCidrs",
+      "status": "500_error",
+      "message": "server crash (InternalError: cannot import name 'InvalidIpamPoolIdError' from 'moto.ec2.e)"
+    },
+    {
+      "operation": "GetIpamPrefixListResolverRules",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetIpamPrefixListResolverVersionEntries",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetIpamPrefixListResolverVersions",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetIpamResourceCidrs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetLaunchTemplateData",
+      "status": "working",
+      "message": "likely implemented (InvalidInstanceID.NotFound: The instance ID 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "GetManagedPrefixListAssociations",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetManagedPrefixListEntries",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetNetworkInsightsAccessScopeAnalysisFindings",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetNetworkInsightsAccessScopeContent",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetPasswordData",
+      "status": "working",
+      "message": "likely implemented (InvalidInstanceID.NotFound: The instance ID 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "GetReservedInstancesExchangeQuote",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetRouteServerAssociations",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetRouteServerPropagations",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetRouteServerRoutingDatabase",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetSecurityGroupsForVpc",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetSerialConsoleAccessStatus",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetSnapshotBlockPublicAccessState",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetSpotPlacementScores",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetSubnetCidrReservations",
+      "status": "working",
+      "message": "likely implemented (InvalidSubnetID.NotFound: The subnet ID 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "GetTransitGatewayAttachmentPropagations",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetTransitGatewayMeteringPolicyEntries",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetTransitGatewayMulticastDomainAssociations",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetTransitGatewayPolicyTableAssociations",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetTransitGatewayPolicyTableEntries",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetTransitGatewayPrefixListReferences",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetTransitGatewayRouteTableAssociations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetTransitGatewayRouteTablePropagations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetVerifiedAccessEndpointPolicy",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetVerifiedAccessEndpointTargets",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetVerifiedAccessGroupPolicy",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetVpcResourcesBlockingEncryptionEnforcement",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetVpnConnectionDeviceSampleConfiguration",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetVpnConnectionDeviceTypes",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetVpnTunnelReplacementStatus",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ImportClientVpnClientCertificateRevocationList",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ImportImage",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ImportInstance",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ImportKeyPair",
+      "status": "working",
+      "message": "likely implemented (InvalidKeyPair.Duplicate: The keypair 'probe-test-value' already exists.)"
+    },
+    {
+      "operation": "ImportSnapshot",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ImportVolume",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListImagesInRecycleBin",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListSnapshotsInRecycleBin",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListVolumesInRecycleBin",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "LockSnapshot",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ModifyAddressAttribute",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ModifyAvailabilityZoneGroup",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ModifyCapacityReservation",
+      "status": "working",
+      "message": "likely implemented (InvalidCapacityReservationId.NotFound: The capacity reservation ID 'probe-test-value' does not exis)"
+    },
+    {
+      "operation": "ModifyCapacityReservationFleet",
+      "status": "working",
+      "message": "likely implemented (InvalidCapacityReservationFleetId.NotFound: The capacity reservation fleet ID 'probe-test-value' does no)"
+    },
+    {
+      "operation": "ModifyClientVpnEndpoint",
+      "status": "working",
+      "message": "likely implemented (InvalidClientVpnEndpointId.NotFound: The Client VPN endpoint ID 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "ModifyDefaultCreditSpecification",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ModifyEbsDefaultKmsKeyId",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "ModifyFleet",
+      "status": "working",
+      "message": "likely implemented (InvalidFleetId.NotFound: The fleet ID 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "ModifyFpgaImageAttribute",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ModifyHosts",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ModifyIdFormat",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ModifyIdentityIdFormat",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ModifyImageAttribute",
+      "status": "working",
+      "message": "likely implemented (InvalidAMIID.Malformed: Invalid id: \"probe-test-value\" (expecting \"ami-...\"))"
+    },
+    {
+      "operation": "ModifyInstanceAttribute",
+      "status": "working",
+      "message": "likely implemented (InvalidInstanceID.NotFound: The instance ID 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "ModifyInstanceCapacityReservationAttributes",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ModifyInstanceConnectEndpoint",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ModifyInstanceCpuOptions",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ModifyInstanceCreditSpecification",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ModifyInstanceEventStartTime",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ModifyInstanceEventWindow",
+      "status": "working",
+      "message": "likely implemented (InvalidInstanceEventWindowId.NotFound: The instance event window ID 'probe-test-value' does not exi)"
+    },
+    {
+      "operation": "ModifyInstanceMaintenanceOptions",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ModifyInstanceMetadataDefaults",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ModifyInstanceMetadataOptions",
+      "status": "working",
+      "message": "likely implemented (InvalidInstanceID.NotFound: The instance ID 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "ModifyInstanceNetworkPerformanceOptions",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ModifyInstancePlacement",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ModifyIpam",
+      "status": "working",
+      "message": "likely implemented (InvalidIpamId.NotFound: The IPAM ID 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "ModifyIpamPolicyAllocationRules",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ModifyIpamPool",
+      "status": "500_error",
+      "message": "server crash (InternalError: cannot import name 'InvalidIpamPoolIdError' from 'moto.ec2.e)"
+    },
+    {
+      "operation": "ModifyIpamPrefixListResolver",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ModifyIpamPrefixListResolverTarget",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ModifyIpamResourceCidr",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ModifyIpamResourceDiscovery",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ModifyIpamScope",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ModifyLaunchTemplate",
+      "status": "working",
+      "message": "implemented (MissingParameter)"
+    },
+    {
+      "operation": "ModifyLocalGatewayRoute",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ModifyManagedPrefixList",
+      "status": "working",
+      "message": "likely implemented (InvalidPrefixListID.NotFound: The prefix list ID 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "ModifyNetworkInterfaceAttribute",
+      "status": "working",
+      "message": "likely implemented (InvalidNetworkInterfaceID.NotFound: The networkInterface ID 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "ModifyPrivateDnsNameOptions",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ModifyPublicIpDnsNameOptions",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ModifyReservedInstances",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ModifyRouteServer",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ModifySecurityGroupRules",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ModifySnapshotAttribute",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ModifySnapshotTier",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ModifySpotFleetRequest",
+      "status": "500_error",
+      "message": "server crash (InternalError: '<' not supported between instances of 'NoneType' and 'int')"
+    },
+    {
+      "operation": "ModifySubnetAttribute",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ModifyTrafficMirrorFilterNetworkServices",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ModifyTrafficMirrorFilterRule",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ModifyTrafficMirrorSession",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ModifyTransitGateway",
+      "status": "working",
+      "message": "likely implemented (InvalidTransitGatewayID.NotFound: The transitGateway ID 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "ModifyTransitGatewayMeteringPolicy",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ModifyTransitGatewayPrefixListReference",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ModifyTransitGatewayVpcAttachment",
+      "status": "working",
+      "message": "likely implemented (InvalidTransitGatewayAttachmentID.NotFound: The transitGatewayAttachment ID 'probe-test-value' does not )"
+    },
+    {
+      "operation": "ModifyVerifiedAccessEndpoint",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ModifyVerifiedAccessEndpointPolicy",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ModifyVerifiedAccessGroup",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ModifyVerifiedAccessGroupPolicy",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ModifyVerifiedAccessInstance",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ModifyVerifiedAccessInstanceLoggingConfiguration",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ModifyVerifiedAccessTrustProvider",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ModifyVolume",
+      "status": "working",
+      "message": "likely implemented (InvalidVolume.NotFound: The volume 'probe-test-value' does not exist.)"
+    },
+    {
+      "operation": "ModifyVolumeAttribute",
+      "status": "working",
+      "message": "likely implemented (InvalidVolume.NotFound: The volume 'probe-test-value' does not exist.)"
+    },
+    {
+      "operation": "ModifyVpcAttribute",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ModifyVpcBlockPublicAccessExclusion",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ModifyVpcBlockPublicAccessOptions",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ModifyVpcEncryptionControl",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ModifyVpcEndpoint",
+      "status": "working",
+      "message": "likely implemented (InvalidVpcEndpointId.NotFound: The VpcEndPoint ID 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "ModifyVpcEndpointConnectionNotification",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ModifyVpcEndpointServiceConfiguration",
+      "status": "working",
+      "message": "likely implemented (InvalidVpcEndpointServiceId.NotFound: The VpcEndpointService Id 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "ModifyVpcEndpointServicePayerResponsibility",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ModifyVpcEndpointServicePermissions",
+      "status": "working",
+      "message": "likely implemented (InvalidVpcEndpointServiceId.NotFound: The VpcEndpointService Id 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "ModifyVpcPeeringConnectionOptions",
+      "status": "working",
+      "message": "likely implemented (InvalidVpcPeeringConnectionId.NotFound: VpcPeeringConnectionID probe-test-value does not exist.)"
+    },
+    {
+      "operation": "ModifyVpcTenancy",
+      "status": "working",
+      "message": "likely implemented (InvalidVpcID.NotFound: VpcID probe-test-value does not exist.)"
+    },
+    {
+      "operation": "ModifyVpnConnection",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ModifyVpnConnectionOptions",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ModifyVpnTunnelCertificate",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ModifyVpnTunnelOptions",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "MonitorInstances",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "MoveAddressToVpc",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "MoveByoipCidrToIpam",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "MoveCapacityReservationInstances",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ProvisionByoipCidr",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ProvisionIpamByoasn",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ProvisionIpamPoolCidr",
+      "status": "500_error",
+      "message": "server crash (InternalError: cannot import name 'InvalidIpamPoolIdError' from 'moto.ec2.e)"
+    },
+    {
+      "operation": "ProvisionPublicIpv4PoolCidr",
+      "status": "working",
+      "message": "likely implemented (InvalidPublicIpv4PoolID.NotFound: The public IPv4 pool ID 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "PurchaseCapacityBlock",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PurchaseCapacityBlockExtension",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "PurchaseHostReservation",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PurchaseReservedInstancesOffering",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "PurchaseScheduledInstances",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "RebootInstances",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "RegisterImage",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "RegisterInstanceEventNotificationAttributes",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "RegisterTransitGatewayMulticastGroupMembers",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "RegisterTransitGatewayMulticastGroupSources",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "RejectCapacityReservationBillingOwnership",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "RejectTransitGatewayMulticastDomainAssociations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "RejectTransitGatewayPeeringAttachment",
+      "status": "working",
+      "message": "likely implemented (InvalidTransitGatewayAttachmentID.NotFound: The transitGatewayAttachment ID 'probe-test-value' does not )"
+    },
+    {
+      "operation": "RejectTransitGatewayVpcAttachment",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "RejectVpcEndpointConnections",
+      "status": "working",
+      "message": "likely implemented (InvalidVpcEndpointServiceId.NotFound: The VpcEndpointService Id 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "RejectVpcPeeringConnection",
+      "status": "working",
+      "message": "likely implemented (InvalidVpcPeeringConnectionId.NotFound: VpcPeeringConnectionID probe-test-value does not exist.)"
+    },
+    {
+      "operation": "ReleaseAddress",
+      "status": "working",
+      "message": "implemented (MissingParameter)"
+    },
+    {
+      "operation": "ReleaseHosts",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ReleaseIpamPoolAllocation",
+      "status": "500_error",
+      "message": "server crash (InternalError: cannot import name 'InvalidIpamPoolIdError' from 'moto.ec2.e)"
+    },
+    {
+      "operation": "ReplaceIamInstanceProfileAssociation",
+      "status": "working",
+      "message": "likely implemented (InvalidAssociationID.NotFound: An invalid association-id of 'probe-test-value' was given)"
+    },
+    {
+      "operation": "ReplaceImageCriteriaInAllowedImagesSettings",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ReplaceNetworkAclAssociation",
+      "status": "working",
+      "message": "likely implemented (InvalidAssociationID.NotFound: Association ID 'probe-test-value' not found.)"
+    },
+    {
+      "operation": "ReplaceNetworkAclEntry",
+      "status": "working",
+      "message": "likely implemented (InvalidNetworkAclID.NotFound: The network acl ID 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "ReplaceRoute",
+      "status": "working",
+      "message": "likely implemented (InvalidRouteTableID.NotFound: The routeTable ID 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "ReplaceRouteTableAssociation",
+      "status": "working",
+      "message": "likely implemented (InvalidRouteTableID.NotFound: The routeTable ID 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "ReplaceTransitGatewayRoute",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ReplaceVpnTunnel",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ReportInstanceStatus",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "RequestSpotFleet",
+      "status": "500_error",
+      "message": "server crash (InternalError: list index out of range)"
+    },
+    {
+      "operation": "RequestSpotInstances",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ResetAddressAttribute",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ResetEbsDefaultKmsKeyId",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ResetFpgaImageAttribute",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ResetImageAttribute",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ResetInstanceAttribute",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ResetNetworkInterfaceAttribute",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ResetSnapshotAttribute",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "RestoreAddressToClassic",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "RestoreImageFromRecycleBin",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "RestoreManagedPrefixListVersion",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "RestoreSnapshotFromRecycleBin",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "RestoreSnapshotTier",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "RestoreVolumeFromRecycleBin",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "RevokeClientVpnIngress",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "RevokeSecurityGroupEgress",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "RevokeSecurityGroupIngress",
+      "status": "working",
+      "message": "likely implemented (InvalidGroup.NotFound: The security group 'None' does not exist)"
+    },
+    {
+      "operation": "RunInstances",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "RunScheduledInstances",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "SearchLocalGatewayRoutes",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "SearchTransitGatewayMulticastGroups",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "SearchTransitGatewayRoutes",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "SendDiagnosticInterrupt",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StartDeclarativePoliciesReport",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StartInstances",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartNetworkInsightsAccessScopeAnalysis",
+      "status": "working",
+      "message": "likely implemented (InvalidNetworkInsightsAccessScopeId.NotFound: The network insights access scope ID 'probe-test-value' does)"
+    },
+    {
+      "operation": "StartNetworkInsightsAnalysis",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartVpcEndpointServicePrivateDnsVerification",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StopInstances",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "TerminateClientVpnConnections",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UnassignIpv6Addresses",
+      "status": "working",
+      "message": "likely implemented (InvalidNetworkInterfaceID.NotFound: The networkInterface ID 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "UnassignPrivateIpAddresses",
+      "status": "working",
+      "message": "likely implemented (InvalidNetworkInterfaceID.NotFound: The networkInterface ID 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "UnassignPrivateNatGatewayAddress",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UnlockSnapshot",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UnmonitorInstances",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateCapacityManagerOrganizationsAccess",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateInterruptibleCapacityReservationAllocation",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateSecurityGroupRuleDescriptionsEgress",
+      "status": "working",
+      "message": "likely implemented (InvalidGroup.NotFound: The security group 'None' does not exist)"
+    },
+    {
+      "operation": "UpdateSecurityGroupRuleDescriptionsIngress",
+      "status": "working",
+      "message": "likely implemented (InvalidGroup.NotFound: The security group 'None' does not exist)"
+    },
+    {
+      "operation": "WithdrawByoipCidr",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    }
+  ]
+}

--- a/probes/ecr.json
+++ b/probes/ecr.json
@@ -1,0 +1,301 @@
+{
+  "service": "ecr",
+  "counts": {
+    "working": 38,
+    "needs_params": 6,
+    "not_implemented": 12,
+    "500_error": 2
+  },
+  "operations": [
+    {
+      "operation": "BatchCheckLayerAvailability",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "BatchDeleteImage",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "BatchGetImage",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "BatchGetRepositoryScanningConfiguration",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CompleteLayerUpload",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreatePullThroughCacheRule",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateRepository",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateRepositoryCreationTemplate",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteLifecyclePolicy",
+      "status": "working",
+      "message": "likely implemented (LifecyclePolicyNotFoundException: Lifecycle policy does not exist for the repository with name)"
+    },
+    {
+      "operation": "DeletePullThroughCacheRule",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteRegistryPolicy",
+      "status": "working",
+      "message": "likely implemented (RegistryPolicyNotFoundException: Registry policy does not exist in the registry with id '1234)"
+    },
+    {
+      "operation": "DeleteRepository",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteRepositoryCreationTemplate",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteRepositoryPolicy",
+      "status": "working",
+      "message": "implemented (RepositoryNotFoundException)"
+    },
+    {
+      "operation": "DeleteSigningConfiguration",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeregisterPullTimeUpdateExclusion",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeImageReplicationStatus",
+      "status": "working",
+      "message": "implemented (RepositoryNotFoundException)"
+    },
+    {
+      "operation": "DescribeImageScanFindings",
+      "status": "working",
+      "message": "implemented (RepositoryNotFoundException)"
+    },
+    {
+      "operation": "DescribeImageSigningStatus",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeImages",
+      "status": "working",
+      "message": "implemented (RepositoryNotFoundException)"
+    },
+    {
+      "operation": "DescribePullThroughCacheRules",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeRegistry",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeRepositories",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeRepositoryCreationTemplates",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetAccountSetting",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetAuthorizationToken",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetDownloadUrlForLayer",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetLifecyclePolicy",
+      "status": "working",
+      "message": "implemented (RepositoryNotFoundException)"
+    },
+    {
+      "operation": "GetLifecyclePolicyPreview",
+      "status": "working",
+      "message": "implemented (RepositoryNotFoundException)"
+    },
+    {
+      "operation": "GetRegistryPolicy",
+      "status": "working",
+      "message": "likely implemented (RegistryPolicyNotFoundException: Registry policy does not exist in the registry with id '1234)"
+    },
+    {
+      "operation": "GetRegistryScanningConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetRepositoryPolicy",
+      "status": "working",
+      "message": "implemented (RepositoryNotFoundException)"
+    },
+    {
+      "operation": "GetSigningConfiguration",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "InitiateLayerUpload",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListImageReferrers",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListImages",
+      "status": "working",
+      "message": "implemented (RepositoryNotFoundException)"
+    },
+    {
+      "operation": "ListPullTimeUpdateExclusions",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "working",
+      "message": "implemented (InvalidParameterException)"
+    },
+    {
+      "operation": "PutAccountSetting",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutImage",
+      "status": "500_error",
+      "message": "server crash (InternalError: probe-test-value is not a repository)"
+    },
+    {
+      "operation": "PutImageScanningConfiguration",
+      "status": "working",
+      "message": "implemented (RepositoryNotFoundException)"
+    },
+    {
+      "operation": "PutImageTagMutability",
+      "status": "working",
+      "message": "implemented (InvalidParameterException)"
+    },
+    {
+      "operation": "PutLifecyclePolicy",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "PutRegistryPolicy",
+      "status": "working",
+      "message": "implemented (InvalidParameterException)"
+    },
+    {
+      "operation": "PutRegistryScanningConfiguration",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'NoneType' object is not iterable)"
+    },
+    {
+      "operation": "PutReplicationConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutSigningConfiguration",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "RegisterPullTimeUpdateExclusion",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "SetRepositoryPolicy",
+      "status": "working",
+      "message": "implemented (RepositoryNotFoundException)"
+    },
+    {
+      "operation": "StartImageScan",
+      "status": "working",
+      "message": "implemented (RepositoryNotFoundException)"
+    },
+    {
+      "operation": "StartLifecyclePolicyPreview",
+      "status": "working",
+      "message": "implemented (RepositoryNotFoundException)"
+    },
+    {
+      "operation": "TagResource",
+      "status": "working",
+      "message": "implemented (InvalidParameterException)"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "working",
+      "message": "implemented (InvalidParameterException)"
+    },
+    {
+      "operation": "UpdateImageStorageClass",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdatePullThroughCacheRule",
+      "status": "working",
+      "message": "likely implemented (PullThroughCacheRuleNotFoundException: The pull through cache rule with Amazon ECR repository prefi)"
+    },
+    {
+      "operation": "UpdateRepositoryCreationTemplate",
+      "status": "working",
+      "message": "likely implemented (TemplateNotFoundException: The repository creation template with the prefix 'probe-test)"
+    },
+    {
+      "operation": "UploadLayerPart",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ValidatePullThroughCacheRule",
+      "status": "working",
+      "message": "likely implemented (PullThroughCacheRuleNotFoundException: The pull through cache rule with Amazon ECR repository prefi)"
+    }
+  ]
+}

--- a/probes/ecs.json
+++ b/probes/ecs.json
@@ -1,0 +1,326 @@
+{
+  "service": "ecs",
+  "counts": {
+    "working": 50,
+    "needs_params": 0,
+    "not_implemented": 9,
+    "500_error": 4
+  },
+  "operations": [
+    {
+      "operation": "CreateCapacityProvider",
+      "status": "500_error",
+      "message": "server crash (InternalError: argument of type 'NoneType' is not iterable)"
+    },
+    {
+      "operation": "CreateCluster",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateExpressGatewayService",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateService",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateTaskSet",
+      "status": "working",
+      "message": "likely implemented (ClusterNotFoundException: Cluster probe-test-value not found.)"
+    },
+    {
+      "operation": "DeleteAccountSetting",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteAttributes",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteCapacityProvider",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'NoneType' object has no attribute 'name')"
+    },
+    {
+      "operation": "DeleteExpressGatewayService",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteService",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteTaskDefinitions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteTaskSet",
+      "status": "working",
+      "message": "implemented (ServiceNotFoundException)"
+    },
+    {
+      "operation": "DeregisterContainerInstance",
+      "status": "working",
+      "message": "implemented (InvalidParameterException)"
+    },
+    {
+      "operation": "DeregisterTaskDefinition",
+      "status": "working",
+      "message": "likely implemented (ClientException: Unable to deregister task definition probe-test-value.)"
+    },
+    {
+      "operation": "DescribeCapacityProviders",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'NoneType' object is not iterable)"
+    },
+    {
+      "operation": "DescribeClusters",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeContainerInstances",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeExpressGatewayService",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeServiceDeployments",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeServiceRevisions",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeServices",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeTaskDefinition",
+      "status": "working",
+      "message": "likely implemented (ClientException: Unable to describe task definition probe-test-value.)"
+    },
+    {
+      "operation": "DescribeTaskSets",
+      "status": "working",
+      "message": "implemented (ServiceNotFoundException)"
+    },
+    {
+      "operation": "DescribeTasks",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DiscoverPollEndpoint",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ExecuteCommand",
+      "status": "working",
+      "message": "likely implemented (ClusterNotFoundException: Cluster not found.)"
+    },
+    {
+      "operation": "GetTaskProtection",
+      "status": "working",
+      "message": "likely implemented (ClusterNotFoundException: Cluster not found.)"
+    },
+    {
+      "operation": "ListAccountSettings",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListAttributes",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListClusters",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListContainerInstances",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListServiceDeployments",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListServices",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListServicesByNamespace",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTaskDefinitionFamilies",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTaskDefinitions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTasks",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutAccountSetting",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutAccountSettingDefault",
+      "status": "working",
+      "message": "implemented (InvalidParameterException)"
+    },
+    {
+      "operation": "PutAttributes",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutClusterCapacityProviders",
+      "status": "working",
+      "message": "likely implemented (ClusterNotFoundException: Cluster probe-test-value not found)"
+    },
+    {
+      "operation": "RegisterContainerInstance",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "RegisterTaskDefinition",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "RunTask",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartTask",
+      "status": "working",
+      "message": "likely implemented (ClusterNotFoundException: Cluster not found.)"
+    },
+    {
+      "operation": "StopServiceDeployment",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StopTask",
+      "status": "working",
+      "message": "implemented (InvalidParameterException)"
+    },
+    {
+      "operation": "SubmitAttachmentStateChanges",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "SubmitContainerStateChange",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "SubmitTaskStateChange",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "TagResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateCapacityProvider",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'NoneType' object has no attribute 'update')"
+    },
+    {
+      "operation": "UpdateCluster",
+      "status": "working",
+      "message": "likely implemented (ClusterNotFoundException: Cluster not found.)"
+    },
+    {
+      "operation": "UpdateClusterSettings",
+      "status": "working",
+      "message": "likely implemented (ClusterNotFoundException: Cluster not found.)"
+    },
+    {
+      "operation": "UpdateContainerAgent",
+      "status": "working",
+      "message": "likely implemented (ClusterNotFoundException: Cluster not found.)"
+    },
+    {
+      "operation": "UpdateContainerInstancesState",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateExpressGatewayService",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateService",
+      "status": "working",
+      "message": "implemented (ServiceNotFoundException)"
+    },
+    {
+      "operation": "UpdateServicePrimaryTaskSet",
+      "status": "working",
+      "message": "likely implemented (ClusterNotFoundException: Cluster not found.)"
+    },
+    {
+      "operation": "UpdateTaskProtection",
+      "status": "working",
+      "message": "likely implemented (ClusterNotFoundException: Cluster not found.)"
+    },
+    {
+      "operation": "UpdateTaskSet",
+      "status": "working",
+      "message": "implemented (ServiceNotFoundException)"
+    }
+  ]
+}

--- a/probes/efs.json
+++ b/probes/efs.json
@@ -1,0 +1,166 @@
+{
+  "service": "efs",
+  "counts": {
+    "working": 22,
+    "needs_params": 2,
+    "not_implemented": 4,
+    "500_error": 3
+  },
+  "operations": [
+    {
+      "operation": "CreateAccessPoint",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateFileSystem",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateMountTarget",
+      "status": "working",
+      "message": "likely implemented (SubnetNotFound: The subnet ID 'probe-test-value' does not exist)"
+    },
+    {
+      "operation": "CreateReplicationConfiguration",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateTags",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteAccessPoint",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteFileSystem",
+      "status": "working",
+      "message": "likely implemented (FileSystemNotFound: File system 'probe-test-value' does not exist.)"
+    },
+    {
+      "operation": "DeleteFileSystemPolicy",
+      "status": "working",
+      "message": "likely implemented (FileSystemNotFound: File system 'probe-test-value' does not exist.)"
+    },
+    {
+      "operation": "DeleteMountTarget",
+      "status": "working",
+      "message": "likely implemented (MountTargetNotFound: Mount target 'probe-test-value' does not exist.)"
+    },
+    {
+      "operation": "DeleteReplicationConfiguration",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteTags",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DescribeAccessPoints",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeAccountPreferences",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeBackupPolicy",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "DescribeFileSystemPolicy",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "DescribeFileSystems",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeLifecycleConfiguration",
+      "status": "working",
+      "message": "likely implemented (FileSystemNotFound: File system 'probe-test-value' does not exist.)"
+    },
+    {
+      "operation": "DescribeMountTargetSecurityGroups",
+      "status": "working",
+      "message": "likely implemented (MountTargetNotFound: Mount target 'probe-test-value' does not exist.)"
+    },
+    {
+      "operation": "DescribeMountTargets",
+      "status": "working",
+      "message": "likely implemented (BadRequest: Must specify exactly one mutually exclusive parameter.)"
+    },
+    {
+      "operation": "DescribeReplicationConfigurations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeTags",
+      "status": "working",
+      "message": "likely implemented (FileSystemNotFound: File system 'probe-test-value' does not exist.)"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ModifyMountTargetSecurityGroups",
+      "status": "working",
+      "message": "likely implemented (MountTargetNotFound: Mount target 'probe-test-value' does not exist.)"
+    },
+    {
+      "operation": "PutAccountPreferences",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutBackupPolicy",
+      "status": "working",
+      "message": "likely implemented (FileSystemNotFound: File system 'probe-test-value' does not exist.)"
+    },
+    {
+      "operation": "PutFileSystemPolicy",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "PutLifecycleConfiguration",
+      "status": "working",
+      "message": "likely implemented (FileSystemNotFound: File system 'probe-test-value' does not exist.)"
+    },
+    {
+      "operation": "TagResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UpdateFileSystem",
+      "status": "working",
+      "message": "likely implemented (FileSystemNotFound: File system 'probe-test-value' does not exist.)"
+    },
+    {
+      "operation": "UpdateFileSystemProtection",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    }
+  ]
+}

--- a/probes/eks.json
+++ b/probes/eks.json
@@ -1,0 +1,326 @@
+{
+  "service": "eks",
+  "counts": {
+    "working": 46,
+    "needs_params": 1,
+    "not_implemented": 13,
+    "500_error": 3
+  },
+  "operations": [
+    {
+      "operation": "AssociateAccessPolicy",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "AssociateEncryptionConfig",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "AssociateIdentityProviderConfig",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "CreateAccessEntry",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "CreateAddon",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "CreateCapability",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "CreateCluster",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'NoneType' object has no attribute 'group')"
+    },
+    {
+      "operation": "CreateEksAnywhereSubscription",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateFargateProfile",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "CreateNodegroup",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "CreatePodIdentityAssociation",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteAccessEntry",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteAddon",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteCapability",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteEksAnywhereSubscription",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteFargateProfile",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteNodegroup",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeletePodIdentityAssociation",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeregisterCluster",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeAccessEntry",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeAddon",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeAddonConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeAddonVersions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeCapability",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeCluster",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeClusterVersions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeEksAnywhereSubscription",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeFargateProfile",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeIdentityProviderConfig",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeInsight",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeInsightsRefresh",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeNodegroup",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribePodIdentityAssociation",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeUpdate",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DisassociateAccessPolicy",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DisassociateIdentityProviderConfig",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListAccessEntries",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListAccessPolicies",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListAddons",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListAssociatedAccessPolicies",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListCapabilities",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListClusters",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListEksAnywhereSubscriptions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListFargateProfiles",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "ListIdentityProviderConfigs",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListInsights",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListNodegroups",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "ListPodIdentityAssociations",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListUpdates",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "RegisterCluster",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StartInsightsRefresh",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "TagResource",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UpdateAccessEntry",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateAddon",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateCapability",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateClusterConfig",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateClusterVersion",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateEksAnywhereSubscription",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateNodegroupConfig",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateNodegroupVersion",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdatePodIdentityAssociation",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    }
+  ]
+}

--- a/probes/elasticache.json
+++ b/probes/elasticache.json
@@ -1,0 +1,381 @@
+{
+  "service": "elasticache",
+  "counts": {
+    "working": 61,
+    "needs_params": 0,
+    "not_implemented": 13,
+    "500_error": 0
+  },
+  "operations": [
+    {
+      "operation": "AddTagsToResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "AuthorizeCacheSecurityGroupIngress",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "BatchApplyUpdateAction",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "BatchStopUpdateAction",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CompleteMigration",
+      "status": "working",
+      "message": "likely implemented (ReplicationGroupNotFoundFault: Replication group probe-test-value not found.)"
+    },
+    {
+      "operation": "CopyServerlessCacheSnapshot",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CopySnapshot",
+      "status": "working",
+      "message": "likely implemented (SnapshotNotFoundFault: Snapshot probe-test-value not found.)"
+    },
+    {
+      "operation": "CreateCacheCluster",
+      "status": "working",
+      "message": "implemented (InvalidParameterValue)"
+    },
+    {
+      "operation": "CreateCacheParameterGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateCacheSecurityGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateCacheSubnetGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateGlobalReplicationGroup",
+      "status": "working",
+      "message": "likely implemented (ReplicationGroupNotFoundFault: Replication group probe-test-value not found.)"
+    },
+    {
+      "operation": "CreateReplicationGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateServerlessCache",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateServerlessCacheSnapshot",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateSnapshot",
+      "status": "working",
+      "message": "implemented (InvalidParameterValue)"
+    },
+    {
+      "operation": "CreateUser",
+      "status": "working",
+      "message": "implemented (InvalidParameterValue)"
+    },
+    {
+      "operation": "CreateUserGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DecreaseNodeGroupsInGlobalReplicationGroup",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DecreaseReplicaCount",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteCacheParameterGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteCacheSecurityGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteCacheSubnetGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteGlobalReplicationGroup",
+      "status": "working",
+      "message": "likely implemented (GlobalReplicationGroupNotFoundFault: Global replication group probe-test-value not found.)"
+    },
+    {
+      "operation": "DeleteReplicationGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteServerlessCache",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteServerlessCacheSnapshot",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteSnapshot",
+      "status": "working",
+      "message": "likely implemented (SnapshotNotFoundFault: Snapshot probe-test-value not found.)"
+    },
+    {
+      "operation": "DeleteUser",
+      "status": "working",
+      "message": "likely implemented (UserNotFound: User probe-test-value not found.)"
+    },
+    {
+      "operation": "DeleteUserGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeCacheClusters",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeCacheEngineVersions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeCacheParameterGroups",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeCacheParameters",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeCacheSecurityGroups",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeCacheSubnetGroups",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeEngineDefaultParameters",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeEvents",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeGlobalReplicationGroups",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeReplicationGroups",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeReservedCacheNodes",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeReservedCacheNodesOfferings",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeServerlessCacheSnapshots",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeServerlessCaches",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeServiceUpdates",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeSnapshots",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeUpdateActions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeUserGroups",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeUsers",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DisassociateGlobalReplicationGroup",
+      "status": "working",
+      "message": "likely implemented (GlobalReplicationGroupNotFoundFault: Global replication group probe-test-value not found.)"
+    },
+    {
+      "operation": "ExportServerlessCacheSnapshot",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "FailoverGlobalReplicationGroup",
+      "status": "working",
+      "message": "likely implemented (GlobalReplicationGroupNotFoundFault: Global replication group probe-test-value not found.)"
+    },
+    {
+      "operation": "IncreaseNodeGroupsInGlobalReplicationGroup",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "IncreaseReplicaCount",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListAllowedNodeTypeModifications",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "working",
+      "message": "likely implemented (InvalidARN: ARN probe-test-value is invalid.)"
+    },
+    {
+      "operation": "ModifyCacheCluster",
+      "status": "working",
+      "message": "likely implemented (CacheClusterNotFound: Cache cluster probe-test-value not found.)"
+    },
+    {
+      "operation": "ModifyCacheParameterGroup",
+      "status": "working",
+      "message": "likely implemented (CacheParameterGroupNotFound: Cache parameter group probe-test-value not found.)"
+    },
+    {
+      "operation": "ModifyCacheSubnetGroup",
+      "status": "working",
+      "message": "likely implemented (CacheSubnetGroupNotFoundFault: CacheSubnetGroup probe-test-value not found.)"
+    },
+    {
+      "operation": "ModifyGlobalReplicationGroup",
+      "status": "working",
+      "message": "likely implemented (GlobalReplicationGroupNotFoundFault: Global replication group probe-test-value not found.)"
+    },
+    {
+      "operation": "ModifyReplicationGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ModifyReplicationGroupShardConfiguration",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ModifyServerlessCache",
+      "status": "working",
+      "message": "likely implemented (ServerlessCacheNotFoundFault: Serverless cache probe-test-value not found.)"
+    },
+    {
+      "operation": "ModifyUser",
+      "status": "working",
+      "message": "likely implemented (UserNotFound: User probe-test-value not found.)"
+    },
+    {
+      "operation": "ModifyUserGroup",
+      "status": "working",
+      "message": "likely implemented (UserGroupNotFound: User group probe-test-value not found.)"
+    },
+    {
+      "operation": "PurchaseReservedCacheNodesOffering",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "RebalanceSlotsInGlobalReplicationGroup",
+      "status": "working",
+      "message": "likely implemented (GlobalReplicationGroupNotFoundFault: Global replication group probe-test-value not found.)"
+    },
+    {
+      "operation": "RebootCacheCluster",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "RemoveTagsFromResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ResetCacheParameterGroup",
+      "status": "working",
+      "message": "likely implemented (CacheParameterGroupNotFound: Cache parameter group probe-test-value not found.)"
+    },
+    {
+      "operation": "RevokeCacheSecurityGroupIngress",
+      "status": "working",
+      "message": "likely implemented (CacheSecurityGroupNotFound: Cache security group probe-test-value not found.)"
+    },
+    {
+      "operation": "StartMigration",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "TestFailover",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "TestMigration",
+      "status": "working",
+      "message": "OK"
+    }
+  ]
+}

--- a/probes/elasticbeanstalk.json
+++ b/probes/elasticbeanstalk.json
@@ -1,0 +1,241 @@
+{
+  "service": "elasticbeanstalk",
+  "counts": {
+    "working": 34,
+    "needs_params": 0,
+    "not_implemented": 11,
+    "500_error": 1
+  },
+  "operations": [
+    {
+      "operation": "AbortEnvironmentUpdate",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ApplyEnvironmentManagedAction",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "AssociateEnvironmentOperationsRole",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CheckDNSAvailability",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ComposeEnvironments",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateApplication",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateApplicationVersion",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateConfigurationTemplate",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateEnvironment",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreatePlatformVersion",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateStorageLocation",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteApplication",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteApplicationVersion",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteConfigurationTemplate",
+      "status": "working",
+      "message": "implemented (InvalidParameterValue)"
+    },
+    {
+      "operation": "DeleteEnvironmentConfiguration",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeletePlatformVersion",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeAccountAttributes",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeApplicationVersions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeApplications",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeConfigurationOptions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeConfigurationSettings",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeEnvironmentHealth",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeEnvironmentManagedActionHistory",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeEnvironmentManagedActions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeEnvironmentResources",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeEnvironments",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeEvents",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeInstancesHealth",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribePlatformVersion",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DisassociateEnvironmentOperationsRole",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListAvailableSolutionStacks",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListPlatformBranches",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListPlatformVersions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "RebuildEnvironment",
+      "status": "working",
+      "message": "implemented (InvalidParameterValue)"
+    },
+    {
+      "operation": "RequestEnvironmentInfo",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "RestartAppServer",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "RetrieveEnvironmentInfo",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "SwapEnvironmentCNAMEs",
+      "status": "500_error",
+      "message": "exception: 'ElasticBeanstalk' object has no attribute 'swap_environment"
+    },
+    {
+      "operation": "UpdateApplication",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateApplicationResourceLifecycle",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateApplicationVersion",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateConfigurationTemplate",
+      "status": "working",
+      "message": "implemented (InvalidParameterValue)"
+    },
+    {
+      "operation": "UpdateEnvironment",
+      "status": "working",
+      "message": "implemented (InvalidParameterValue)"
+    },
+    {
+      "operation": "UpdateTagsForResource",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ValidateConfigurationSettings",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    }
+  ]
+}

--- a/probes/elb.json
+++ b/probes/elb.json
@@ -1,0 +1,156 @@
+{
+  "service": "elb",
+  "counts": {
+    "working": 7,
+    "needs_params": 4,
+    "not_implemented": 2,
+    "500_error": 16
+  },
+  "operations": [
+    {
+      "operation": "AddTags",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "ApplySecurityGroupsToLoadBalancer",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'NoneType' object has no attribute 'security_groups' and no )"
+    },
+    {
+      "operation": "AttachLoadBalancerToSubnets",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'NoneType' object has no attribute 'subnets')"
+    },
+    {
+      "operation": "ConfigureHealthCheck",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateAppCookieStickinessPolicy",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'NoneType' object has no attribute 'policies')"
+    },
+    {
+      "operation": "CreateLBCookieStickinessPolicy",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'NoneType' object has no attribute 'policies')"
+    },
+    {
+      "operation": "CreateLoadBalancer",
+      "status": "working",
+      "message": "implemented (ValidationError)"
+    },
+    {
+      "operation": "CreateLoadBalancerListeners",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateLoadBalancerPolicy",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'NoneType' object has no attribute 'policies')"
+    },
+    {
+      "operation": "DeleteLoadBalancer",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteLoadBalancerListeners",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'NoneType' object has no attribute 'listeners' and no __dict)"
+    },
+    {
+      "operation": "DeleteLoadBalancerPolicy",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'NoneType' object has no attribute 'policies')"
+    },
+    {
+      "operation": "DeregisterInstancesFromLoadBalancer",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'NoneType' object has no attribute 'instance_sparse_ids')"
+    },
+    {
+      "operation": "DescribeAccountLimits",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeInstanceHealth",
+      "status": "working",
+      "message": "likely implemented (LoadBalancerNotFound: There is no ACTIVE Load Balancer named 'probe-test-value')"
+    },
+    {
+      "operation": "DescribeLoadBalancerAttributes",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'NoneType' object has no attribute 'attributes')"
+    },
+    {
+      "operation": "DescribeLoadBalancerPolicies",
+      "status": "working",
+      "message": "likely implemented (LoadBalancerNotFound: The specified load balancer does not exist: None)"
+    },
+    {
+      "operation": "DescribeLoadBalancerPolicyTypes",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeLoadBalancers",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeTags",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DetachLoadBalancerFromSubnets",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'NoneType' object has no attribute 'subnets')"
+    },
+    {
+      "operation": "DisableAvailabilityZonesForLoadBalancer",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'NoneType' object has no attribute 'availability_zones')"
+    },
+    {
+      "operation": "EnableAvailabilityZonesForLoadBalancer",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'NoneType' object has no attribute 'availability_zones')"
+    },
+    {
+      "operation": "ModifyLoadBalancerAttributes",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'NoneType' object has no attribute 'name')"
+    },
+    {
+      "operation": "RegisterInstancesWithLoadBalancer",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'NoneType' object has no attribute 'instance_sparse_ids')"
+    },
+    {
+      "operation": "RemoveTags",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "SetLoadBalancerListenerSSLCertificate",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "SetLoadBalancerPoliciesForBackendServer",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'NoneType' object has no attribute 'backends')"
+    },
+    {
+      "operation": "SetLoadBalancerPoliciesOfListener",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'NoneType' object has no attribute 'listeners')"
+    }
+  ]
+}

--- a/probes/elbv2.json
+++ b/probes/elbv2.json
@@ -1,0 +1,266 @@
+{
+  "service": "elbv2",
+  "counts": {
+    "working": 36,
+    "needs_params": 1,
+    "not_implemented": 14,
+    "500_error": 0
+  },
+  "operations": [
+    {
+      "operation": "AddListenerCertificates",
+      "status": "working",
+      "message": "likely implemented (ListenerNotFound: The specified listener does not exist.)"
+    },
+    {
+      "operation": "AddTags",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "AddTrustStoreRevocations",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateListener",
+      "status": "working",
+      "message": "likely implemented (LoadBalancerNotFound: The specified load balancer does not exist.)"
+    },
+    {
+      "operation": "CreateLoadBalancer",
+      "status": "working",
+      "message": "likely implemented (SubnetNotFound: The specified subnet does not exist.)"
+    },
+    {
+      "operation": "CreateRule",
+      "status": "working",
+      "message": "likely implemented (ListenerNotFound: The specified listener does not exist.)"
+    },
+    {
+      "operation": "CreateTargetGroup",
+      "status": "working",
+      "message": "implemented (ValidationError)"
+    },
+    {
+      "operation": "CreateTrustStore",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteListener",
+      "status": "working",
+      "message": "likely implemented (ListenerNotFound: The specified listener does not exist.)"
+    },
+    {
+      "operation": "DeleteLoadBalancer",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteRule",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteSharedTrustStoreAssociation",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteTargetGroup",
+      "status": "working",
+      "message": "likely implemented (TargetGroupNotFound: One or more target groups not found)"
+    },
+    {
+      "operation": "DeleteTrustStore",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeregisterTargets",
+      "status": "working",
+      "message": "likely implemented (TargetGroupNotFound: One or more target groups not found)"
+    },
+    {
+      "operation": "DescribeAccountLimits",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeCapacityReservation",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeListenerAttributes",
+      "status": "working",
+      "message": "likely implemented (ListenerNotFound: The specified listener does not exist.)"
+    },
+    {
+      "operation": "DescribeListenerCertificates",
+      "status": "working",
+      "message": "likely implemented (ListenerNotFound: The specified listener does not exist.)"
+    },
+    {
+      "operation": "DescribeListeners",
+      "status": "working",
+      "message": "implemented (ValidationError)"
+    },
+    {
+      "operation": "DescribeLoadBalancerAttributes",
+      "status": "working",
+      "message": "likely implemented (LoadBalancerNotFound: The specified load balancer does not exist.)"
+    },
+    {
+      "operation": "DescribeLoadBalancers",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeRules",
+      "status": "working",
+      "message": "implemented (ValidationError)"
+    },
+    {
+      "operation": "DescribeSSLPolicies",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeTags",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeTargetGroupAttributes",
+      "status": "working",
+      "message": "likely implemented (TargetGroupNotFound: One or more target groups not found)"
+    },
+    {
+      "operation": "DescribeTargetGroups",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeTargetHealth",
+      "status": "working",
+      "message": "likely implemented (TargetGroupNotFound: One or more target groups not found)"
+    },
+    {
+      "operation": "DescribeTrustStoreAssociations",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeTrustStoreRevocations",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeTrustStores",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetResourcePolicy",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetTrustStoreCaCertificatesBundle",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetTrustStoreRevocationContent",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ModifyCapacityReservation",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ModifyIpPools",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ModifyListener",
+      "status": "working",
+      "message": "likely implemented (ListenerNotFound: The specified listener does not exist.)"
+    },
+    {
+      "operation": "ModifyListenerAttributes",
+      "status": "working",
+      "message": "likely implemented (ListenerNotFound: The specified listener does not exist.)"
+    },
+    {
+      "operation": "ModifyLoadBalancerAttributes",
+      "status": "working",
+      "message": "likely implemented (LoadBalancerNotFound: The specified load balancer does not exist.)"
+    },
+    {
+      "operation": "ModifyRule",
+      "status": "working",
+      "message": "implemented (ValidationError)"
+    },
+    {
+      "operation": "ModifyTargetGroup",
+      "status": "working",
+      "message": "likely implemented (TargetGroupNotFound: One or more target groups not found)"
+    },
+    {
+      "operation": "ModifyTargetGroupAttributes",
+      "status": "working",
+      "message": "likely implemented (TargetGroupNotFound: One or more target groups not found)"
+    },
+    {
+      "operation": "ModifyTrustStore",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "RegisterTargets",
+      "status": "working",
+      "message": "likely implemented (TargetGroupNotFound: One or more target groups not found)"
+    },
+    {
+      "operation": "RemoveListenerCertificates",
+      "status": "working",
+      "message": "likely implemented (ListenerNotFound: The specified listener does not exist.)"
+    },
+    {
+      "operation": "RemoveTags",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "RemoveTrustStoreRevocations",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "SetIpAddressType",
+      "status": "working",
+      "message": "implemented (ValidationError)"
+    },
+    {
+      "operation": "SetRulePriorities",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "SetSecurityGroups",
+      "status": "working",
+      "message": "likely implemented (LoadBalancerNotFound: The specified load balancer does not exist.)"
+    },
+    {
+      "operation": "SetSubnets",
+      "status": "working",
+      "message": "likely implemented (LoadBalancerNotFound: The specified load balancer does not exist.)"
+    }
+  ]
+}

--- a/probes/emr.json
+++ b/probes/emr.json
@@ -1,0 +1,311 @@
+{
+  "service": "emr",
+  "counts": {
+    "working": 50,
+    "needs_params": 0,
+    "not_implemented": 10,
+    "500_error": 0
+  },
+  "operations": [
+    {
+      "operation": "AddInstanceFleet",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "AddInstanceGroups",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "AddJobFlowSteps",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "AddTags",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "CancelSteps",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "CreatePersistentAppUI",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateSecurityConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateStudio",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateStudioSessionMapping",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "DeleteSecurityConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteStudio",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "DeleteStudioSessionMapping",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "DescribeCluster",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "DescribeJobFlows",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeNotebookExecution",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "DescribePersistentAppUI",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeReleaseLabel",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "DescribeSecurityConfiguration",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "DescribeStep",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "DescribeStudio",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "GetAutoTerminationPolicy",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "GetBlockPublicAccessConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetClusterSessionCredentials",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetManagedScalingPolicy",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "GetOnClusterAppUIPresignedURL",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetPersistentAppUIPresignedURL",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetStudioSessionMapping",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "ListBootstrapActions",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "ListClusters",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListInstanceFleets",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "ListInstanceGroups",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "ListInstances",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "ListNotebookExecutions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListReleaseLabels",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListSecurityConfigurations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListSteps",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "ListStudioSessionMappings",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListStudios",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListSupportedInstanceTypes",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "ModifyCluster",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "ModifyInstanceFleet",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "ModifyInstanceGroups",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutAutoScalingPolicy",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "PutAutoTerminationPolicy",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "PutBlockPublicAccessConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutManagedScalingPolicy",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "RemoveAutoScalingPolicy",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "RemoveAutoTerminationPolicy",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "RemoveManagedScalingPolicy",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "RemoveTags",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "RunJobFlow",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "SetKeepJobFlowAliveWhenNoSteps",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "SetTerminationProtection",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "SetUnhealthyNodeReplacement",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "SetVisibleToAllUsers",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartNotebookExecution",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StopNotebookExecution",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "TerminateJobFlows",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateStudio",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateStudioSessionMapping",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    }
+  ]
+}

--- a/probes/es.json
+++ b/probes/es.json
@@ -1,0 +1,266 @@
+{
+  "service": "es",
+  "counts": {
+    "working": 39,
+    "needs_params": 0,
+    "not_implemented": 11,
+    "500_error": 1
+  },
+  "operations": [
+    {
+      "operation": "AcceptInboundCrossClusterSearchConnection",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "AddTags",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "AssociatePackage",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "AuthorizeVpcEndpointAccess",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CancelDomainConfigChange",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CancelElasticsearchServiceSoftwareUpdate",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateElasticsearchDomain",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateOutboundCrossClusterSearchConnection",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreatePackage",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateVpcEndpoint",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteElasticsearchDomain",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteElasticsearchServiceRole",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteInboundCrossClusterSearchConnection",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteOutboundCrossClusterSearchConnection",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeletePackage",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteVpcEndpoint",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeDomainAutoTunes",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeDomainChangeProgress",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeElasticsearchDomain",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeElasticsearchDomainConfig",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeElasticsearchDomains",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeElasticsearchInstanceTypeLimits",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeInboundCrossClusterSearchConnections",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeOutboundCrossClusterSearchConnections",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribePackages",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeReservedElasticsearchInstanceOfferings",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeReservedElasticsearchInstances",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeVpcEndpoints",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DissociatePackage",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetCompatibleElasticsearchVersions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetPackageVersionHistory",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetUpgradeHistory",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetUpgradeStatus",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListDomainNames",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListDomainsForPackage",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListElasticsearchInstanceTypes",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListElasticsearchVersions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListPackagesForDomain",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListTags",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListVpcEndpointAccess",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListVpcEndpoints",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListVpcEndpointsForDomain",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "PurchaseReservedElasticsearchInstanceOffering",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "RejectInboundCrossClusterSearchConnection",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "RemoveTags",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "RevokeVpcEndpointAccess",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StartElasticsearchServiceSoftwareUpdate",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateElasticsearchDomainConfig",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "UpdatePackage",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateVpcEndpoint",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpgradeElasticsearchDomain",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    }
+  ]
+}

--- a/probes/events.json
+++ b/probes/events.json
@@ -1,0 +1,296 @@
+{
+  "service": "events",
+  "counts": {
+    "working": 45,
+    "needs_params": 5,
+    "not_implemented": 5,
+    "500_error": 2
+  },
+  "operations": [
+    {
+      "operation": "ActivateEventSource",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CancelReplay",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "CreateApiDestination",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateArchive",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateConnection",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateEndpoint",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateEventBus",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreatePartnerEventSource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeactivateEventSource",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeauthorizeConnection",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteApiDestination",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteArchive",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteConnection",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteEndpoint",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteEventBus",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeletePartnerEventSource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteRule",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeApiDestination",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeArchive",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeConnection",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeEndpoint",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeEventBus",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeEventSource",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "DescribePartnerEventSource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeReplay",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeRule",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DisableRule",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "EnableRule",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListApiDestinations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListArchives",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListConnections",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListEndpoints",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListEventBuses",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListEventSources",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListPartnerEventSourceAccounts",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListPartnerEventSources",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListReplays",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListRuleNamesByTarget",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListRules",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTargetsByRule",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutEvents",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "PutPartnerEvents",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "PutPermission",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "PutRule",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutTargets",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "RemovePermission",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "RemoveTargets",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "StartReplay",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "TagResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "TestEventPattern",
+      "status": "500_error",
+      "message": "server crash (InternalError: Expecting value: line 1 column 1 (char 0))"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateApiDestination",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateArchive",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateConnection",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateEndpoint",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateEventBus",
+      "status": "working",
+      "message": "OK"
+    }
+  ]
+}

--- a/probes/fsx.json
+++ b/probes/fsx.json
@@ -1,0 +1,251 @@
+{
+  "service": "fsx",
+  "counts": {
+    "working": 26,
+    "needs_params": 9,
+    "not_implemented": 11,
+    "500_error": 2
+  },
+  "operations": [
+    {
+      "operation": "AssociateFileSystemAliases",
+      "status": "working",
+      "message": "likely implemented (FileSystemNotFound: File system 'probe-test-value' does not exist.)"
+    },
+    {
+      "operation": "CancelDataRepositoryTask",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CopyBackup",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CopySnapshotAndUpdateVolume",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateAndAttachS3AccessPoint",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateBackup",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "CreateDataRepositoryAssociation",
+      "status": "working",
+      "message": "likely implemented (FileSystemNotFound: File system 'probe-test-value' does not exist.)"
+    },
+    {
+      "operation": "CreateDataRepositoryTask",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateFileCache",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateFileSystem",
+      "status": "500_error",
+      "message": "server crash (InternalError: Invalid FileSystemType: probe-test-value)"
+    },
+    {
+      "operation": "CreateFileSystemFromBackup",
+      "status": "working",
+      "message": "likely implemented (BackupNotFound: Backup 'probe-test-value' does not exist.)"
+    },
+    {
+      "operation": "CreateSnapshot",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateStorageVirtualMachine",
+      "status": "working",
+      "message": "likely implemented (FileSystemNotFound: File system 'probe-test-value' does not exist.)"
+    },
+    {
+      "operation": "CreateVolume",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateVolumeFromBackup",
+      "status": "working",
+      "message": "likely implemented (BackupNotFound: Backup 'probe-test-value' does not exist.)"
+    },
+    {
+      "operation": "DeleteBackup",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteDataRepositoryAssociation",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteFileCache",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteFileSystem",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "DeleteSnapshot",
+      "status": "working",
+      "message": "likely implemented (SnapshotNotFound: Snapshot 'probe-test-value' does not exist.)"
+    },
+    {
+      "operation": "DeleteStorageVirtualMachine",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DeleteVolume",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DescribeBackups",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeDataRepositoryAssociations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeDataRepositoryTasks",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeFileCaches",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeFileSystemAliases",
+      "status": "working",
+      "message": "likely implemented (FileSystemNotFound: File system 'probe-test-value' does not exist.)"
+    },
+    {
+      "operation": "DescribeFileSystems",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeS3AccessPointAttachments",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeSharedVpcConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeSnapshots",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeStorageVirtualMachines",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeVolumes",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DetachAndDeleteS3AccessPoint",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DisassociateFileSystemAliases",
+      "status": "working",
+      "message": "likely implemented (FileSystemNotFound: File system 'probe-test-value' does not exist.)"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ReleaseFileSystemNfsV3Locks",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "RestoreVolumeFromSnapshot",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "StartMisconfiguredStateRecovery",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "TagResource",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UpdateDataRepositoryAssociation",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateFileCache",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateFileSystem",
+      "status": "working",
+      "message": "likely implemented (FileSystemNotFound: File system 'probe-test-value' does not exist.)"
+    },
+    {
+      "operation": "UpdateSharedVpcConfiguration",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateSnapshot",
+      "status": "working",
+      "message": "likely implemented (SnapshotNotFound: Snapshot 'probe-test-value' does not exist.)"
+    },
+    {
+      "operation": "UpdateStorageVirtualMachine",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UpdateVolume",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    }
+  ]
+}

--- a/probes/glacier.json
+++ b/probes/glacier.json
@@ -1,0 +1,176 @@
+{
+  "service": "glacier",
+  "counts": {
+    "working": 33,
+    "needs_params": 0,
+    "not_implemented": 0,
+    "500_error": 0
+  },
+  "operations": [
+    {
+      "operation": "AbortMultipartUpload",
+      "status": "working",
+      "message": "likely implemented (VaultNotFound: Vault not found)"
+    },
+    {
+      "operation": "AbortVaultLock",
+      "status": "working",
+      "message": "likely implemented (VaultNotFound: Vault not found)"
+    },
+    {
+      "operation": "AddTagsToVault",
+      "status": "working",
+      "message": "likely implemented (VaultNotFound: Vault not found)"
+    },
+    {
+      "operation": "CompleteMultipartUpload",
+      "status": "working",
+      "message": "likely implemented (VaultNotFound: Vault not found)"
+    },
+    {
+      "operation": "CompleteVaultLock",
+      "status": "working",
+      "message": "likely implemented (VaultNotFound: Vault not found)"
+    },
+    {
+      "operation": "CreateVault",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteArchive",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteVault",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteVaultAccessPolicy",
+      "status": "working",
+      "message": "likely implemented (VaultNotFound: Vault not found)"
+    },
+    {
+      "operation": "DeleteVaultNotifications",
+      "status": "working",
+      "message": "likely implemented (VaultNotFound: Vault not found)"
+    },
+    {
+      "operation": "DescribeJob",
+      "status": "working",
+      "message": "likely implemented (VaultNotFound: Vault not found)"
+    },
+    {
+      "operation": "DescribeVault",
+      "status": "working",
+      "message": "likely implemented (VaultNotFound: Vault not found)"
+    },
+    {
+      "operation": "GetDataRetrievalPolicy",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetJobOutput",
+      "status": "working",
+      "message": "likely implemented (VaultNotFound: Vault not found)"
+    },
+    {
+      "operation": "GetVaultAccessPolicy",
+      "status": "working",
+      "message": "likely implemented (VaultNotFound: Vault not found)"
+    },
+    {
+      "operation": "GetVaultLock",
+      "status": "working",
+      "message": "likely implemented (VaultNotFound: Vault not found)"
+    },
+    {
+      "operation": "GetVaultNotifications",
+      "status": "working",
+      "message": "likely implemented (VaultNotFound: Vault not found)"
+    },
+    {
+      "operation": "InitiateJob",
+      "status": "working",
+      "message": "likely implemented (VaultNotFound: Vault not found)"
+    },
+    {
+      "operation": "InitiateMultipartUpload",
+      "status": "working",
+      "message": "likely implemented (VaultNotFound: Vault not found)"
+    },
+    {
+      "operation": "InitiateVaultLock",
+      "status": "working",
+      "message": "likely implemented (VaultNotFound: Vault not found)"
+    },
+    {
+      "operation": "ListJobs",
+      "status": "working",
+      "message": "likely implemented (VaultNotFound: Vault not found)"
+    },
+    {
+      "operation": "ListMultipartUploads",
+      "status": "working",
+      "message": "likely implemented (VaultNotFound: Vault not found)"
+    },
+    {
+      "operation": "ListParts",
+      "status": "working",
+      "message": "likely implemented (VaultNotFound: Vault not found)"
+    },
+    {
+      "operation": "ListProvisionedCapacity",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTagsForVault",
+      "status": "working",
+      "message": "likely implemented (VaultNotFound: Vault not found)"
+    },
+    {
+      "operation": "ListVaults",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PurchaseProvisionedCapacity",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "RemoveTagsFromVault",
+      "status": "working",
+      "message": "likely implemented (VaultNotFound: Vault not found)"
+    },
+    {
+      "operation": "SetDataRetrievalPolicy",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "SetVaultAccessPolicy",
+      "status": "working",
+      "message": "likely implemented (VaultNotFound: Vault not found)"
+    },
+    {
+      "operation": "SetVaultNotifications",
+      "status": "working",
+      "message": "likely implemented (VaultNotFound: Vault not found)"
+    },
+    {
+      "operation": "UploadArchive",
+      "status": "working",
+      "message": "likely implemented (VaultNotFound: Vault not found)"
+    },
+    {
+      "operation": "UploadMultipartPart",
+      "status": "working",
+      "message": "likely implemented (VaultNotFound: Vault not found)"
+    }
+  ]
+}

--- a/probes/glue.json
+++ b/probes/glue.json
@@ -1,0 +1,1331 @@
+{
+  "service": "glue",
+  "counts": {
+    "working": 213,
+    "needs_params": 13,
+    "not_implemented": 34,
+    "500_error": 4
+  },
+  "operations": [
+    {
+      "operation": "BatchCreatePartition",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Database probe-test-value not found.)"
+    },
+    {
+      "operation": "BatchDeleteConnection",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "BatchDeletePartition",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Database probe-test-value not found.)"
+    },
+    {
+      "operation": "BatchDeleteTable",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "BatchDeleteTableVersion",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Database probe-test-value not found.)"
+    },
+    {
+      "operation": "BatchGetBlueprints",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "BatchGetCrawlers",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "BatchGetCustomEntityTypes",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "BatchGetDataQualityResult",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "BatchGetDevEndpoints",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "BatchGetJobs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "BatchGetPartition",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Database probe-test-value not found.)"
+    },
+    {
+      "operation": "BatchGetTableOptimizer",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "BatchGetTriggers",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "BatchGetWorkflows",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "BatchPutDataQualityStatisticAnnotation",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "BatchStopJobRun",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "BatchUpdatePartition",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CancelDataQualityRuleRecommendationRun",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CancelDataQualityRulesetEvaluationRun",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CancelMLTaskRun",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CancelStatement",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Session probe-test-value not found.)"
+    },
+    {
+      "operation": "CheckSchemaVersionValidity",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateBlueprint",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateCatalog",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateClassifier",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateColumnStatisticsTaskSettings",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Database probe-test-value not found.)"
+    },
+    {
+      "operation": "CreateConnection",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateCrawler",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateCustomEntityType",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateDataQualityRuleset",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateDatabase",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateDevEndpoint",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateGlueIdentityCenterConfiguration",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateIntegration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateIntegrationResourceProperty",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateIntegrationTableProperties",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateJob",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateMLTransform",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreatePartition",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Table probe-test-value not found.)"
+    },
+    {
+      "operation": "CreatePartitionIndex",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateRegistry",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateSchema",
+      "status": "working",
+      "message": "likely implemented (InvalidInputException: Data format is not valid.)"
+    },
+    {
+      "operation": "CreateScript",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateSecurityConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateSession",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateTable",
+      "status": "working",
+      "message": "likely implemented (InvalidInputException: TableInput is required.)"
+    },
+    {
+      "operation": "CreateTableOptimizer",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateTrigger",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateUsageProfile",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateUserDefinedFunction",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateWorkflow",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteBlueprint",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteCatalog",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteClassifier",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Classifier probe-test-value not found.)"
+    },
+    {
+      "operation": "DeleteColumnStatisticsForPartition",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Table probe-test-value not found.)"
+    },
+    {
+      "operation": "DeleteColumnStatisticsForTable",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Table probe-test-value not found.)"
+    },
+    {
+      "operation": "DeleteColumnStatisticsTaskSettings",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteConnection",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteConnectionType",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteCrawler",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteCustomEntityType",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteDataQualityRuleset",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteDatabase",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteDevEndpoint",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteGlueIdentityCenterConfiguration",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteIntegration",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'IntegrationArn')"
+    },
+    {
+      "operation": "DeleteIntegrationResourceProperty",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteIntegrationTableProperties",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteJob",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteMLTransform",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: MLTransform probe-test-value not found.)"
+    },
+    {
+      "operation": "DeletePartition",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Database probe-test-value not found.)"
+    },
+    {
+      "operation": "DeletePartitionIndex",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Database probe-test-value not found.)"
+    },
+    {
+      "operation": "DeleteRegistry",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteResourcePolicy",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Policy does not exist)"
+    },
+    {
+      "operation": "DeleteSchema",
+      "status": "working",
+      "message": "likely implemented (InvalidInputException: At least one of (registryName and schemaName) or schemaArn h)"
+    },
+    {
+      "operation": "DeleteSchemaVersions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteSecurityConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteSession",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Session probe-test-value not found.)"
+    },
+    {
+      "operation": "DeleteTableOptimizer",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteTableVersion",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Database probe-test-value not found.)"
+    },
+    {
+      "operation": "DeleteTrigger",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteUsageProfile",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteUserDefinedFunction",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Database probe-test-value not found.)"
+    },
+    {
+      "operation": "DeleteWorkflow",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeConnectionType",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeEntity",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeInboundIntegrations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeIntegrations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetBlueprint",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Blueprint probe-test-value not found.)"
+    },
+    {
+      "operation": "GetBlueprintRun",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Blueprint probe-test-value not found.)"
+    },
+    {
+      "operation": "GetBlueprintRuns",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Blueprint probe-test-value not found.)"
+    },
+    {
+      "operation": "GetCatalog",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Catalog probe-test-value not found.)"
+    },
+    {
+      "operation": "GetCatalogImportStatus",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetCatalogs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetClassifier",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Classifier probe-test-value not found.)"
+    },
+    {
+      "operation": "GetClassifiers",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetColumnStatisticsForPartition",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Database probe-test-value not found.)"
+    },
+    {
+      "operation": "GetColumnStatisticsForTable",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Database probe-test-value not found.)"
+    },
+    {
+      "operation": "GetColumnStatisticsTaskRun",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: ColumnStatisticsTaskRun probe-test-value not found.)"
+    },
+    {
+      "operation": "GetColumnStatisticsTaskRuns",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetColumnStatisticsTaskSettings",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: ColumnStatisticsTaskSettings for probe-test-value/probe-test)"
+    },
+    {
+      "operation": "GetConnection",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Connection probe-test-value not found)"
+    },
+    {
+      "operation": "GetConnections",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetCrawler",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Crawler probe-test-value not found.)"
+    },
+    {
+      "operation": "GetCrawlerMetrics",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetCrawlers",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetCustomEntityType",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: CustomEntityType probe-test-value not found.)"
+    },
+    {
+      "operation": "GetDataCatalogEncryptionSettings",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetDataQualityModel",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: DataQualityModel for profile probe-test-value not found.)"
+    },
+    {
+      "operation": "GetDataQualityModelResult",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: DataQualityModelResult for profile probe-test-value not foun)"
+    },
+    {
+      "operation": "GetDataQualityResult",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: DataQualityResult probe-test-value not found.)"
+    },
+    {
+      "operation": "GetDataQualityRuleRecommendationRun",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: DataQualityRuleRecommendationRun probe-test-value not found.)"
+    },
+    {
+      "operation": "GetDataQualityRuleset",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: DataQualityRuleset probe-test-value not found.)"
+    },
+    {
+      "operation": "GetDataQualityRulesetEvaluationRun",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: DataQualityRulesetEvaluationRun probe-test-value not found.)"
+    },
+    {
+      "operation": "GetDatabase",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Database probe-test-value not found.)"
+    },
+    {
+      "operation": "GetDatabases",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetDataflowGraph",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetDevEndpoint",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: DevEndpoint probe-test-value not found)"
+    },
+    {
+      "operation": "GetDevEndpoints",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetEntityRecords",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetGlueIdentityCenterConfiguration",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetIntegrationResourceProperty",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: IntegrationResourceProperty for arn:aws:glue:us-east-1:12345)"
+    },
+    {
+      "operation": "GetIntegrationTableProperties",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: IntegrationTableProperties for arn:aws:glue:us-east-1:123456)"
+    },
+    {
+      "operation": "GetJob",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Job probe-test-value not found.)"
+    },
+    {
+      "operation": "GetJobBookmark",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Job probe-test-value not found.)"
+    },
+    {
+      "operation": "GetJobRun",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Job probe-test-value not found.)"
+    },
+    {
+      "operation": "GetJobRuns",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Job probe-test-value not found.)"
+    },
+    {
+      "operation": "GetJobs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetMLTaskRun",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: MLTransform probe-test-value not found.)"
+    },
+    {
+      "operation": "GetMLTaskRuns",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: MLTransform probe-test-value not found.)"
+    },
+    {
+      "operation": "GetMLTransform",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: MLTransform probe-test-value not found.)"
+    },
+    {
+      "operation": "GetMLTransforms",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetMapping",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetMaterializedViewRefreshTaskRun",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetPartition",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Database probe-test-value not found.)"
+    },
+    {
+      "operation": "GetPartitionIndexes",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetPartitions",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Database probe-test-value not found.)"
+    },
+    {
+      "operation": "GetPlan",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetRegistry",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Registry is not found. RegistryName: default-registry)"
+    },
+    {
+      "operation": "GetResourcePolicies",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetResourcePolicy",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetSchema",
+      "status": "working",
+      "message": "likely implemented (InvalidInputException: At least one of (registryName and schemaName) or schemaArn h)"
+    },
+    {
+      "operation": "GetSchemaByDefinition",
+      "status": "working",
+      "message": "likely implemented (InvalidInputException: At least one of (registryName and schemaName) or schemaArn h)"
+    },
+    {
+      "operation": "GetSchemaVersion",
+      "status": "working",
+      "message": "likely implemented (InvalidInputException: At least one of (registryName and schemaName) or schemaArn h)"
+    },
+    {
+      "operation": "GetSchemaVersionsDiff",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetSecurityConfiguration",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: SecurityConfiguration probe-test-value not found)"
+    },
+    {
+      "operation": "GetSecurityConfigurations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetSession",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Session probe-test-value not found.)"
+    },
+    {
+      "operation": "GetStatement",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Session probe-test-value not found.)"
+    },
+    {
+      "operation": "GetTable",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Database probe-test-value not found.)"
+    },
+    {
+      "operation": "GetTableOptimizer",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetTableVersion",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Database probe-test-value not found.)"
+    },
+    {
+      "operation": "GetTableVersions",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Database probe-test-value not found.)"
+    },
+    {
+      "operation": "GetTables",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Database probe-test-value not found.)"
+    },
+    {
+      "operation": "GetTags",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetTrigger",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Trigger probe-test-value not found.)"
+    },
+    {
+      "operation": "GetTriggers",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetUnfilteredPartitionMetadata",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "GetUnfilteredPartitionsMetadata",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "GetUnfilteredTableMetadata",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "GetUsageProfile",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: UsageProfile probe-test-value not found.)"
+    },
+    {
+      "operation": "GetUserDefinedFunction",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Database probe-test-value not found.)"
+    },
+    {
+      "operation": "GetUserDefinedFunctions",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'DatabaseName')"
+    },
+    {
+      "operation": "GetWorkflow",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Entity not found)"
+    },
+    {
+      "operation": "GetWorkflowRun",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Entity not found)"
+    },
+    {
+      "operation": "GetWorkflowRunProperties",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Entity not found)"
+    },
+    {
+      "operation": "GetWorkflowRuns",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Entity not found)"
+    },
+    {
+      "operation": "ImportCatalogToGlue",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListBlueprints",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListColumnStatisticsTaskRuns",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListConnectionTypes",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListCrawlers",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListCrawls",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Crawler entry with name probe-test-value does not exist)"
+    },
+    {
+      "operation": "ListCustomEntityTypes",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListDataQualityResults",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListDataQualityRuleRecommendationRuns",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListDataQualityRulesetEvaluationRuns",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListDataQualityRulesets",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListDataQualityStatisticAnnotations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListDataQualityStatistics",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListDevEndpoints",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListEntities",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListIntegrationResourceProperties",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'ResourceArn')"
+    },
+    {
+      "operation": "ListJobs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListMLTransforms",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListMaterializedViewRefreshTaskRuns",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListRegistries",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListSchemaVersions",
+      "status": "working",
+      "message": "likely implemented (InvalidInputException: At least one of (registryName and schemaName) or schemaArn h)"
+    },
+    {
+      "operation": "ListSchemas",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListSessions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListStatements",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Session probe-test-value not found.)"
+    },
+    {
+      "operation": "ListTableOptimizerRuns",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListTriggers",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListUsageProfiles",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListWorkflows",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ModifyIntegration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutDataCatalogEncryptionSettings",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutDataQualityProfileAnnotation",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutResourcePolicy",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutSchemaVersionMetadata",
+      "status": "working",
+      "message": "likely implemented (InvalidInputException: The parameter value contains one or more characters that are)"
+    },
+    {
+      "operation": "PutWorkflowRunProperties",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Entity not found)"
+    },
+    {
+      "operation": "QuerySchemaVersionMetadata",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "RegisterConnectionType",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "RegisterSchemaVersion",
+      "status": "working",
+      "message": "likely implemented (InvalidInputException: At least one of (registryName and schemaName) or schemaArn h)"
+    },
+    {
+      "operation": "RemoveSchemaVersionMetadata",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ResetJobBookmark",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Job probe-test-value not found.)"
+    },
+    {
+      "operation": "ResumeWorkflowRun",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Entity not found)"
+    },
+    {
+      "operation": "RunStatement",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Session probe-test-value not found.)"
+    },
+    {
+      "operation": "SearchTables",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartBlueprintRun",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Blueprint probe-test-value not found.)"
+    },
+    {
+      "operation": "StartColumnStatisticsTaskRun",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Database probe-test-value not found.)"
+    },
+    {
+      "operation": "StartColumnStatisticsTaskRunSchedule",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Database probe-test-value not found.)"
+    },
+    {
+      "operation": "StartCrawler",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Crawler probe-test-value not found.)"
+    },
+    {
+      "operation": "StartCrawlerSchedule",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Crawler probe-test-value not found.)"
+    },
+    {
+      "operation": "StartDataQualityRuleRecommendationRun",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartDataQualityRulesetEvaluationRun",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "StartExportLabelsTaskRun",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StartImportLabelsTaskRun",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StartJobRun",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Job probe-test-value not found.)"
+    },
+    {
+      "operation": "StartMLEvaluationTaskRun",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StartMLLabelingSetGenerationTaskRun",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StartMaterializedViewRefreshTaskRun",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StartTrigger",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Trigger probe-test-value not found.)"
+    },
+    {
+      "operation": "StartWorkflowRun",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Entity not found)"
+    },
+    {
+      "operation": "StopColumnStatisticsTaskRun",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Database probe-test-value not found.)"
+    },
+    {
+      "operation": "StopColumnStatisticsTaskRunSchedule",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Database probe-test-value not found.)"
+    },
+    {
+      "operation": "StopCrawler",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Crawler probe-test-value not found.)"
+    },
+    {
+      "operation": "StopCrawlerSchedule",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Crawler probe-test-value not found.)"
+    },
+    {
+      "operation": "StopMaterializedViewRefreshTaskRun",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StopSession",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Session probe-test-value not found.)"
+    },
+    {
+      "operation": "StopTrigger",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Trigger probe-test-value not found.)"
+    },
+    {
+      "operation": "StopWorkflowRun",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Entity not found)"
+    },
+    {
+      "operation": "TagResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "TestConnection",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateBlueprint",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Blueprint probe-test-value not found.)"
+    },
+    {
+      "operation": "UpdateCatalog",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Catalog probe-test-value not found.)"
+    },
+    {
+      "operation": "UpdateClassifier",
+      "status": "working",
+      "message": "likely implemented (InvalidInputException: No classifier provided)"
+    },
+    {
+      "operation": "UpdateColumnStatisticsForPartition",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Database probe-test-value not found.)"
+    },
+    {
+      "operation": "UpdateColumnStatisticsForTable",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Database probe-test-value not found.)"
+    },
+    {
+      "operation": "UpdateColumnStatisticsTaskSettings",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: ColumnStatisticsTaskSettings for probe-test-value/probe-test)"
+    },
+    {
+      "operation": "UpdateConnection",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Connection probe-test-value not found)"
+    },
+    {
+      "operation": "UpdateCrawler",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Crawler probe-test-value not found.)"
+    },
+    {
+      "operation": "UpdateCrawlerSchedule",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Crawler probe-test-value not found.)"
+    },
+    {
+      "operation": "UpdateDataQualityRuleset",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: DataQualityRuleset probe-test-value not found.)"
+    },
+    {
+      "operation": "UpdateDatabase",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Database probe-test-value not found.)"
+    },
+    {
+      "operation": "UpdateDevEndpoint",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: DevEndpoint probe-test-value not found)"
+    },
+    {
+      "operation": "UpdateGlueIdentityCenterConfiguration",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateIntegrationResourceProperty",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: IntegrationResourceProperty for arn:aws:glue:us-east-1:12345)"
+    },
+    {
+      "operation": "UpdateIntegrationTableProperties",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: IntegrationTableProperties for arn:aws:glue:us-east-1:123456)"
+    },
+    {
+      "operation": "UpdateJob",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Job probe-test-value not found.)"
+    },
+    {
+      "operation": "UpdateJobFromSourceControl",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateMLTransform",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: MLTransform probe-test-value not found.)"
+    },
+    {
+      "operation": "UpdatePartition",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Database probe-test-value not found.)"
+    },
+    {
+      "operation": "UpdateRegistry",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'default-registry')"
+    },
+    {
+      "operation": "UpdateSchema",
+      "status": "working",
+      "message": "likely implemented (InvalidInputException: At least one of (registryName and schemaName) or schemaArn h)"
+    },
+    {
+      "operation": "UpdateSourceControlFromJob",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateTable",
+      "status": "working",
+      "message": "likely implemented (InvalidInputException: TableInput is required.)"
+    },
+    {
+      "operation": "UpdateTableOptimizer",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateTrigger",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Trigger probe-test-value not found.)"
+    },
+    {
+      "operation": "UpdateUsageProfile",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: UsageProfile probe-test-value not found.)"
+    },
+    {
+      "operation": "UpdateUserDefinedFunction",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Database probe-test-value not found.)"
+    },
+    {
+      "operation": "UpdateWorkflow",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Entity not found)"
+    }
+  ]
+}

--- a/probes/greengrass.json
+++ b/probes/greengrass.json
@@ -1,0 +1,471 @@
+{
+  "service": "greengrass",
+  "counts": {
+    "working": 61,
+    "needs_params": 0,
+    "not_implemented": 22,
+    "500_error": 9
+  },
+  "operations": [
+    {
+      "operation": "AssociateRoleToGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "AssociateServiceRoleToAccount",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateConnectorDefinition",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'NoneType' object has no attribute 'get')"
+    },
+    {
+      "operation": "CreateConnectorDefinitionVersion",
+      "status": "working",
+      "message": "likely implemented (IdNotFoundException: That connectors definition does not exist.)"
+    },
+    {
+      "operation": "CreateCoreDefinition",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'NoneType' object is not subscriptable)"
+    },
+    {
+      "operation": "CreateCoreDefinitionVersion",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "CreateDeployment",
+      "status": "working",
+      "message": "likely implemented (InvalidInputException: That deployment type is not valid.  Please specify one of th)"
+    },
+    {
+      "operation": "CreateDeviceDefinition",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'NoneType' object has no attribute 'get')"
+    },
+    {
+      "operation": "CreateDeviceDefinitionVersion",
+      "status": "working",
+      "message": "likely implemented (IdNotFoundException: That devices definition does not exist.)"
+    },
+    {
+      "operation": "CreateFunctionDefinition",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'NoneType' object has no attribute 'get')"
+    },
+    {
+      "operation": "CreateFunctionDefinitionVersion",
+      "status": "working",
+      "message": "likely implemented (IdNotFoundException: That lambdas does not exist.)"
+    },
+    {
+      "operation": "CreateGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateGroupCertificateAuthority",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateGroupVersion",
+      "status": "working",
+      "message": "likely implemented (IdNotFoundException: That group does not exist.)"
+    },
+    {
+      "operation": "CreateLoggerDefinition",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'NoneType' object has no attribute 'get')"
+    },
+    {
+      "operation": "CreateLoggerDefinitionVersion",
+      "status": "working",
+      "message": "likely implemented (IdNotFoundException: That loggers definition does not exist.)"
+    },
+    {
+      "operation": "CreateResourceDefinition",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'NoneType' object has no attribute 'get')"
+    },
+    {
+      "operation": "CreateResourceDefinitionVersion",
+      "status": "working",
+      "message": "likely implemented (IdNotFoundException: That resource definition does not exist.)"
+    },
+    {
+      "operation": "CreateSoftwareUpdateJob",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateSubscriptionDefinition",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'NoneType' object is not subscriptable)"
+    },
+    {
+      "operation": "CreateSubscriptionDefinitionVersion",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'NoneType' object is not iterable)"
+    },
+    {
+      "operation": "DeleteConnectorDefinition",
+      "status": "working",
+      "message": "likely implemented (IdNotFoundException: That connectors definition does not exist.)"
+    },
+    {
+      "operation": "DeleteCoreDefinition",
+      "status": "working",
+      "message": "likely implemented (IdNotFoundException: That cores definition does not exist.)"
+    },
+    {
+      "operation": "DeleteDeviceDefinition",
+      "status": "working",
+      "message": "likely implemented (IdNotFoundException: That devices definition does not exist.)"
+    },
+    {
+      "operation": "DeleteFunctionDefinition",
+      "status": "working",
+      "message": "likely implemented (IdNotFoundException: That lambdas definition does not exist.)"
+    },
+    {
+      "operation": "DeleteGroup",
+      "status": "working",
+      "message": "likely implemented (IdNotFoundException: That group definition does not exist.)"
+    },
+    {
+      "operation": "DeleteLoggerDefinition",
+      "status": "working",
+      "message": "likely implemented (IdNotFoundException: That loggers definition does not exist.)"
+    },
+    {
+      "operation": "DeleteResourceDefinition",
+      "status": "working",
+      "message": "likely implemented (IdNotFoundException: That resources definition does not exist.)"
+    },
+    {
+      "operation": "DeleteSubscriptionDefinition",
+      "status": "working",
+      "message": "likely implemented (IdNotFoundException: That subscriptions definition does not exist.)"
+    },
+    {
+      "operation": "DisassociateRoleFromGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DisassociateServiceRoleFromAccount",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetAssociatedRole",
+      "status": "working",
+      "message": "likely implemented (404: You need to attach an IAM role to this deployment group.)"
+    },
+    {
+      "operation": "GetBulkDeploymentStatus",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetConnectivityInfo",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetConnectorDefinition",
+      "status": "working",
+      "message": "likely implemented (IdNotFoundException: That Connector List Definition does not exist.)"
+    },
+    {
+      "operation": "GetConnectorDefinitionVersion",
+      "status": "working",
+      "message": "likely implemented (IdNotFoundException: That connectors definition does not exist.)"
+    },
+    {
+      "operation": "GetCoreDefinition",
+      "status": "working",
+      "message": "likely implemented (IdNotFoundException: That Core List Definition does not exist)"
+    },
+    {
+      "operation": "GetCoreDefinitionVersion",
+      "status": "working",
+      "message": "likely implemented (IdNotFoundException: That cores definition does not exist.)"
+    },
+    {
+      "operation": "GetDeploymentStatus",
+      "status": "working",
+      "message": "likely implemented (InvalidInputException: Deployment 'probe-test-value' does not exist.)"
+    },
+    {
+      "operation": "GetDeviceDefinition",
+      "status": "working",
+      "message": "likely implemented (IdNotFoundException: That Device List Definition does not exist.)"
+    },
+    {
+      "operation": "GetDeviceDefinitionVersion",
+      "status": "working",
+      "message": "likely implemented (IdNotFoundException: That devices definition does not exist.)"
+    },
+    {
+      "operation": "GetFunctionDefinition",
+      "status": "working",
+      "message": "likely implemented (IdNotFoundException: That Lambda List Definition does not exist.)"
+    },
+    {
+      "operation": "GetFunctionDefinitionVersion",
+      "status": "working",
+      "message": "likely implemented (IdNotFoundException: That lambdas definition does not exist.)"
+    },
+    {
+      "operation": "GetGroup",
+      "status": "working",
+      "message": "likely implemented (IdNotFoundException: That Group Definition does not exist.)"
+    },
+    {
+      "operation": "GetGroupCertificateAuthority",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetGroupCertificateConfiguration",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetGroupVersion",
+      "status": "working",
+      "message": "likely implemented (IdNotFoundException: That group definition does not exist.)"
+    },
+    {
+      "operation": "GetLoggerDefinition",
+      "status": "working",
+      "message": "likely implemented (IdNotFoundException: That Logger List Definition does not exist.)"
+    },
+    {
+      "operation": "GetLoggerDefinitionVersion",
+      "status": "working",
+      "message": "likely implemented (IdNotFoundException: That loggers definition does not exist.)"
+    },
+    {
+      "operation": "GetResourceDefinition",
+      "status": "working",
+      "message": "likely implemented (IdNotFoundException: That Resource List Definition does not exist.)"
+    },
+    {
+      "operation": "GetResourceDefinitionVersion",
+      "status": "working",
+      "message": "likely implemented (IdNotFoundException: That resources definition does not exist.)"
+    },
+    {
+      "operation": "GetServiceRoleForAccount",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetSubscriptionDefinition",
+      "status": "working",
+      "message": "likely implemented (IdNotFoundException: That Subscription List Definition does not exist.)"
+    },
+    {
+      "operation": "GetSubscriptionDefinitionVersion",
+      "status": "working",
+      "message": "likely implemented (IdNotFoundException: That subscriptions definition does not exist.)"
+    },
+    {
+      "operation": "GetThingRuntimeConfiguration",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListBulkDeploymentDetailedReports",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListBulkDeployments",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListConnectorDefinitionVersions",
+      "status": "working",
+      "message": "likely implemented (IdNotFoundException: That connectors definition does not exist.)"
+    },
+    {
+      "operation": "ListConnectorDefinitions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListCoreDefinitionVersions",
+      "status": "working",
+      "message": "likely implemented (IdNotFoundException: That cores definition does not exist.)"
+    },
+    {
+      "operation": "ListCoreDefinitions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListDeployments",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListDeviceDefinitionVersions",
+      "status": "working",
+      "message": "likely implemented (IdNotFoundException: That devices definition does not exist.)"
+    },
+    {
+      "operation": "ListDeviceDefinitions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListFunctionDefinitionVersions",
+      "status": "working",
+      "message": "likely implemented (IdNotFoundException: That lambdas definition does not exist.)"
+    },
+    {
+      "operation": "ListFunctionDefinitions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListGroupCertificateAuthorities",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListGroupVersions",
+      "status": "working",
+      "message": "likely implemented (IdNotFoundException: That group definition does not exist.)"
+    },
+    {
+      "operation": "ListGroups",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListLoggerDefinitionVersions",
+      "status": "working",
+      "message": "likely implemented (IdNotFoundException: That loggers definition does not exist.)"
+    },
+    {
+      "operation": "ListLoggerDefinitions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListResourceDefinitionVersions",
+      "status": "working",
+      "message": "likely implemented (IdNotFoundException: That resources definition does not exist.)"
+    },
+    {
+      "operation": "ListResourceDefinitions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListSubscriptionDefinitionVersions",
+      "status": "working",
+      "message": "likely implemented (IdNotFoundException: That subscriptions definition does not exist.)"
+    },
+    {
+      "operation": "ListSubscriptionDefinitions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ResetDeployments",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StartBulkDeployment",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StopBulkDeployment",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "TagResource",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateConnectivityInfo",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateConnectorDefinition",
+      "status": "working",
+      "message": "likely implemented (IdNotFoundException: That connectors definition does not exist.)"
+    },
+    {
+      "operation": "UpdateCoreDefinition",
+      "status": "working",
+      "message": "likely implemented (IdNotFoundException: That cores definition does not exist.)"
+    },
+    {
+      "operation": "UpdateDeviceDefinition",
+      "status": "working",
+      "message": "likely implemented (IdNotFoundException: That devices definition does not exist.)"
+    },
+    {
+      "operation": "UpdateFunctionDefinition",
+      "status": "working",
+      "message": "likely implemented (IdNotFoundException: That lambdas definition does not exist.)"
+    },
+    {
+      "operation": "UpdateGroup",
+      "status": "working",
+      "message": "likely implemented (IdNotFoundException: That group definition does not exist.)"
+    },
+    {
+      "operation": "UpdateGroupCertificateConfiguration",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateLoggerDefinition",
+      "status": "working",
+      "message": "likely implemented (IdNotFoundException: That loggers definition does not exist.)"
+    },
+    {
+      "operation": "UpdateResourceDefinition",
+      "status": "working",
+      "message": "likely implemented (IdNotFoundException: That resources definition does not exist.)"
+    },
+    {
+      "operation": "UpdateSubscriptionDefinition",
+      "status": "working",
+      "message": "likely implemented (IdNotFoundException: That subscriptions definition does not exist.)"
+    },
+    {
+      "operation": "UpdateThingRuntimeConfiguration",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    }
+  ]
+}

--- a/probes/iam.json
+++ b/probes/iam.json
@@ -1,0 +1,891 @@
+{
+  "service": "iam",
+  "counts": {
+    "working": 152,
+    "needs_params": 17,
+    "not_implemented": 7,
+    "500_error": 0
+  },
+  "operations": [
+    {
+      "operation": "AcceptDelegationRequest",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "AddClientIDToOpenIDConnectProvider",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "AddRoleToInstanceProfile",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "AddUserToGroup",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "AssociateDelegationRequest",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "AttachGroupPolicy",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "AttachRolePolicy",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "AttachUserPolicy",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "ChangePassword",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateAccessKey",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "CreateAccountAlias",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateDelegationRequest",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateInstanceProfile",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateLoginProfile",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "CreateOpenIDConnectProvider",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreatePolicy",
+      "status": "working",
+      "message": "implemented (MalformedPolicyDocument)"
+    },
+    {
+      "operation": "CreatePolicyVersion",
+      "status": "working",
+      "message": "implemented (MalformedPolicyDocument)"
+    },
+    {
+      "operation": "CreateRole",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateSAMLProvider",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateServiceLinkedRole",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateServiceSpecificCredential",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "CreateUser",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateVirtualMFADevice",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeactivateMFADevice",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "DeleteAccessKey",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "DeleteAccountAlias",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteAccountPasswordPolicy",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "DeleteGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteGroupPolicy",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "DeleteInstanceProfile",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteLoginProfile",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "DeleteOpenIDConnectProvider",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeletePolicy",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "DeletePolicyVersion",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "DeleteRole",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteRolePermissionsBoundary",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "DeleteRolePolicy",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "DeleteSAMLProvider",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteSSHPublicKey",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DeleteServerCertificate",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "DeleteServiceLinkedRole",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "DeleteServiceSpecificCredential",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DeleteSigningCertificate",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DeleteUser",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteUserPermissionsBoundary",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "DeleteUserPolicy",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "DeleteVirtualMFADevice",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "DetachGroupPolicy",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "DetachRolePolicy",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "DetachUserPolicy",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "DisableOrganizationsRootCredentialsManagement",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DisableOrganizationsRootSessions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DisableOutboundWebIdentityFederation",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "EnableMFADevice",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "EnableOrganizationsRootCredentialsManagement",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "EnableOrganizationsRootSessions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "EnableOutboundWebIdentityFederation",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GenerateCredentialReport",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GenerateOrganizationsAccessReport",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "GenerateServiceLastAccessedDetails",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetAccessKeyLastUsed",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "GetAccountAuthorizationDetails",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetAccountPasswordPolicy",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "GetAccountSummary",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetContextKeysForCustomPolicy",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetContextKeysForPrincipalPolicy",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetCredentialReport",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetDelegationRequest",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetGroup",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "GetGroupPolicy",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "GetHumanReadableSummary",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetInstanceProfile",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "GetLoginProfile",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "GetMFADevice",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "GetOpenIDConnectProvider",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "GetOrganizationsAccessReport",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "GetOutboundWebIdentityFederationInfo",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetPolicy",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "GetPolicyVersion",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "GetRole",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "GetRolePolicy",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "GetSAMLProvider",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "GetSSHPublicKey",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "GetServerCertificate",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "GetServiceLastAccessedDetails",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "GetServiceLastAccessedDetailsWithEntities",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "GetServiceLinkedRoleDeletionStatus",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetUser",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetUserPolicy",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "ListAccessKeys",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "ListAccountAliases",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListAttachedGroupPolicies",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "ListAttachedRolePolicies",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "ListAttachedUserPolicies",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "ListDelegationRequests",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListEntitiesForPolicy",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListGroupPolicies",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "ListGroups",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListGroupsForUser",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "ListInstanceProfileTags",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "ListInstanceProfiles",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListInstanceProfilesForRole",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListMFADeviceTags",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "ListMFADevices",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "ListOpenIDConnectProviderTags",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "ListOpenIDConnectProviders",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListOrganizationsFeatures",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListPolicies",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListPoliciesGrantingServiceAccess",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "ListPolicyTags",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "ListPolicyVersions",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "ListRolePolicies",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "ListRoleTags",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "ListRoles",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListSAMLProviderTags",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "ListSAMLProviders",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListSSHPublicKeys",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "ListServerCertificateTags",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "ListServerCertificates",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListServiceSpecificCredentials",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListSigningCertificates",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "ListUserPolicies",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "ListUserTags",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "ListUsers",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListVirtualMFADevices",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutGroupPolicy",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "PutRolePermissionsBoundary",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "PutRolePolicy",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "PutUserPermissionsBoundary",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "PutUserPolicy",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "RejectDelegationRequest",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "RemoveClientIDFromOpenIDConnectProvider",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "RemoveRoleFromInstanceProfile",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "RemoveUserFromGroup",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "ResetServiceSpecificCredential",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "ResyncMFADevice",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "SendDelegationToken",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "SetDefaultPolicyVersion",
+      "status": "working",
+      "message": "implemented (ValidationError)"
+    },
+    {
+      "operation": "SetSecurityTokenServicePreferences",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "SimulateCustomPolicy",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "SimulatePrincipalPolicy",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "TagInstanceProfile",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "TagMFADevice",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "TagOpenIDConnectProvider",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "TagPolicy",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "TagRole",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "TagSAMLProvider",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "TagServerCertificate",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "TagUser",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "UntagInstanceProfile",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "UntagMFADevice",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "UntagOpenIDConnectProvider",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "UntagPolicy",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "UntagRole",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "UntagSAMLProvider",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "UntagServerCertificate",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "UntagUser",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "UpdateAccessKey",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "UpdateAccountPasswordPolicy",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateAssumeRolePolicy",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "UpdateDelegationRequest",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateLoginProfile",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "UpdateOpenIDConnectProviderThumbprint",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "UpdateRole",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "UpdateRoleDescription",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "UpdateSAMLProvider",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "UpdateSSHPublicKey",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UpdateServerCertificate",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "UpdateServiceSpecificCredential",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UpdateSigningCertificate",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UpdateUser",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "UploadSSHPublicKey",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    },
+    {
+      "operation": "UploadServerCertificate",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UploadSigningCertificate",
+      "status": "working",
+      "message": "implemented (NoSuchEntity)"
+    }
+  ]
+}

--- a/probes/identitystore.json
+++ b/probes/identitystore.json
@@ -1,0 +1,106 @@
+{
+  "service": "identitystore",
+  "counts": {
+    "working": 10,
+    "needs_params": 8,
+    "not_implemented": 1,
+    "500_error": 0
+  },
+  "operations": [
+    {
+      "operation": "CreateGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateGroupMembership",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateUser",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DeleteGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteGroupMembership",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteUser",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeGroup",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeGroupMembership",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeUser",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetGroupId",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "GetGroupMembershipId",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "GetUserId",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "IsMemberInGroups",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "ListGroupMemberships",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListGroupMembershipsForMember",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "ListGroups",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListUsers",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateGroup",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UpdateUser",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    }
+  ]
+}

--- a/probes/inspector2.json
+++ b/probes/inspector2.json
@@ -1,0 +1,386 @@
+{
+  "service": "inspector2",
+  "counts": {
+    "working": 58,
+    "needs_params": 14,
+    "not_implemented": 0,
+    "500_error": 3
+  },
+  "operations": [
+    {
+      "operation": "AssociateMember",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "BatchAssociateCodeSecurityScanConfiguration",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "BatchDisassociateCodeSecurityScanConfiguration",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "BatchGetAccountStatus",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "BatchGetCodeSnippet",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "BatchGetFindingDetails",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "BatchGetFreeTrialInfo",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "BatchGetMemberEc2DeepInspectionStatus",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "BatchUpdateMemberEc2DeepInspectionStatus",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CancelFindingsReport",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CancelSbomExport",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateCisScanConfiguration",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateCodeSecurityIntegration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateCodeSecurityScanConfiguration",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateFilter",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateFindingsReport",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateSbomExport",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteCisScanConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteCodeSecurityIntegration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteCodeSecurityScanConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteFilter",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeOrganizationConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "Disable",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'NoneType' object is not iterable)"
+    },
+    {
+      "operation": "DisableDelegatedAdminAccount",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DisassociateMember",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "Enable",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "EnableDelegatedAdminAccount",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetCisScanReport",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetCisScanResultDetails",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetClustersForImage",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetCodeSecurityIntegration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetCodeSecurityScan",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "GetCodeSecurityScanConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetDelegatedAdminAccount",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetEc2DeepInspectionConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetEncryptionKey",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetFindingsReportStatus",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetMember",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetSbomExport",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListAccountPermissions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListCisScanConfigurations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListCisScanResultsAggregatedByChecks",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListCisScanResultsAggregatedByTargetResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListCisScans",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListCodeSecurityIntegrations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListCodeSecurityScanConfigurationAssociations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListCodeSecurityScanConfigurations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListCoverage",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListCoverageStatistics",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListDelegatedAdminAccounts",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListFilters",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListFindingAggregations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListFindings",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListMembers",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListUsageTotals",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ResetEncryptionKey",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "SearchVulnerabilities",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "SendCisSessionHealth",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "SendCisSessionTelemetry",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "StartCisSession",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartCodeSecurityScan",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "StopCisSession",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "TagResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'NoneType' object is not iterable)"
+    },
+    {
+      "operation": "UpdateCisScanConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateCodeSecurityIntegration",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UpdateCodeSecurityScanConfiguration",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UpdateConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateEc2DeepInspectionConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateEncryptionKey",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateFilter",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'arn:aws:inspector2:us-east-1:123456789012:thing/probe-test')"
+    },
+    {
+      "operation": "UpdateOrgEc2DeepInspectionConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateOrganizationConfiguration",
+      "status": "working",
+      "message": "OK"
+    }
+  ]
+}

--- a/probes/iot.json
+++ b/probes/iot.json
@@ -1,0 +1,1371 @@
+{
+  "service": "iot",
+  "counts": {
+    "working": 216,
+    "needs_params": 21,
+    "not_implemented": 34,
+    "500_error": 1
+  },
+  "operations": [
+    {
+      "operation": "AcceptCertificateTransfer",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "AddThingToBillingGroup",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "AddThingToThingGroup",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "AssociateSbomWithPackageVersion",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "AssociateTargetsWithJob",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "AttachPolicy",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "AttachPrincipalPolicy",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "AttachSecurityProfile",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "AttachThingPrincipal",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "CancelAuditMitigationActionsTask",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CancelAuditTask",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CancelCertificateTransfer",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CancelDetectMitigationActionsTask",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CancelJob",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "CancelJobExecution",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ClearDefaultAuthorizer",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ConfirmTopicRuleDestination",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateAuditSuppression",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateAuthorizer",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateBillingGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateCertificateFromCsr",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "CreateCertificateProvider",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateCommand",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateCustomMetric",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateDimension",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateDomainConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateDynamicThingGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateFleetMetric",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateJob",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateJobTemplate",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateKeysAndCertificate",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateMitigationAction",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateOTAUpdate",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreatePackage",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreatePackageVersion",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreatePolicy",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreatePolicyVersion",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateProvisioningClaim",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateProvisioningTemplate",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateProvisioningTemplateVersion",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateRoleAlias",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateScheduledAudit",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateSecurityProfile",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateStream",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateThing",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateThingGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateThingType",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateTopicRule",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "CreateTopicRuleDestination",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteAccountAuditConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteAuditSuppression",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteAuthorizer",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteBillingGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteCACertificate",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DeleteCertificate",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DeleteCertificateProvider",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteCommand",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteCommandExecution",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteCustomMetric",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteDimension",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteDomainConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteDynamicThingGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteFleetMetric",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteJob",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteJobExecution",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteJobTemplate",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteMitigationAction",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteOTAUpdate",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeletePackage",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeletePackageVersion",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeletePolicy",
+      "status": "working",
+      "message": "likely implemented (DeleteConflictException: Cannot delete the policy because it has one or more policy v)"
+    },
+    {
+      "operation": "DeletePolicyVersion",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteProvisioningTemplate",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteProvisioningTemplateVersion",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteRegistrationCode",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteRoleAlias",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteScheduledAudit",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteSecurityProfile",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteStream",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteThing",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteThingGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteThingType",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteTopicRule",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteTopicRuleDestination",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteV2LoggingLevel",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeprecateThingType",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeAccountAuditConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeAuditFinding",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeAuditMitigationActionsTask",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeAuditSuppression",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeAuditTask",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeAuthorizer",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeBillingGroup",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeCACertificate",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DescribeCertificate",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DescribeCertificateProvider",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeCustomMetric",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeDefaultAuthorizer",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeDetectMitigationActionsTask",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeDimension",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeDomainConfiguration",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeEncryptionConfiguration",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeEndpoint",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeEventConfigurations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeFleetMetric",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeIndex",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeJob",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeJobExecution",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeJobTemplate",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeManagedJobTemplate",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeMitigationAction",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeProvisioningTemplate",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeProvisioningTemplateVersion",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeRoleAlias",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeScheduledAudit",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeSecurityProfile",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeStream",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeThing",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeThingGroup",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeThingRegistrationTask",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeThingType",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DetachPolicy",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DetachPrincipalPolicy",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DetachSecurityProfile",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DetachThingPrincipal",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DisableTopicRule",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DisassociateSbomFromPackageVersion",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "EnableTopicRule",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetBehaviorModelTrainingSummaries",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetBucketsAggregation",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetCardinality",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetCommand",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetCommandExecution",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetEffectivePolicies",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetIndexingConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetJobDocument",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetLoggingOptions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetOTAUpdate",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetPackage",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetPackageConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetPackageVersion",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetPercentiles",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetPolicy",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetPolicyVersion",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetRegistrationCode",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetStatistics",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetThingConnectivityData",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetTopicRule",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetTopicRuleDestination",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetV2LoggingOptions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListActiveViolations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListAttachedPolicies",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListAuditFindings",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListAuditMitigationActionsExecutions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListAuditMitigationActionsTasks",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListAuditSuppressions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListAuditTasks",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListAuthorizers",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListBillingGroups",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListCACertificates",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListCertificateProviders",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListCertificates",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListCertificatesByCA",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "ListCommandExecutions",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListCommands",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListCustomMetrics",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListDetectMitigationActionsExecutions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListDetectMitigationActionsTasks",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListDimensions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListDomainConfigurations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListFleetMetrics",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListIndices",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListJobExecutionsForJob",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListJobExecutionsForThing",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListJobTemplates",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListJobs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListManagedJobTemplates",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListMetricValues",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListMitigationActions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListOTAUpdates",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListOutgoingCertificates",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListPackageVersions",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListPackages",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListPolicies",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListPolicyPrincipals",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListPolicyVersions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListPrincipalPolicies",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListPrincipalThings",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListPrincipalThingsV2",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListProvisioningTemplateVersions",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListProvisioningTemplates",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListRelatedResourcesForAuditFinding",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListRoleAliases",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListSbomValidationResults",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListScheduledAudits",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListSecurityProfiles",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListSecurityProfilesForTarget",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListStreams",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "working",
+      "message": "likely implemented (404: )"
+    },
+    {
+      "operation": "ListTargetsForPolicy",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTargetsForSecurityProfile",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListThingGroups",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListThingGroupsForThing",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListThingPrincipals",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListThingPrincipalsV2",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListThingRegistrationTaskReports",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListThingRegistrationTasks",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListThingTypes",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListThings",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListThingsInBillingGroup",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListThingsInThingGroup",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListTopicRuleDestinations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTopicRules",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListV2LoggingLevels",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListViolationEvents",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutVerificationStateOnViolation",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "RegisterCACertificate",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "RegisterCertificate",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "RegisterCertificateWithoutCA",
+      "status": "working",
+      "message": "likely implemented (ResourceAlreadyExistsException: The certificate is already provisioned or registered)"
+    },
+    {
+      "operation": "RegisterThing",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "RejectCertificateTransfer",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "RemoveThingFromBillingGroup",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "RemoveThingFromThingGroup",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "ReplaceTopicRule",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "SearchIndex",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "SetDefaultAuthorizer",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "SetDefaultPolicyVersion",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "SetLoggingOptions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "SetV2LoggingLevel",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "SetV2LoggingOptions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartAuditMitigationActionsTask",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartDetectMitigationActionsTask",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "StartOnDemandAuditTask",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartThingRegistrationTask",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StopThingRegistrationTask",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "TagResource",
+      "status": "working",
+      "message": "likely implemented (404: )"
+    },
+    {
+      "operation": "TestAuthorization",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "TestInvokeAuthorizer",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "TransferCertificate",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateAccountAuditConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateAuditSuppression",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateAuthorizer",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateBillingGroup",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateCACertificate",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UpdateCertificate",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UpdateCertificateProvider",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateCommand",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateCustomMetric",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateDimension",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UpdateDomainConfiguration",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateDynamicThingGroup",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateEncryptionConfiguration",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateEventConfigurations",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'NoneType' object is not iterable)"
+    },
+    {
+      "operation": "UpdateFleetMetric",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateIndexingConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateJob",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateMitigationAction",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdatePackage",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdatePackageConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdatePackageVersion",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateProvisioningTemplate",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateRoleAlias",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateScheduledAudit",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateSecurityProfile",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateStream",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateThing",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateThingGroup",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateThingGroupsForThing",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateThingType",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateTopicRuleDestination",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ValidateSecurityProfileBehaviors",
+      "status": "working",
+      "message": "OK"
+    }
+  ]
+}

--- a/probes/ivs.json
+++ b/probes/ivs.json
@@ -1,0 +1,186 @@
+{
+  "service": "ivs",
+  "counts": {
+    "working": 20,
+    "needs_params": 3,
+    "not_implemented": 12,
+    "500_error": 0
+  },
+  "operations": [
+    {
+      "operation": "BatchGetChannel",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "BatchGetStreamKey",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "BatchStartViewerSessionRevocation",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateChannel",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreatePlaybackRestrictionPolicy",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateRecordingConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateStreamKey",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteChannel",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeletePlaybackKeyPair",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeletePlaybackRestrictionPolicy",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteRecordingConfiguration",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteStreamKey",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetChannel",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetPlaybackKeyPair",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetPlaybackRestrictionPolicy",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetRecordingConfiguration",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetStream",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetStreamKey",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetStreamSession",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ImportPlaybackKeyPair",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListChannels",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListPlaybackKeyPairs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListPlaybackRestrictionPolicies",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListRecordingConfigurations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListStreamKeys",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListStreamSessions",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListStreams",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "PutMetadata",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StartViewerSessionRevocation",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StopStream",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "TagResource",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateChannel",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdatePlaybackRestrictionPolicy",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    }
+  ]
+}

--- a/probes/kinesis.json
+++ b/probes/kinesis.json
@@ -1,0 +1,206 @@
+{
+  "service": "kinesis",
+  "counts": {
+    "working": 27,
+    "needs_params": 6,
+    "not_implemented": 5,
+    "500_error": 1
+  },
+  "operations": [
+    {
+      "operation": "AddTagsToStream",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "CreateStream",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DecreaseStreamRetentionPeriod",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteResourcePolicy",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteStream",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeregisterStreamConsumer",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeAccountSettings",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeLimits",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeStream",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeStreamConsumer",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeStreamSummary",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DisableEnhancedMonitoring",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "EnableEnhancedMonitoring",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "GetRecords",
+      "status": "working",
+      "message": "likely implemented (InvalidArgumentException: Invalid ShardIterator.)"
+    },
+    {
+      "operation": "GetResourcePolicy",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetShardIterator",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "IncreaseStreamRetentionPeriod",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListShards",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListStreamConsumers",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListStreams",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListTagsForStream",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "MergeShards",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "PutRecord",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "PutRecords",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "PutResourcePolicy",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "RegisterStreamConsumer",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "RemoveTagsFromStream",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "SplitShard",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "StartStreamEncryption",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "StopStreamEncryption",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "SubscribeToShard",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "TagResource",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UpdateAccountSettings",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateMaxRecordSize",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UpdateShardCount",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateStreamMode",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'NoneType' object has no attribute 'stream_mode' and no __di)"
+    },
+    {
+      "operation": "UpdateStreamWarmThroughput",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    }
+  ]
+}

--- a/probes/kinesisvideo.json
+++ b/probes/kinesisvideo.json
@@ -1,0 +1,171 @@
+{
+  "service": "kinesisvideo",
+  "counts": {
+    "working": 13,
+    "needs_params": 3,
+    "not_implemented": 16,
+    "500_error": 0
+  },
+  "operations": [
+    {
+      "operation": "CreateSignalingChannel",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateStream",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteEdgeConfiguration",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteSignalingChannel",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteStream",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeEdgeConfiguration",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeImageGenerationConfiguration",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeMappedResourceConfiguration",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeMediaStorageConfiguration",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeNotificationConfiguration",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeSignalingChannel",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeStream",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeStreamStorageConfiguration",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetDataEndpoint",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetSignalingChannelEndpoint",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListEdgeAgentConfigurations",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListSignalingChannels",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListStreams",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListTagsForStream",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StartEdgeConfigurationUpdate",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "TagResource",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "TagStream",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UntagStream",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UpdateDataRetention",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateImageGenerationConfiguration",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateMediaStorageConfiguration",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateNotificationConfiguration",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateSignalingChannel",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateStream",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateStreamStorageConfiguration",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    }
+  ]
+}

--- a/probes/lakeformation.json
+++ b/probes/lakeformation.json
@@ -1,0 +1,316 @@
+{
+  "service": "lakeformation",
+  "counts": {
+    "working": 31,
+    "needs_params": 10,
+    "not_implemented": 18,
+    "500_error": 2
+  },
+  "operations": [
+    {
+      "operation": "AddLFTagsToResource",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "AssumeDecoratedRoleWithSAML",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "BatchGrantPermissions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "BatchRevokePermissions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CancelTransaction",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Entity not found)"
+    },
+    {
+      "operation": "CommitTransaction",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Entity not found)"
+    },
+    {
+      "operation": "CreateDataCellsFilter",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateLFTag",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateLFTagExpression",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateLakeFormationIdentityCenterConfiguration",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateLakeFormationOptIn",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteDataCellsFilter",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Entity not found)"
+    },
+    {
+      "operation": "DeleteLFTag",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteLFTagExpression",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteLakeFormationIdentityCenterConfiguration",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteLakeFormationOptIn",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteObjectsOnCancel",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DeregisterResource",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Entity not found)"
+    },
+    {
+      "operation": "DescribeLakeFormationIdentityCenterConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeResource",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Entity not found)"
+    },
+    {
+      "operation": "DescribeTransaction",
+      "status": "working",
+      "message": "likely implemented (EntityNotFoundException: Entity not found)"
+    },
+    {
+      "operation": "ExtendTransaction",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetDataCellsFilter",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetDataLakePrincipal",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetDataLakeSettings",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetEffectivePermissionsForPath",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetLFTag",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetLFTagExpression",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetQueryState",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "GetQueryStatistics",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "GetResourceLFTags",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetTableObjects",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetTemporaryDataLocationCredentials",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetTemporaryGluePartitionCredentials",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "GetTemporaryGlueTableCredentials",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetWorkUnitResults",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "GetWorkUnits",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "GrantPermissions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListDataCellsFilter",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListLFTagExpressions",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListLFTags",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListLakeFormationOptIns",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListPermissions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListResources",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTableStorageOptimizers",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListTransactions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutDataLakeSettings",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "RegisterResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "RemoveLFTagsFromResource",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "RevokePermissions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "SearchDatabasesByLFTags",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "SearchTablesByLFTags",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartQueryPlanning",
+      "status": "500_error",
+      "message": "exception: Could not connect to the endpoint URL: \"http://query-localho"
+    },
+    {
+      "operation": "StartTransaction",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateDataCellsFilter",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateLFTag",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "UpdateLFTagExpression",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateLakeFormationIdentityCenterConfiguration",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateResource",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateTableObjects",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UpdateTableStorageOptimizer",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    }
+  ]
+}

--- a/probes/lambda.json
+++ b/probes/lambda.json
@@ -1,0 +1,431 @@
+{
+  "service": "lambda",
+  "counts": {
+    "working": 64,
+    "needs_params": 2,
+    "not_implemented": 18,
+    "500_error": 0
+  },
+  "operations": [
+    {
+      "operation": "AddLayerVersionPermission",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "AddPermission",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "CheckpointDurableExecution",
+      "status": "not_implemented",
+      "message": "not implemented (InvalidRequest)"
+    },
+    {
+      "operation": "CreateAlias",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "CreateCapacityProvider",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateCodeSigningConfig",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateEventSourceMapping",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateFunction",
+      "status": "working",
+      "message": "likely implemented (InvalidRoleFormat: 400 Bad Request: {\"__type\": \"ValidationException\", \"message\")"
+    },
+    {
+      "operation": "CreateFunctionUrlConfig",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteAlias",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteCapacityProvider",
+      "status": "not_implemented",
+      "message": "not implemented (InvalidRequest)"
+    },
+    {
+      "operation": "DeleteCodeSigningConfig",
+      "status": "not_implemented",
+      "message": "not implemented (InvalidRequest)"
+    },
+    {
+      "operation": "DeleteEventSourceMapping",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteFunctionCodeSigningConfig",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteFunctionConcurrency",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteFunctionEventInvokeConfig",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteFunctionUrlConfig",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteLayerVersion",
+      "status": "working",
+      "message": "likely implemented (UnknownLayerException: 404 Not Found: {\"__type\": \"ResourceNotFoundException\", \"mess)"
+    },
+    {
+      "operation": "DeleteProvisionedConcurrencyConfig",
+      "status": "working",
+      "message": "likely implemented (ProvisionedConcurrencyConfigNotFoundException: No provisioned concurrency config for probe-test-value:probe)"
+    },
+    {
+      "operation": "GetAccountSettings",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetAlias",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetCapacityProvider",
+      "status": "not_implemented",
+      "message": "not implemented (InvalidRequest)"
+    },
+    {
+      "operation": "GetCodeSigningConfig",
+      "status": "not_implemented",
+      "message": "not implemented (InvalidRequest)"
+    },
+    {
+      "operation": "GetDurableExecution",
+      "status": "not_implemented",
+      "message": "not implemented (InvalidRequest)"
+    },
+    {
+      "operation": "GetDurableExecutionHistory",
+      "status": "not_implemented",
+      "message": "not implemented (InvalidRequest)"
+    },
+    {
+      "operation": "GetDurableExecutionState",
+      "status": "not_implemented",
+      "message": "not implemented (InvalidRequest)"
+    },
+    {
+      "operation": "GetEventSourceMapping",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetFunction",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetFunctionCodeSigningConfig",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetFunctionConcurrency",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetFunctionConfiguration",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetFunctionEventInvokeConfig",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetFunctionRecursionConfig",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetFunctionScalingConfig",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetFunctionUrlConfig",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetLayerVersion",
+      "status": "working",
+      "message": "likely implemented (UnknownLayerException: 404 Not Found: {\"__type\": \"ResourceNotFoundException\", \"mess)"
+    },
+    {
+      "operation": "GetLayerVersionByArn",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetLayerVersionPolicy",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetPolicy",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetProvisionedConcurrencyConfig",
+      "status": "working",
+      "message": "likely implemented (ProvisionedConcurrencyConfigNotFoundException: No provisioned concurrency config for probe-test-value:probe)"
+    },
+    {
+      "operation": "GetRuntimeManagementConfig",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "Invoke",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "InvokeAsync",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "InvokeWithResponseStream",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListAliases",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListCapacityProviders",
+      "status": "not_implemented",
+      "message": "not implemented (InvalidRequest)"
+    },
+    {
+      "operation": "ListCodeSigningConfigs",
+      "status": "not_implemented",
+      "message": "not implemented (InvalidRequest)"
+    },
+    {
+      "operation": "ListDurableExecutionsByFunction",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListEventSourceMappings",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListFunctionEventInvokeConfigs",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListFunctionUrlConfigs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListFunctionVersionsByCapacityProvider",
+      "status": "not_implemented",
+      "message": "not implemented (InvalidRequest)"
+    },
+    {
+      "operation": "ListFunctions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListFunctionsByCodeSigningConfig",
+      "status": "not_implemented",
+      "message": "not implemented (InvalidRequest)"
+    },
+    {
+      "operation": "ListLayerVersions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListLayers",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListProvisionedConcurrencyConfigs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTags",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListVersionsByFunction",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PublishLayerVersion",
+      "status": "working",
+      "message": "implemented (InvalidParameterValueException)"
+    },
+    {
+      "operation": "PublishVersion",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "PutFunctionCodeSigningConfig",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "PutFunctionConcurrency",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "PutFunctionEventInvokeConfig",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "PutFunctionRecursionConfig",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "PutFunctionScalingConfig",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "PutProvisionedConcurrencyConfig",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutRuntimeManagementConfig",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "RemoveLayerVersionPermission",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "RemovePermission",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "SendDurableExecutionCallbackFailure",
+      "status": "not_implemented",
+      "message": "not implemented (InvalidRequest)"
+    },
+    {
+      "operation": "SendDurableExecutionCallbackHeartbeat",
+      "status": "not_implemented",
+      "message": "not implemented (InvalidRequest)"
+    },
+    {
+      "operation": "SendDurableExecutionCallbackSuccess",
+      "status": "not_implemented",
+      "message": "not implemented (InvalidRequest)"
+    },
+    {
+      "operation": "StopDurableExecution",
+      "status": "not_implemented",
+      "message": "not implemented (InvalidRequest)"
+    },
+    {
+      "operation": "TagResource",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateAlias",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateCapacityProvider",
+      "status": "not_implemented",
+      "message": "not implemented (InvalidRequest)"
+    },
+    {
+      "operation": "UpdateCodeSigningConfig",
+      "status": "not_implemented",
+      "message": "not implemented (InvalidRequest)"
+    },
+    {
+      "operation": "UpdateEventSourceMapping",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateFunctionCode",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateFunctionConfiguration",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateFunctionEventInvokeConfig",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateFunctionUrlConfig",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    }
+  ]
+}

--- a/probes/logs.json
+++ b/probes/logs.json
@@ -1,0 +1,551 @@
+{
+  "service": "logs",
+  "counts": {
+    "working": 91,
+    "needs_params": 10,
+    "not_implemented": 5,
+    "500_error": 2
+  },
+  "operations": [
+    {
+      "operation": "AssociateKmsKey",
+      "status": "working",
+      "message": "implemented (InvalidParameterException)"
+    },
+    {
+      "operation": "AssociateSourceToS3TableIntegration",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CancelExportTask",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "CancelImportTask",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateDelivery",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "CreateExportTask",
+      "status": "working",
+      "message": "implemented (InvalidParameterException)"
+    },
+    {
+      "operation": "CreateImportTask",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateLogAnomalyDetector",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateLogGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateLogStream",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateScheduledQuery",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteAccountPolicy",
+      "status": "working",
+      "message": "implemented (InvalidParameterException)"
+    },
+    {
+      "operation": "DeleteDataProtectionPolicy",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteDelivery",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteDeliveryDestination",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteDeliveryDestinationPolicy",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteDeliverySource",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteDestination",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteIndexPolicy",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteIntegration",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteLogAnomalyDetector",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteLogGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteLogStream",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteMetricFilter",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteQueryDefinition",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteResourcePolicy",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteRetentionPolicy",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteScheduledQuery",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteSubscriptionFilter",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteTransformer",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeAccountPolicies",
+      "status": "working",
+      "message": "implemented (InvalidParameterException)"
+    },
+    {
+      "operation": "DescribeConfigurationTemplates",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeDeliveries",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeDeliveryDestinations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeDeliverySources",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeDestinations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeExportTasks",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeFieldIndexes",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DescribeImportTaskBatches",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeImportTasks",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeIndexPolicies",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DescribeLogGroups",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeLogStreams",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeMetricFilters",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeQueries",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeQueryDefinitions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeResourcePolicies",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeSubscriptionFilters",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DisassociateKmsKey",
+      "status": "working",
+      "message": "implemented (InvalidParameterException)"
+    },
+    {
+      "operation": "DisassociateSourceFromS3TableIntegration",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "FilterLogEvents",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetDataProtectionPolicy",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetDelivery",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetDeliveryDestination",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetDeliveryDestinationPolicy",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetDeliverySource",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetIntegration",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetLogAnomalyDetector",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetLogEvents",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetLogFields",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetLogGroupFields",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetLogObject",
+      "status": "500_error",
+      "message": "exception: Could not connect to the endpoint URL: \"http://streaming-loc"
+    },
+    {
+      "operation": "GetLogRecord",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetQueryResults",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetScheduledQuery",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetScheduledQueryHistory",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetTransformer",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListAggregateLogGroupSummaries",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListAnomalies",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListIntegrations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListLogAnomalyDetectors",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListLogGroups",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListLogGroupsForQuery",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListScheduledQueries",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListSourcesForS3TableIntegration",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTagsLogGroup",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "PutAccountPolicy",
+      "status": "working",
+      "message": "implemented (InvalidParameterException)"
+    },
+    {
+      "operation": "PutBearerTokenAuthentication",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "PutDataProtectionPolicy",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "PutDeliveryDestination",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'NoneType' object is not subscriptable)"
+    },
+    {
+      "operation": "PutDeliveryDestinationPolicy",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "PutDeliverySource",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "PutDestination",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutDestinationPolicy",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutIndexPolicy",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "PutIntegration",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "PutLogEvents",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "PutLogGroupDeletionProtection",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "PutMetricFilter",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "PutQueryDefinition",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutResourcePolicy",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutRetentionPolicy",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "PutSubscriptionFilter",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutTransformer",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "StartLiveTail",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "StartQuery",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StopQuery",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "TagLogGroup",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "TagResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "TestMetricFilter",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "TestTransformer",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UntagLogGroup",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateAnomaly",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateDeliveryConfiguration",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateLogAnomalyDetector",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateScheduledQuery",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    }
+  ]
+}

--- a/probes/managedblockchain.json
+++ b/probes/managedblockchain.json
@@ -1,0 +1,146 @@
+{
+  "service": "managedblockchain",
+  "counts": {
+    "working": 17,
+    "needs_params": 0,
+    "not_implemented": 7,
+    "500_error": 3
+  },
+  "operations": [
+    {
+      "operation": "CreateAccessor",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateMember",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "CreateNetwork",
+      "status": "working",
+      "message": "likely implemented (BadRequestException: An error occurred (BadRequestException) when calling the Cre)"
+    },
+    {
+      "operation": "CreateNode",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'MemberId')"
+    },
+    {
+      "operation": "CreateProposal",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteAccessor",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteMember",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteNode",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetAccessor",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetMember",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetNetwork",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetNode",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetProposal",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListAccessors",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListInvitations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListMembers",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListNetworks",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListNodes",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListProposalVotes",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListProposals",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "RejectInvitation",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "TagResource",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateMember",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'MemberId')"
+    },
+    {
+      "operation": "UpdateNode",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'MemberId')"
+    },
+    {
+      "operation": "VoteOnProposal",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    }
+  ]
+}

--- a/probes/mediaconnect.json
+++ b/probes/mediaconnect.json
@@ -1,0 +1,421 @@
+{
+  "service": "mediaconnect",
+  "counts": {
+    "working": 12,
+    "needs_params": 6,
+    "not_implemented": 63,
+    "500_error": 1
+  },
+  "operations": [
+    {
+      "operation": "AddBridgeOutputs",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "AddBridgeSources",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "AddFlowMediaStreams",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "AddFlowOutputs",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "AddFlowSources",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "AddFlowVpcInterfaces",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "BatchGetRouterInput",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "BatchGetRouterNetworkInterface",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "BatchGetRouterOutput",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateBridge",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateFlow",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'NoneType' object is not iterable)"
+    },
+    {
+      "operation": "CreateGateway",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateRouterInput",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateRouterNetworkInterface",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateRouterOutput",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DeleteBridge",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteFlow",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteGateway",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteRouterInput",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteRouterNetworkInterface",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteRouterOutput",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeregisterGatewayInstance",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeBridge",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeFlow",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeFlowSourceMetadata",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeFlowSourceThumbnail",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeGateway",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeGatewayInstance",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeOffering",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeReservation",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetRouterInput",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetRouterInputSourceMetadata",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetRouterInputThumbnail",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetRouterNetworkInterface",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetRouterOutput",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GrantFlowEntitlements",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListBridges",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListEntitlements",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListFlows",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListGatewayInstances",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListGateways",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListOfferings",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListReservations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListRouterInputs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListRouterNetworkInterfaces",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListRouterOutputs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTagsForGlobalResource",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "PurchaseOffering",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "RemoveBridgeOutput",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "RemoveBridgeSource",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "RemoveFlowMediaStream",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "RemoveFlowOutput",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "RemoveFlowSource",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "RemoveFlowVpcInterface",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "RestartRouterInput",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "RestartRouterOutput",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "RevokeFlowEntitlement",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StartFlow",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StartRouterInput",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StartRouterOutput",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StopFlow",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StopRouterInput",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StopRouterOutput",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "TagGlobalResource",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "TagResource",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "TakeRouterInput",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UntagGlobalResource",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateBridge",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateBridgeOutput",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateBridgeSource",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateBridgeState",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateFlow",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateFlowEntitlement",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateFlowMediaStream",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateFlowOutput",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateFlowSource",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateGatewayInstance",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateRouterInput",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateRouterNetworkInterface",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateRouterOutput",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    }
+  ]
+}

--- a/probes/mediapackage.json
+++ b/probes/mediapackage.json
@@ -1,0 +1,106 @@
+{
+  "service": "mediapackage",
+  "counts": {
+    "working": 9,
+    "needs_params": 0,
+    "not_implemented": 10,
+    "500_error": 0
+  },
+  "operations": [
+    {
+      "operation": "ConfigureLogs",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateChannel",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateHarvestJob",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateOriginEndpoint",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteChannel",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteOriginEndpoint",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeChannel",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DescribeHarvestJob",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeOriginEndpoint",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "ListChannels",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListHarvestJobs",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListOriginEndpoints",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "RotateChannelCredentials",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "RotateIngestEndpointCredentials",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "TagResource",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateChannel",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateOriginEndpoint",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    }
+  ]
+}

--- a/probes/mediastore.json
+++ b/probes/mediastore.json
@@ -1,0 +1,116 @@
+{
+  "service": "mediastore",
+  "counts": {
+    "working": 11,
+    "needs_params": 2,
+    "not_implemented": 8,
+    "500_error": 0
+  },
+  "operations": [
+    {
+      "operation": "CreateContainer",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteContainer",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteContainerPolicy",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteCorsPolicy",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteLifecyclePolicy",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteMetricPolicy",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeContainer",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetContainerPolicy",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetCorsPolicy",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetLifecyclePolicy",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetMetricPolicy",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListContainers",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "working",
+      "message": "likely implemented (ContainerNotFoundException: The specified container does not exist)"
+    },
+    {
+      "operation": "PutContainerPolicy",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "PutCorsPolicy",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "PutLifecyclePolicy",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "PutMetricPolicy",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "StartAccessLogging",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StopAccessLogging",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "TagResource",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    }
+  ]
+}

--- a/probes/memorydb.json
+++ b/probes/memorydb.json
@@ -1,0 +1,231 @@
+{
+  "service": "memorydb",
+  "counts": {
+    "working": 28,
+    "needs_params": 0,
+    "not_implemented": 15,
+    "500_error": 1
+  },
+  "operations": [
+    {
+      "operation": "BatchUpdateCluster",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CopySnapshot",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateACL",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateCluster",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateMultiRegionCluster",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateParameterGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateSnapshot",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateSubnetGroup",
+      "status": "working",
+      "message": "likely implemented (InvalidSubnetError: Subnet [] not found.)"
+    },
+    {
+      "operation": "CreateUser",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteACL",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteMultiRegionCluster",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteParameterGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteSnapshot",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteSubnetGroup",
+      "status": "working",
+      "message": "likely implemented (SubnetGroupNotFoundFault: Subnet group probe-test-value not found.)"
+    },
+    {
+      "operation": "DeleteUser",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeACLs",
+      "status": "500_error",
+      "message": "exception: 'MemoryDB' object has no attribute 'describe_ac_ls'"
+    },
+    {
+      "operation": "DescribeClusters",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeEngineVersions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeEvents",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeMultiRegionClusters",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeMultiRegionParameterGroups",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeMultiRegionParameters",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeParameterGroups",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeParameters",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeReservedNodes",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeReservedNodesOfferings",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeServiceUpdates",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeSnapshots",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeSubnetGroups",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeUsers",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "FailoverShard",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListAllowedMultiRegionClusterUpdates",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListAllowedNodeTypeUpdates",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListTags",
+      "status": "working",
+      "message": "likely implemented (ClusterNotFoundFault: probe-test is not present)"
+    },
+    {
+      "operation": "PurchaseReservedNodesOffering",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ResetParameterGroup",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "TagResource",
+      "status": "working",
+      "message": "likely implemented (ClusterNotFoundFault: probe-test is not present)"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "working",
+      "message": "likely implemented (ClusterNotFoundFault: probe-test is not present)"
+    },
+    {
+      "operation": "UpdateACL",
+      "status": "working",
+      "message": "likely implemented (ACLNotFoundFault: ACL probe-test-value not found.)"
+    },
+    {
+      "operation": "UpdateCluster",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateMultiRegionCluster",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateParameterGroup",
+      "status": "working",
+      "message": "likely implemented (ParameterGroupNotFoundFault: Parameter group probe-test-value not found.)"
+    },
+    {
+      "operation": "UpdateSubnetGroup",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateUser",
+      "status": "working",
+      "message": "likely implemented (UserNotFoundFault: User probe-test-value not found.)"
+    }
+  ]
+}

--- a/probes/mq.json
+++ b/probes/mq.json
@@ -1,0 +1,131 @@
+{
+  "service": "mq",
+  "counts": {
+    "working": 12,
+    "needs_params": 0,
+    "not_implemented": 8,
+    "500_error": 4
+  },
+  "operations": [
+    {
+      "operation": "CreateBroker",
+      "status": "working",
+      "message": "likely implemented (BadRequestException: Broker engine type [probe-test-value] is invalid. Valid valu)"
+    },
+    {
+      "operation": "CreateConfiguration",
+      "status": "working",
+      "message": "likely implemented (BadRequestException: Broker engine type [probe-test-value] is invalid. Valid valu)"
+    },
+    {
+      "operation": "CreateTags",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateUser",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeleteBroker",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "DeleteConfiguration",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteTags",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteUser",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DescribeBroker",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DescribeBrokerEngineTypes",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeBrokerInstanceOptions",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeConfiguration",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DescribeConfigurationRevision",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "DescribeUser",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "ListBrokers",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListConfigurationRevisions",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListConfigurations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTags",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListUsers",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "Promote",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "RebootBroker",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "UpdateBroker",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UpdateConfiguration",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "UpdateUser",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    }
+  ]
+}

--- a/probes/neptune.json
+++ b/probes/neptune.json
@@ -1,0 +1,351 @@
+{
+  "service": "neptune",
+  "counts": {
+    "working": 64,
+    "needs_params": 0,
+    "not_implemented": 3,
+    "500_error": 1
+  },
+  "operations": [
+    {
+      "operation": "AddRoleToDBCluster",
+      "status": "working",
+      "message": "likely implemented (DBClusterNotFoundFault: DBCluster probe-test-value not found.)"
+    },
+    {
+      "operation": "AddSourceIdentifierToSubscription",
+      "status": "working",
+      "message": "likely implemented (SubscriptionNotFound: Subscription probe-test-value not found.)"
+    },
+    {
+      "operation": "AddTagsToResource",
+      "status": "working",
+      "message": "implemented (InvalidParameterValue)"
+    },
+    {
+      "operation": "ApplyPendingMaintenanceAction",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CopyDBClusterParameterGroup",
+      "status": "working",
+      "message": "likely implemented (DBParameterGroupNotFound: DB Parameter Group probe-test-value not found.)"
+    },
+    {
+      "operation": "CopyDBClusterSnapshot",
+      "status": "working",
+      "message": "likely implemented (DBClusterSnapshotNotFoundFault: DBClusterSnapshot probe-test-value not found.)"
+    },
+    {
+      "operation": "CopyDBParameterGroup",
+      "status": "working",
+      "message": "likely implemented (DBParameterGroupNotFound: DB Parameter Group probe-test-value not found.)"
+    },
+    {
+      "operation": "CreateDBCluster",
+      "status": "working",
+      "message": "implemented (InvalidParameterValue)"
+    },
+    {
+      "operation": "CreateDBClusterEndpoint",
+      "status": "working",
+      "message": "likely implemented (DBClusterNotFoundFault: DBCluster probe-test-value not found.)"
+    },
+    {
+      "operation": "CreateDBClusterParameterGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateDBClusterSnapshot",
+      "status": "working",
+      "message": "likely implemented (DBClusterNotFoundFault: DBCluster probe-test-value not found.)"
+    },
+    {
+      "operation": "CreateDBInstance",
+      "status": "working",
+      "message": "implemented (InvalidParameterValue)"
+    },
+    {
+      "operation": "CreateDBParameterGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateDBSubnetGroup",
+      "status": "working",
+      "message": "implemented (InvalidParameterValue)"
+    },
+    {
+      "operation": "CreateEventSubscription",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateGlobalCluster",
+      "status": "working",
+      "message": "implemented (InvalidParameterValue)"
+    },
+    {
+      "operation": "DeleteDBClusterEndpoint",
+      "status": "working",
+      "message": "likely implemented (DBClusterEndpointNotFoundFault: The specified custom endpoint probe-test-value was not found)"
+    },
+    {
+      "operation": "DeleteDBClusterParameterGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteDBClusterSnapshot",
+      "status": "working",
+      "message": "likely implemented (DBClusterSnapshotNotFoundFault: DBClusterSnapshot probe-test-value not found.)"
+    },
+    {
+      "operation": "DeleteDBParameterGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteDBSubnetGroup",
+      "status": "working",
+      "message": "likely implemented (DBSubnetGroupNotFoundFault: Subnet Group probe-test-value not found.)"
+    },
+    {
+      "operation": "DeleteEventSubscription",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteGlobalCluster",
+      "status": "working",
+      "message": "likely implemented (GlobalClusterNotFoundFault: Global Cluster probe-test-value not found.)"
+    },
+    {
+      "operation": "DescribeDBClusterEndpoints",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeDBClusterParameterGroups",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeDBClusterParameters",
+      "status": "working",
+      "message": "likely implemented (DBParameterGroupNotFound: DBClusterParameterGroup not found: probe-test-value)"
+    },
+    {
+      "operation": "DescribeDBClusterSnapshotAttributes",
+      "status": "working",
+      "message": "likely implemented (DBClusterSnapshotNotFoundFault: DBClusterSnapshot probe-test-value not found.)"
+    },
+    {
+      "operation": "DescribeDBClusterSnapshots",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeDBClusters",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeDBEngineVersions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeDBInstances",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeDBParameterGroups",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeDBParameters",
+      "status": "working",
+      "message": "likely implemented (DBParameterGroupNotFound: DB Parameter Group probe-test-value not found.)"
+    },
+    {
+      "operation": "DescribeDBSubnetGroups",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeEngineDefaultClusterParameters",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeEngineDefaultParameters",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeEventCategories",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeEventSubscriptions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeEvents",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeGlobalClusters",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeOrderableDBInstanceOptions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribePendingMaintenanceActions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeValidDBInstanceModifications",
+      "status": "working",
+      "message": "likely implemented (DBInstanceNotFound: DBInstance probe-test-value not found.)"
+    },
+    {
+      "operation": "FailoverDBCluster",
+      "status": "500_error",
+      "message": "server crash (InternalError: RDSBackend.failover_db_cluster() missing 1 required position)"
+    },
+    {
+      "operation": "FailoverGlobalCluster",
+      "status": "working",
+      "message": "likely implemented (GlobalClusterNotFoundFault: Global Cluster probe-test-value not found.)"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "working",
+      "message": "implemented (InvalidParameterValue)"
+    },
+    {
+      "operation": "ModifyDBCluster",
+      "status": "working",
+      "message": "likely implemented (DBClusterNotFoundFault: DBCluster probe-test-value not found.)"
+    },
+    {
+      "operation": "ModifyDBClusterEndpoint",
+      "status": "working",
+      "message": "likely implemented (DBClusterEndpointNotFoundFault: The specified custom endpoint probe-test-value was not found)"
+    },
+    {
+      "operation": "ModifyDBClusterParameterGroup",
+      "status": "working",
+      "message": "likely implemented (DBParameterGroupNotFound: DBClusterParameterGroup not found: probe-test-value)"
+    },
+    {
+      "operation": "ModifyDBClusterSnapshotAttribute",
+      "status": "working",
+      "message": "likely implemented (DBClusterSnapshotNotFoundFault: DBClusterSnapshot probe-test-value not found.)"
+    },
+    {
+      "operation": "ModifyDBInstance",
+      "status": "working",
+      "message": "likely implemented (DBInstanceNotFound: DBInstance probe-test-value not found.)"
+    },
+    {
+      "operation": "ModifyDBParameterGroup",
+      "status": "working",
+      "message": "likely implemented (DBParameterGroupNotFound: DB Parameter Group probe-test-value not found.)"
+    },
+    {
+      "operation": "ModifyDBSubnetGroup",
+      "status": "working",
+      "message": "likely implemented (DBSubnetGroupNotFoundFault: Subnet Group probe-test-value not found.)"
+    },
+    {
+      "operation": "ModifyEventSubscription",
+      "status": "working",
+      "message": "likely implemented (SubscriptionNotFound: Subscription probe-test-value not found.)"
+    },
+    {
+      "operation": "ModifyGlobalCluster",
+      "status": "working",
+      "message": "likely implemented (GlobalClusterNotFoundFault: Global Cluster probe-test-value not found.)"
+    },
+    {
+      "operation": "PromoteReadReplicaDBCluster",
+      "status": "working",
+      "message": "likely implemented (DBClusterNotFoundFault: DBCluster probe-test-value not found.)"
+    },
+    {
+      "operation": "RebootDBInstance",
+      "status": "working",
+      "message": "likely implemented (DBInstanceNotFound: DBInstance probe-test-value not found.)"
+    },
+    {
+      "operation": "RemoveFromGlobalCluster",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "RemoveRoleFromDBCluster",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "RemoveSourceIdentifierFromSubscription",
+      "status": "working",
+      "message": "likely implemented (SubscriptionNotFound: Subscription probe-test-value not found.)"
+    },
+    {
+      "operation": "RemoveTagsFromResource",
+      "status": "working",
+      "message": "implemented (InvalidParameterValue)"
+    },
+    {
+      "operation": "ResetDBClusterParameterGroup",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ResetDBParameterGroup",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "RestoreDBClusterFromSnapshot",
+      "status": "working",
+      "message": "likely implemented (DBClusterSnapshotNotFoundFault: DBClusterSnapshot probe-test-value not found.)"
+    },
+    {
+      "operation": "RestoreDBClusterToPointInTime",
+      "status": "working",
+      "message": "likely implemented (DBClusterNotFoundFault: DBCluster probe-test-value not found.)"
+    },
+    {
+      "operation": "StartDBCluster",
+      "status": "working",
+      "message": "likely implemented (DBClusterNotFoundFault: DBCluster probe-test-value not found.)"
+    },
+    {
+      "operation": "StopDBCluster",
+      "status": "working",
+      "message": "likely implemented (DBClusterNotFoundFault: DBCluster probe-test-value not found.)"
+    },
+    {
+      "operation": "SwitchoverGlobalCluster",
+      "status": "working",
+      "message": "likely implemented (GlobalClusterNotFoundFault: Global Cluster probe-test-value not found.)"
+    }
+  ]
+}

--- a/probes/networkmanager.json
+++ b/probes/networkmanager.json
@@ -1,0 +1,486 @@
+{
+  "service": "networkmanager",
+  "counts": {
+    "working": 93,
+    "needs_params": 0,
+    "not_implemented": 2,
+    "500_error": 0
+  },
+  "operations": [
+    {
+      "operation": "AcceptAttachment",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "AssociateConnectPeer",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "AssociateCustomerGateway",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "AssociateLink",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "AssociateTransitGatewayConnectPeer",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "CreateConnectAttachment",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "CreateConnectPeer",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "CreateConnection",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "CreateCoreNetwork",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "CreateCoreNetworkPrefixListAssociation",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "CreateDevice",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "CreateDirectConnectGatewayAttachment",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "CreateGlobalNetwork",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateLink",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "CreateSite",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "CreateSiteToSiteVpnAttachment",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "CreateTransitGatewayPeering",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "CreateTransitGatewayRouteTableAttachment",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "CreateVpcAttachment",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeleteAttachment",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeleteConnectPeer",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeleteConnection",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeleteCoreNetwork",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeleteCoreNetworkPolicyVersion",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeleteCoreNetworkPrefixListAssociation",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteDevice",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeleteGlobalNetwork",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeleteLink",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeletePeering",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeleteResourcePolicy",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteSite",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeregisterTransitGateway",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DescribeGlobalNetworks",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DisassociateConnectPeer",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DisassociateCustomerGateway",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DisassociateLink",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DisassociateTransitGatewayConnectPeer",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "ExecuteCoreNetworkChangeSet",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetConnectAttachment",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetConnectPeer",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetConnectPeerAssociations",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "GetConnections",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "GetCoreNetwork",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetCoreNetworkChangeEvents",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetCoreNetworkChangeSet",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetCoreNetworkPolicy",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetCustomerGatewayAssociations",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "GetDevices",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "GetDirectConnectGatewayAttachment",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetLinkAssociations",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "GetLinks",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "GetNetworkResourceCounts",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetNetworkResourceRelationships",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetNetworkResources",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetNetworkRoutes",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetNetworkTelemetry",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetResourcePolicy",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetRouteAnalysis",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetSiteToSiteVpnAttachment",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetSites",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "GetTransitGatewayConnectPeerAssociations",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "GetTransitGatewayPeering",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetTransitGatewayRegistrations",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "GetTransitGatewayRouteTableAttachment",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetVpcAttachment",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "ListAttachmentRoutingPolicyAssociations",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "ListAttachments",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListConnectPeers",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListCoreNetworkPolicyVersions",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "ListCoreNetworkPrefixListAssociations",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "ListCoreNetworkRoutingInformation",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "ListCoreNetworks",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListOrganizationServiceAccessStatus",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListPeerings",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "PutAttachmentRoutingPolicyLabel",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "PutCoreNetworkPolicy",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "PutResourcePolicy",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "RegisterTransitGateway",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "RejectAttachment",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "RemoveAttachmentRoutingPolicyLabel",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "RestoreCoreNetworkPolicyVersion",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StartOrganizationServiceAccessUpdate",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartRouteAnalysis",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "TagResource",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UpdateConnection",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UpdateCoreNetwork",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UpdateDevice",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UpdateDirectConnectGatewayAttachment",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UpdateGlobalNetwork",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UpdateLink",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UpdateNetworkResourceMetadata",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UpdateSite",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UpdateVpcAttachment",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    }
+  ]
+}

--- a/probes/opensearch.json
+++ b/probes/opensearch.json
@@ -1,0 +1,421 @@
+{
+  "service": "opensearch",
+  "counts": {
+    "working": 56,
+    "needs_params": 5,
+    "not_implemented": 20,
+    "500_error": 1
+  },
+  "operations": [
+    {
+      "operation": "AcceptInboundConnection",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "AddDataSource",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "AddDirectQueryDataSource",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "AddTags",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "AssociatePackage",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "AssociatePackages",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "AuthorizeVpcEndpointAccess",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "CancelDomainConfigChange",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CancelServiceSoftwareUpdate",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateApplication",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateDomain",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateIndex",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateOutboundConnection",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreatePackage",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateVpcEndpoint",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteApplication",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteDataSource",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteDirectQueryDataSource",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteDomain",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteInboundConnection",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteIndex",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteOutboundConnection",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeletePackage",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteVpcEndpoint",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeDomain",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeDomainAutoTunes",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeDomainChangeProgress",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeDomainConfig",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeDomainHealth",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeDomainNodes",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeDomains",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeDryRunProgress",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeInboundConnections",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeInstanceTypeLimits",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeOutboundConnections",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribePackages",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeReservedInstanceOfferings",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeReservedInstances",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeVpcEndpoints",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DissociatePackage",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DissociatePackages",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetApplication",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetCompatibleVersions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetDataSource",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetDefaultApplicationSetting",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetDirectQueryDataSource",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetDomainMaintenanceStatus",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetIndex",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetPackageVersionHistory",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetUpgradeHistory",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetUpgradeStatus",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListApplications",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListDataSources",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListDirectQueryDataSources",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListDomainMaintenances",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListDomainNames",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListDomainsForPackage",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListInstanceTypeDetails",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListPackagesForDomain",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListScheduledActions",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListTags",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListVersions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListVpcEndpointAccess",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListVpcEndpoints",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListVpcEndpointsForDomain",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "PurchaseReservedInstanceOffering",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "PutDefaultApplicationSetting",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "RejectInboundConnection",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "RemoveTags",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "RevokeVpcEndpointAccess",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "StartDomainMaintenance",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "StartServiceSoftwareUpdate",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateApplication",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateDataSource",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UpdateDirectQueryDataSource",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UpdateDomainConfig",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "UpdateIndex",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdatePackage",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdatePackageScope",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateScheduledAction",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateVpcEndpoint",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpgradeDomain",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    }
+  ]
+}

--- a/probes/opensearchserverless.json
+++ b/probes/opensearchserverless.json
@@ -1,0 +1,241 @@
+{
+  "service": "opensearchserverless",
+  "counts": {
+    "working": 27,
+    "needs_params": 8,
+    "not_implemented": 9,
+    "500_error": 2
+  },
+  "operations": [
+    {
+      "operation": "BatchGetCollection",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "BatchGetCollectionGroup",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "BatchGetEffectiveLifecyclePolicy",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "BatchGetLifecyclePolicy",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "BatchGetVpcEndpoint",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateAccessPolicy",
+      "status": "500_error",
+      "message": "server crash (InternalError: Expecting value: line 1 column 1 (char 0))"
+    },
+    {
+      "operation": "CreateCollection",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "CreateCollectionGroup",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateIndex",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateLifecyclePolicy",
+      "status": "500_error",
+      "message": "server crash (InternalError: Expecting value: line 1 column 1 (char 0))"
+    },
+    {
+      "operation": "CreateSecurityConfig",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateSecurityPolicy",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "CreateVpcEndpoint",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DeleteAccessPolicy",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteCollection",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteCollectionGroup",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteIndex",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteLifecyclePolicy",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteSecurityConfig",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteSecurityPolicy",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteVpcEndpoint",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetAccessPolicy",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetAccountSettings",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetIndex",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetPoliciesStats",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetSecurityConfig",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetSecurityPolicy",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListAccessPolicies",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListCollectionGroups",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListCollections",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListLifecyclePolicies",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListSecurityConfigs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListSecurityPolicies",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListVpcEndpoints",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "TagResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateAccessPolicy",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UpdateAccountSettings",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateCollection",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateCollectionGroup",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateIndex",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateLifecyclePolicy",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UpdateSecurityConfig",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UpdateSecurityPolicy",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UpdateVpcEndpoint",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    }
+  ]
+}

--- a/probes/organizations.json
+++ b/probes/organizations.json
@@ -1,0 +1,326 @@
+{
+  "service": "organizations",
+  "counts": {
+    "working": 50,
+    "needs_params": 0,
+    "not_implemented": 13,
+    "500_error": 0
+  },
+  "operations": [
+    {
+      "operation": "AcceptHandshake",
+      "status": "working",
+      "message": "likely implemented (400: <?xml version=\"1.0\" encoding=\"UTF-8\"?>\n  <ErrorResponse>\n   )"
+    },
+    {
+      "operation": "AttachPolicy",
+      "status": "working",
+      "message": "likely implemented (PolicyNotFoundException: We can't find a policy with the PolicyId that you specified.)"
+    },
+    {
+      "operation": "CancelHandshake",
+      "status": "working",
+      "message": "likely implemented (400: <?xml version=\"1.0\" encoding=\"UTF-8\"?>\n  <ErrorResponse>\n   )"
+    },
+    {
+      "operation": "CloseAccount",
+      "status": "working",
+      "message": "likely implemented (AWSOrganizationsNotInUseException: Your account is not a member of an organization.)"
+    },
+    {
+      "operation": "CreateAccount",
+      "status": "working",
+      "message": "likely implemented (AWSOrganizationsNotInUseException: Your account is not a member of an organization.)"
+    },
+    {
+      "operation": "CreateGovCloudAccount",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateOrganization",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateOrganizationalUnit",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreatePolicy",
+      "status": "working",
+      "message": "likely implemented (InvalidInputException: You specified an invalid value.)"
+    },
+    {
+      "operation": "DeclineHandshake",
+      "status": "working",
+      "message": "likely implemented (400: <?xml version=\"1.0\" encoding=\"UTF-8\"?>\n  <ErrorResponse>\n   )"
+    },
+    {
+      "operation": "DeleteOrganization",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteOrganizationalUnit",
+      "status": "working",
+      "message": "likely implemented (400: <?xml version=\"1.0\" encoding=\"UTF-8\"?>\n  <ErrorResponse>\n   )"
+    },
+    {
+      "operation": "DeletePolicy",
+      "status": "working",
+      "message": "likely implemented (PolicyNotFoundException: We can't find a policy with the PolicyId that you specified.)"
+    },
+    {
+      "operation": "DeleteResourcePolicy",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeregisterDelegatedAdministrator",
+      "status": "working",
+      "message": "likely implemented (AccountNotFoundException: You specified an account that doesn't exist.)"
+    },
+    {
+      "operation": "DescribeAccount",
+      "status": "working",
+      "message": "likely implemented (AccountNotFoundException: You specified an account that doesn't exist.)"
+    },
+    {
+      "operation": "DescribeCreateAccountStatus",
+      "status": "working",
+      "message": "likely implemented (AccountNotFoundException: You specified an account that doesn't exist.)"
+    },
+    {
+      "operation": "DescribeEffectivePolicy",
+      "status": "working",
+      "message": "likely implemented (InvalidInputException: You specified an invalid value.)"
+    },
+    {
+      "operation": "DescribeHandshake",
+      "status": "working",
+      "message": "likely implemented (400: <?xml version=\"1.0\" encoding=\"UTF-8\"?>\n  <ErrorResponse>\n   )"
+    },
+    {
+      "operation": "DescribeOrganization",
+      "status": "working",
+      "message": "likely implemented (AWSOrganizationsNotInUseException: Your account is not a member of an organization.)"
+    },
+    {
+      "operation": "DescribeOrganizationalUnit",
+      "status": "working",
+      "message": "likely implemented (400: <?xml version=\"1.0\" encoding=\"UTF-8\"?>\n  <ErrorResponse>\n   )"
+    },
+    {
+      "operation": "DescribePolicy",
+      "status": "working",
+      "message": "likely implemented (InvalidInputException: You specified an invalid value.)"
+    },
+    {
+      "operation": "DescribeResourcePolicy",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeResponsibilityTransfer",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DetachPolicy",
+      "status": "working",
+      "message": "likely implemented (PolicyNotFoundException: We can't find a policy with the PolicyId that you specified.)"
+    },
+    {
+      "operation": "DisableAWSServiceAccess",
+      "status": "working",
+      "message": "likely implemented (InvalidInputException: You specified an unrecognized service principal.)"
+    },
+    {
+      "operation": "DisablePolicyType",
+      "status": "working",
+      "message": "likely implemented (RootNotFoundException: You specified a root that doesn't exist.)"
+    },
+    {
+      "operation": "EnableAWSServiceAccess",
+      "status": "working",
+      "message": "likely implemented (InvalidInputException: You specified an unrecognized service principal.)"
+    },
+    {
+      "operation": "EnableAllFeatures",
+      "status": "working",
+      "message": "likely implemented (AWSOrganizationsNotInUseException: Your account is not a member of an organization.)"
+    },
+    {
+      "operation": "EnablePolicyType",
+      "status": "working",
+      "message": "likely implemented (RootNotFoundException: You specified a root that doesn't exist.)"
+    },
+    {
+      "operation": "InviteAccountToOrganization",
+      "status": "working",
+      "message": "likely implemented (AWSOrganizationsNotInUseException: Your account is not a member of an organization.)"
+    },
+    {
+      "operation": "InviteOrganizationToTransferResponsibility",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "LeaveOrganization",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListAWSServiceAccessForOrganization",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListAccounts",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListAccountsForParent",
+      "status": "working",
+      "message": "likely implemented (400: <?xml version=\"1.0\" encoding=\"UTF-8\"?>\n  <ErrorResponse>\n   )"
+    },
+    {
+      "operation": "ListAccountsWithInvalidEffectivePolicy",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListChildren",
+      "status": "working",
+      "message": "likely implemented (400: <?xml version=\"1.0\" encoding=\"UTF-8\"?>\n  <ErrorResponse>\n   )"
+    },
+    {
+      "operation": "ListCreateAccountStatus",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListDelegatedAdministrators",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListDelegatedServicesForAccount",
+      "status": "working",
+      "message": "likely implemented (AWSOrganizationsNotInUseException: Your account is not a member of an organization.)"
+    },
+    {
+      "operation": "ListEffectivePolicyValidationErrors",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListHandshakesForAccount",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListHandshakesForOrganization",
+      "status": "working",
+      "message": "likely implemented (AWSOrganizationsNotInUseException: Your account is not a member of an organization.)"
+    },
+    {
+      "operation": "ListInboundResponsibilityTransfers",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListOrganizationalUnitsForParent",
+      "status": "working",
+      "message": "likely implemented (400: <?xml version=\"1.0\" encoding=\"UTF-8\"?>\n  <ErrorResponse>\n   )"
+    },
+    {
+      "operation": "ListOutboundResponsibilityTransfers",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListParents",
+      "status": "working",
+      "message": "likely implemented (400: <?xml version=\"1.0\" encoding=\"UTF-8\"?>\n  <ErrorResponse>\n   )"
+    },
+    {
+      "operation": "ListPolicies",
+      "status": "working",
+      "message": "likely implemented (InvalidInputException: You specified an invalid value.)"
+    },
+    {
+      "operation": "ListPoliciesForTarget",
+      "status": "working",
+      "message": "likely implemented (InvalidInputException: You specified an invalid value.)"
+    },
+    {
+      "operation": "ListRoots",
+      "status": "working",
+      "message": "likely implemented (AWSOrganizationsNotInUseException: Your account is not a member of an organization.)"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "working",
+      "message": "likely implemented (InvalidInputException: You provided a value that does not match the required patter)"
+    },
+    {
+      "operation": "ListTargetsForPolicy",
+      "status": "working",
+      "message": "likely implemented (InvalidInputException: You specified an invalid value.)"
+    },
+    {
+      "operation": "MoveAccount",
+      "status": "working",
+      "message": "likely implemented (400: <?xml version=\"1.0\" encoding=\"UTF-8\"?>\n  <ErrorResponse>\n   )"
+    },
+    {
+      "operation": "PutResourcePolicy",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "RegisterDelegatedAdministrator",
+      "status": "working",
+      "message": "likely implemented (AccountNotFoundException: You specified an account that doesn't exist.)"
+    },
+    {
+      "operation": "RemoveAccountFromOrganization",
+      "status": "working",
+      "message": "likely implemented (AWSOrganizationsNotInUseException: Your account is not a member of an organization.)"
+    },
+    {
+      "operation": "TagResource",
+      "status": "working",
+      "message": "likely implemented (InvalidInputException: You provided a value that does not match the required patter)"
+    },
+    {
+      "operation": "TerminateResponsibilityTransfer",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "working",
+      "message": "likely implemented (InvalidInputException: You provided a value that does not match the required patter)"
+    },
+    {
+      "operation": "UpdateOrganizationalUnit",
+      "status": "working",
+      "message": "likely implemented (400: <?xml version=\"1.0\" encoding=\"UTF-8\"?>\n  <ErrorResponse>\n   )"
+    },
+    {
+      "operation": "UpdatePolicy",
+      "status": "working",
+      "message": "likely implemented (PolicyNotFoundException: We can't find a policy with the PolicyId that you specified.)"
+    },
+    {
+      "operation": "UpdateResponsibilityTransfer",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    }
+  ]
+}

--- a/probes/osis.json
+++ b/probes/osis.json
@@ -1,0 +1,121 @@
+{
+  "service": "osis",
+  "counts": {
+    "working": 12,
+    "needs_params": 0,
+    "not_implemented": 9,
+    "500_error": 1
+  },
+  "operations": [
+    {
+      "operation": "CreatePipeline",
+      "status": "500_error",
+      "message": "server crash (InternalError: string indices must be integers, not 'str')"
+    },
+    {
+      "operation": "CreatePipelineEndpoint",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeletePipeline",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeletePipelineEndpoint",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteResourcePolicy",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetPipeline",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetPipelineBlueprint",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetPipelineChangeProgress",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetResourcePolicy",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListPipelineBlueprints",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListPipelineEndpointConnections",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListPipelineEndpoints",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListPipelines",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutResourcePolicy",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "RevokePipelineEndpointConnections",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StartPipeline",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "StopPipeline",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "TagResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdatePipeline",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ValidatePipeline",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    }
+  ]
+}

--- a/probes/panorama.json
+++ b/probes/panorama.json
@@ -1,0 +1,181 @@
+{
+  "service": "panorama",
+  "counts": {
+    "working": 18,
+    "needs_params": 4,
+    "not_implemented": 10,
+    "500_error": 2
+  },
+  "operations": [
+    {
+      "operation": "CreateApplicationInstance",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateJobForDevices",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateNodeFromTemplateJob",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreatePackage",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreatePackageImportJob",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteDevice",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "DeletePackage",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeregisterPackageVersion",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeApplicationInstance",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeApplicationInstanceDetails",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeDevice",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DescribeDeviceJob",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeNode",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeNodeFromTemplateJob",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribePackage",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribePackageImportJob",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribePackageVersion",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListApplicationInstanceDependencies",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListApplicationInstanceNodeInstances",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListApplicationInstances",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListDevices",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListDevicesJobs",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListNodeFromTemplateJobs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListNodes",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListPackageImportJobs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListPackages",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ProvisionDevice",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "RegisterPackageVersion",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "RemoveApplicationInstance",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "SignalApplicationInstanceNodeInstances",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "TagResource",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UpdateDeviceMetadata",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    }
+  ]
+}

--- a/probes/pinpoint.json
+++ b/probes/pinpoint.json
@@ -1,0 +1,621 @@
+{
+  "service": "pinpoint",
+  "counts": {
+    "working": 117,
+    "needs_params": 0,
+    "not_implemented": 2,
+    "500_error": 3
+  },
+  "operations": [
+    {
+      "operation": "CreateApp",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateCampaign",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "CreateEmailTemplate",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateExportJob",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "CreateImportJob",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "CreateInAppTemplate",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateJourney",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "CreatePushTemplate",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateRecommenderConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateSegment",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "CreateSmsTemplate",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateVoiceTemplate",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteAdmChannel",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeleteApnsChannel",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeleteApnsSandboxChannel",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeleteApnsVoipChannel",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeleteApnsVoipSandboxChannel",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeleteApp",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeleteBaiduChannel",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeleteCampaign",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeleteEmailChannel",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeleteEmailTemplate",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteEndpoint",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeleteEventStream",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeleteGcmChannel",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeleteInAppTemplate",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteJourney",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeletePushTemplate",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteRecommenderConfiguration",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeleteSegment",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeleteSmsChannel",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeleteSmsTemplate",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteUserEndpoints",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeleteVoiceChannel",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeleteVoiceTemplate",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetAdmChannel",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetApnsChannel",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetApnsSandboxChannel",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetApnsVoipChannel",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetApnsVoipSandboxChannel",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetApp",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetApplicationDateRangeKpi",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetApplicationSettings",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetApps",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetBaiduChannel",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetCampaign",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetCampaignActivities",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetCampaignDateRangeKpi",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetCampaignVersion",
+      "status": "500_error",
+      "message": "server crash (InternalError: invalid literal for int() with base 10: 'probe-test-value')"
+    },
+    {
+      "operation": "GetCampaignVersions",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetCampaigns",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetChannels",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetEmailChannel",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetEmailTemplate",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetEndpoint",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetEventStream",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetExportJob",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetExportJobs",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetGcmChannel",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetImportJob",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetImportJobs",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetInAppMessages",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetInAppTemplate",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetJourney",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetJourneyDateRangeKpi",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetJourneyExecutionActivityMetrics",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetJourneyExecutionMetrics",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetJourneyRunExecutionActivityMetrics",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetJourneyRunExecutionMetrics",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetJourneyRuns",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetPushTemplate",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetRecommenderConfiguration",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetRecommenderConfigurations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetSegment",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetSegmentExportJobs",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetSegmentImportJobs",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetSegmentVersion",
+      "status": "500_error",
+      "message": "server crash (InternalError: invalid literal for int() with base 10: 'probe-test-value')"
+    },
+    {
+      "operation": "GetSegmentVersions",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetSegments",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetSmsChannel",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetSmsTemplate",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetUserEndpoints",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetVoiceChannel",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetVoiceTemplate",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "ListJourneys",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTemplateVersions",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "ListTemplates",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PhoneNumberValidate",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutEventStream",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "PutEvents",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "RemoveAttributes",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "SendMessages",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "SendOTPMessage",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "SendUsersMessages",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "TagResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'NoneType' object is not iterable)"
+    },
+    {
+      "operation": "UpdateAdmChannel",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UpdateApnsChannel",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UpdateApnsSandboxChannel",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UpdateApnsVoipChannel",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UpdateApnsVoipSandboxChannel",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UpdateApplicationSettings",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UpdateBaiduChannel",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UpdateCampaign",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UpdateEmailChannel",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UpdateEmailTemplate",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UpdateEndpoint",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UpdateEndpointsBatch",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UpdateGcmChannel",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UpdateInAppTemplate",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UpdateJourney",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UpdateJourneyState",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UpdatePushTemplate",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UpdateRecommenderConfiguration",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UpdateSegment",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UpdateSmsChannel",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UpdateSmsTemplate",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UpdateTemplateActiveVersion",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UpdateVoiceChannel",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UpdateVoiceTemplate",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "VerifyOTPMessage",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    }
+  ]
+}

--- a/probes/pipes.json
+++ b/probes/pipes.json
@@ -1,0 +1,61 @@
+{
+  "service": "pipes",
+  "counts": {
+    "working": 10,
+    "needs_params": 0,
+    "not_implemented": 0,
+    "500_error": 0
+  },
+  "operations": [
+    {
+      "operation": "CreatePipe",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeletePipe",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribePipe",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "ListPipes",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartPipe",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "StopPipe",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "TagResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdatePipe",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    }
+  ]
+}

--- a/probes/polly.json
+++ b/probes/polly.json
@@ -1,0 +1,56 @@
+{
+  "service": "polly",
+  "counts": {
+    "working": 6,
+    "needs_params": 0,
+    "not_implemented": 3,
+    "500_error": 0
+  },
+  "operations": [
+    {
+      "operation": "DeleteLexicon",
+      "status": "working",
+      "message": "likely implemented (LexiconNotFoundException: Lexicon not found)"
+    },
+    {
+      "operation": "DescribeVoices",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetLexicon",
+      "status": "working",
+      "message": "likely implemented (LexiconNotFoundException: Lexicon not found)"
+    },
+    {
+      "operation": "GetSpeechSynthesisTask",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListLexicons",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListSpeechSynthesisTasks",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "PutLexicon",
+      "status": "working",
+      "message": "implemented (InvalidParameterValue)"
+    },
+    {
+      "operation": "StartSpeechSynthesisTask",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "SynthesizeSpeech",
+      "status": "working",
+      "message": "implemented (InvalidParameterValue)"
+    }
+  ]
+}

--- a/probes/quicksight.json
+++ b/probes/quicksight.json
@@ -1,0 +1,1156 @@
+{
+  "service": "quicksight",
+  "counts": {
+    "working": 210,
+    "needs_params": 15,
+    "not_implemented": 4,
+    "500_error": 0
+  },
+  "operations": [
+    {
+      "operation": "BatchCreateTopicReviewedAnswer",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "BatchDeleteTopicReviewedAnswer",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "CancelIngestion",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "CreateAccountCustomization",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateAccountSubscription",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateActionConnector",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateAnalysis",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateBrand",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateCustomPermissions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateDashboard",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateDataSet",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateDataSource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateFolder",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateFolderMembership",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateGroupMembership",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateIAMPolicyAssignment",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateIngestion",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateNamespace",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateRefreshSchedule",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateRoleMembership",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateTemplate",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateTemplateAlias",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateTheme",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateThemeAlias",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateTopic",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateTopicRefreshSchedule",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateVPCConnection",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DeleteAccountCustomPermission",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteAccountCustomization",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteAccountSubscription",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteActionConnector",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteAnalysis",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteBrand",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteBrandAssignment",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteCustomPermissions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteDashboard",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteDataSet",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteDataSetRefreshProperties",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteDataSource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteDefaultQBusinessApplication",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteFolder",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteFolderMembership",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteGroupMembership",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteIAMPolicyAssignment",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteIdentityPropagationConfig",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteNamespace",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteRefreshSchedule",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteRoleCustomPermission",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteRoleMembership",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteTemplate",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteTemplateAlias",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteTheme",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteThemeAlias",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteTopicRefreshSchedule",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteUser",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteUserByPrincipalId",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteUserCustomPermission",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteVPCConnection",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeAccountCustomPermission",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeAccountCustomization",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeAccountSettings",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeAccountSubscription",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeActionConnector",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeActionConnectorPermissions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeAnalysis",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeAnalysisDefinition",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeAnalysisPermissions",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeAssetBundleExportJob",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeAssetBundleImportJob",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeBrand",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeBrandAssignment",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeBrandPublishedVersion",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeCustomPermissions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeDashboard",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeDashboardDefinition",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeDashboardPermissions",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeDashboardSnapshotJob",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeDashboardSnapshotJobResult",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeDashboardsQAConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeDataSet",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeDataSetPermissions",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeDataSetRefreshProperties",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeDataSource",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeDataSourcePermissions",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeDefaultQBusinessApplication",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeFolder",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeFolderPermissions",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeFolderResolvedPermissions",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeGroup",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeGroupMembership",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeIAMPolicyAssignment",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeIngestion",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeIpRestriction",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeKeyRegistration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeNamespace",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeQPersonalizationConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeQuickSightQSearchConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeRefreshSchedule",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeRoleCustomPermission",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeSelfUpgradeConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeTemplate",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeTemplateAlias",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeTemplateDefinition",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeTemplatePermissions",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeTheme",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeThemeAlias",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeThemePermissions",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeTopic",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeTopicPermissions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeTopicRefresh",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeTopicRefreshSchedule",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeUser",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeVPCConnection",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GenerateEmbedUrlForAnonymousUser",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GenerateEmbedUrlForRegisteredUser",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GenerateEmbedUrlForRegisteredUserWithIdentity",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetDashboardEmbedUrl",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetFlowMetadata",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetFlowPermissions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetIdentityContext",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "GetSessionEmbedUrl",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListActionConnectors",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListAnalyses",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListAssetBundleExportJobs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListAssetBundleImportJobs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListBrands",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListCustomPermissions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListDashboardVersions",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListDashboards",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListDataSets",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListDataSources",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListFlows",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListFolderMembers",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListFolders",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListFoldersForResource",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListGroupMemberships",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListGroups",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListIAMPolicyAssignments",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListIAMPolicyAssignmentsForUser",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListIdentityPropagationConfigs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListIngestions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListNamespaces",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListRefreshSchedules",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListRoleMemberships",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListSelfUpgrades",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTemplateAliases",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListTemplateVersions",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListTemplates",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListThemeAliases",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListThemeVersions",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListThemes",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTopicRefreshSchedules",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTopicReviewedAnswers",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTopics",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListUserGroups",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListUsers",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListVPCConnections",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PredictQAResults",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutDataSetRefreshProperties",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "RegisterUser",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "RestoreAnalysis",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "SearchActionConnectors",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "SearchAnalyses",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "SearchDashboards",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "SearchDataSets",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "SearchDataSources",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "SearchFlows",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "SearchFolders",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "SearchGroups",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "SearchTopics",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "StartAssetBundleExportJob",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "StartAssetBundleImportJob",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartDashboardSnapshotJob",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "StartDashboardSnapshotJobSchedule",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "TagResource",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UpdateAccountCustomPermission",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateAccountCustomization",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateAccountSettings",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateActionConnector",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UpdateActionConnectorPermissions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateAnalysis",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateAnalysisPermissions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateApplicationWithTokenExchangeGrant",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateBrand",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateBrandAssignment",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateBrandPublishedVersion",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateCustomPermissions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateDashboard",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateDashboardLinks",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateDashboardPermissions",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateDashboardPublishedVersion",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateDashboardsQAConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateDataSet",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateDataSetPermissions",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateDataSource",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateDataSourcePermissions",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateDefaultQBusinessApplication",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateFlowPermissions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateFolder",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateFolderPermissions",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateGroup",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateIAMPolicyAssignment",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateIdentityPropagationConfig",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateIpRestriction",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateKeyRegistration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdatePublicSharingSettings",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateQPersonalizationConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateQuickSightQSearchConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateRefreshSchedule",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateRoleCustomPermission",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateSPICECapacityConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateSelfUpgrade",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateSelfUpgradeConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateTemplate",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateTemplateAlias",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateTemplatePermissions",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateTheme",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateThemeAlias",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateThemePermissions",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateTopic",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateTopicPermissions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateTopicRefreshSchedule",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateUser",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateUserCustomPermission",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateVPCConnection",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    }
+  ]
+}

--- a/probes/ram.json
+++ b/probes/ram.json
@@ -1,0 +1,186 @@
+{
+  "service": "ram",
+  "counts": {
+    "working": 35,
+    "needs_params": 0,
+    "not_implemented": 0,
+    "500_error": 0
+  },
+  "operations": [
+    {
+      "operation": "AcceptResourceShareInvitation",
+      "status": "working",
+      "message": "likely implemented (UnknownResourceException: ResourceShareInvitation arn:aws:ram:us-east-1:123456789012:t)"
+    },
+    {
+      "operation": "AssociateResourceShare",
+      "status": "working",
+      "message": "likely implemented (UnknownResourceException: ResourceShare arn:aws:ram:us-east-1:123456789012:thing/probe)"
+    },
+    {
+      "operation": "AssociateResourceSharePermission",
+      "status": "working",
+      "message": "likely implemented (UnknownResourceException: ResourceShare arn:aws:ram:us-east-1:123456789012:thing/probe)"
+    },
+    {
+      "operation": "CreatePermission",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreatePermissionVersion",
+      "status": "working",
+      "message": "likely implemented (UnknownResourceException: Permission arn:aws:ram:us-east-1:123456789012:thing/probe-te)"
+    },
+    {
+      "operation": "CreateResourceShare",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeletePermission",
+      "status": "working",
+      "message": "likely implemented (UnknownResourceException: Permission arn:aws:ram:us-east-1:123456789012:thing/probe-te)"
+    },
+    {
+      "operation": "DeletePermissionVersion",
+      "status": "working",
+      "message": "likely implemented (UnknownResourceException: Permission arn:aws:ram:us-east-1:123456789012:thing/probe-te)"
+    },
+    {
+      "operation": "DeleteResourceShare",
+      "status": "working",
+      "message": "likely implemented (UnknownResourceException: ResourceShare arn:aws:ram:us-east-1:123456789012:thing/probe)"
+    },
+    {
+      "operation": "DisassociateResourceShare",
+      "status": "working",
+      "message": "likely implemented (UnknownResourceException: ResourceShare arn:aws:ram:us-east-1:123456789012:thing/probe)"
+    },
+    {
+      "operation": "DisassociateResourceSharePermission",
+      "status": "working",
+      "message": "likely implemented (UnknownResourceException: ResourceShare arn:aws:ram:us-east-1:123456789012:thing/probe)"
+    },
+    {
+      "operation": "EnableSharingWithAwsOrganization",
+      "status": "working",
+      "message": "likely implemented (OperationNotPermittedException: Unable to enable sharing with AWS Organizations. Received Ac)"
+    },
+    {
+      "operation": "GetPermission",
+      "status": "working",
+      "message": "likely implemented (UnknownResourceException: Permission arn:aws:ram:us-east-1:123456789012:thing/probe-te)"
+    },
+    {
+      "operation": "GetResourcePolicies",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetResourceShareAssociations",
+      "status": "working",
+      "message": "implemented (InvalidParameterException)"
+    },
+    {
+      "operation": "GetResourceShareInvitations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetResourceShares",
+      "status": "working",
+      "message": "implemented (InvalidParameterException)"
+    },
+    {
+      "operation": "ListPendingInvitationResources",
+      "status": "working",
+      "message": "likely implemented (UnknownResourceException: ResourceShareInvitation arn:aws:ram:us-east-1:123456789012:t)"
+    },
+    {
+      "operation": "ListPermissionAssociations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListPermissionVersions",
+      "status": "working",
+      "message": "likely implemented (UnknownResourceException: Permission arn:aws:ram:us-east-1:123456789012:thing/probe-te)"
+    },
+    {
+      "operation": "ListPermissions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListPrincipals",
+      "status": "working",
+      "message": "implemented (InvalidParameterException)"
+    },
+    {
+      "operation": "ListReplacePermissionAssociationsWork",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListResourceSharePermissions",
+      "status": "working",
+      "message": "likely implemented (UnknownResourceException: ResourceShare arn:aws:ram:us-east-1:123456789012:thing/probe)"
+    },
+    {
+      "operation": "ListResourceTypes",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListResources",
+      "status": "working",
+      "message": "implemented (InvalidParameterException)"
+    },
+    {
+      "operation": "ListSourceAssociations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PromotePermissionCreatedFromPolicy",
+      "status": "working",
+      "message": "likely implemented (UnknownResourceException: Permission arn:aws:ram:us-east-1:123456789012:thing/probe-te)"
+    },
+    {
+      "operation": "PromoteResourceShareCreatedFromPolicy",
+      "status": "working",
+      "message": "likely implemented (UnknownResourceException: ResourceShare arn:aws:ram:us-east-1:123456789012:thing/probe)"
+    },
+    {
+      "operation": "RejectResourceShareInvitation",
+      "status": "working",
+      "message": "likely implemented (UnknownResourceException: ResourceShareInvitation arn:aws:ram:us-east-1:123456789012:t)"
+    },
+    {
+      "operation": "ReplacePermissionAssociations",
+      "status": "working",
+      "message": "likely implemented (UnknownResourceException: Permission arn:aws:ram:us-east-1:123456789012:thing/probe-te)"
+    },
+    {
+      "operation": "SetDefaultPermissionVersion",
+      "status": "working",
+      "message": "likely implemented (UnknownResourceException: Permission arn:aws:ram:us-east-1:123456789012:thing/probe-te)"
+    },
+    {
+      "operation": "TagResource",
+      "status": "working",
+      "message": "implemented (InvalidParameterException)"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "working",
+      "message": "implemented (InvalidParameterException)"
+    },
+    {
+      "operation": "UpdateResourceShare",
+      "status": "working",
+      "message": "likely implemented (UnknownResourceException: ResourceShare arn:aws:ram:us-east-1:123456789012:thing/probe)"
+    }
+  ]
+}

--- a/probes/rds.json
+++ b/probes/rds.json
@@ -1,0 +1,816 @@
+{
+  "service": "rds",
+  "counts": {
+    "working": 129,
+    "needs_params": 1,
+    "not_implemented": 25,
+    "500_error": 6
+  },
+  "operations": [
+    {
+      "operation": "AddRoleToDBCluster",
+      "status": "working",
+      "message": "likely implemented (DBClusterNotFoundFault: DBCluster probe-test-value not found.)"
+    },
+    {
+      "operation": "AddRoleToDBInstance",
+      "status": "working",
+      "message": "likely implemented (DBInstanceNotFound: DBInstance probe-test-value not found.)"
+    },
+    {
+      "operation": "AddSourceIdentifierToSubscription",
+      "status": "working",
+      "message": "likely implemented (SubscriptionNotFound: Subscription probe-test-value not found.)"
+    },
+    {
+      "operation": "AddTagsToResource",
+      "status": "working",
+      "message": "implemented (InvalidParameterValue)"
+    },
+    {
+      "operation": "ApplyPendingMaintenanceAction",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "AuthorizeDBSecurityGroupIngress",
+      "status": "working",
+      "message": "likely implemented (DBSecurityGroupNotFound: Security Group probe-test-value not found.)"
+    },
+    {
+      "operation": "BacktrackDBCluster",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CancelExportTask",
+      "status": "working",
+      "message": "likely implemented (ExportTaskNotFound: Cannot cancel export task because a task with the identifier)"
+    },
+    {
+      "operation": "CopyDBClusterParameterGroup",
+      "status": "working",
+      "message": "likely implemented (DBParameterGroupNotFound: DB Parameter Group probe-test-value not found.)"
+    },
+    {
+      "operation": "CopyDBClusterSnapshot",
+      "status": "working",
+      "message": "likely implemented (DBClusterSnapshotNotFoundFault: DBClusterSnapshot probe-test-value not found.)"
+    },
+    {
+      "operation": "CopyDBParameterGroup",
+      "status": "working",
+      "message": "likely implemented (DBParameterGroupNotFound: DB Parameter Group probe-test-value not found.)"
+    },
+    {
+      "operation": "CopyDBSnapshot",
+      "status": "working",
+      "message": "likely implemented (DBSnapshotNotFound: DBSnapshot probe-test-value not found.)"
+    },
+    {
+      "operation": "CopyOptionGroup",
+      "status": "working",
+      "message": "likely implemented (OptionGroupNotFoundFault: Specified OptionGroupName: probe-test-value not found.)"
+    },
+    {
+      "operation": "CreateBlueGreenDeployment",
+      "status": "working",
+      "message": "implemented (InvalidParameterValue)"
+    },
+    {
+      "operation": "CreateCustomDBEngineVersion",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateDBCluster",
+      "status": "working",
+      "message": "implemented (InvalidParameterValue)"
+    },
+    {
+      "operation": "CreateDBClusterEndpoint",
+      "status": "working",
+      "message": "likely implemented (DBClusterNotFoundFault: DBCluster probe-test-value not found.)"
+    },
+    {
+      "operation": "CreateDBClusterParameterGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateDBClusterSnapshot",
+      "status": "working",
+      "message": "likely implemented (DBClusterNotFoundFault: DBCluster probe-test-value not found.)"
+    },
+    {
+      "operation": "CreateDBInstance",
+      "status": "working",
+      "message": "implemented (InvalidParameterValue)"
+    },
+    {
+      "operation": "CreateDBInstanceReadReplica",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'source_db_instance_identifier')"
+    },
+    {
+      "operation": "CreateDBParameterGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateDBProxy",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'auth')"
+    },
+    {
+      "operation": "CreateDBProxyEndpoint",
+      "status": "working",
+      "message": "likely implemented (DBProxyNotFoundFault: The specified proxy name probe-test-value doesn't correspond)"
+    },
+    {
+      "operation": "CreateDBSecurityGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateDBShardGroup",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateDBSnapshot",
+      "status": "working",
+      "message": "likely implemented (DBInstanceNotFound: DBInstance probe-test-value not found.)"
+    },
+    {
+      "operation": "CreateDBSubnetGroup",
+      "status": "working",
+      "message": "implemented (InvalidParameterValue)"
+    },
+    {
+      "operation": "CreateEventSubscription",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateGlobalCluster",
+      "status": "working",
+      "message": "implemented (InvalidParameterValue)"
+    },
+    {
+      "operation": "CreateIntegration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateOptionGroup",
+      "status": "working",
+      "message": "implemented (InvalidParameterValue)"
+    },
+    {
+      "operation": "CreateTenantDatabase",
+      "status": "working",
+      "message": "likely implemented (DBInstanceNotFound: DBInstance probe-test-value not found.)"
+    },
+    {
+      "operation": "DeleteBlueGreenDeployment",
+      "status": "working",
+      "message": "likely implemented (BlueGreenDeploymentNotFoundFault: BlueGreenDeploymentIdentifier probe-test-value doesn't refer)"
+    },
+    {
+      "operation": "DeleteCustomDBEngineVersion",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteDBClusterAutomatedBackup",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteDBClusterEndpoint",
+      "status": "working",
+      "message": "likely implemented (DBClusterEndpointNotFoundFault: The specified custom endpoint probe-test-value was not found)"
+    },
+    {
+      "operation": "DeleteDBClusterParameterGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteDBClusterSnapshot",
+      "status": "working",
+      "message": "likely implemented (DBClusterSnapshotNotFoundFault: DBClusterSnapshot probe-test-value not found.)"
+    },
+    {
+      "operation": "DeleteDBInstanceAutomatedBackup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteDBParameterGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteDBProxy",
+      "status": "working",
+      "message": "likely implemented (DBProxyNotFoundFault: The specified proxy name probe-test-value doesn't correspond)"
+    },
+    {
+      "operation": "DeleteDBProxyEndpoint",
+      "status": "working",
+      "message": "likely implemented (DBProxyEndpointNotFoundFault: The specified DB proxy endpoint probe-test-value was not fou)"
+    },
+    {
+      "operation": "DeleteDBSecurityGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteDBShardGroup",
+      "status": "working",
+      "message": "likely implemented (DBShardGroupNotFound: DBShardGroup probe-test-value not found.)"
+    },
+    {
+      "operation": "DeleteDBSnapshot",
+      "status": "working",
+      "message": "likely implemented (DBSnapshotNotFound: DBSnapshot probe-test-value not found.)"
+    },
+    {
+      "operation": "DeleteDBSubnetGroup",
+      "status": "working",
+      "message": "likely implemented (DBSubnetGroupNotFoundFault: Subnet Group probe-test-value not found.)"
+    },
+    {
+      "operation": "DeleteEventSubscription",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteGlobalCluster",
+      "status": "working",
+      "message": "likely implemented (GlobalClusterNotFoundFault: Global Cluster probe-test-value not found.)"
+    },
+    {
+      "operation": "DeleteIntegration",
+      "status": "working",
+      "message": "likely implemented (IntegrationNotFoundFault: Integration probe-test-value not found.)"
+    },
+    {
+      "operation": "DeleteOptionGroup",
+      "status": "working",
+      "message": "likely implemented (OptionGroupNotFoundFault: Specified OptionGroupName: probe-test-value not found.)"
+    },
+    {
+      "operation": "DeleteTenantDatabase",
+      "status": "working",
+      "message": "likely implemented (TenantDatabaseNotFound: Tenant database probe-test-value not found.)"
+    },
+    {
+      "operation": "DeregisterDBProxyTargets",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "DescribeAccountAttributes",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeBlueGreenDeployments",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeCertificates",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeDBClusterAutomatedBackups",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeDBClusterBacktracks",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeDBClusterEndpoints",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeDBClusterParameterGroups",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeDBClusterParameters",
+      "status": "working",
+      "message": "likely implemented (DBParameterGroupNotFound: DBClusterParameterGroup not found: probe-test-value)"
+    },
+    {
+      "operation": "DescribeDBClusterSnapshotAttributes",
+      "status": "working",
+      "message": "likely implemented (DBClusterSnapshotNotFoundFault: DBClusterSnapshot probe-test-value not found.)"
+    },
+    {
+      "operation": "DescribeDBClusterSnapshots",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeDBClusters",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeDBEngineVersions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeDBInstanceAutomatedBackups",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeDBInstances",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeDBLogFiles",
+      "status": "working",
+      "message": "likely implemented (DBInstanceNotFound: DBInstance probe-test-value not found.)"
+    },
+    {
+      "operation": "DescribeDBMajorEngineVersions",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeDBParameterGroups",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeDBParameters",
+      "status": "working",
+      "message": "likely implemented (DBParameterGroupNotFound: DB Parameter Group probe-test-value not found.)"
+    },
+    {
+      "operation": "DescribeDBProxies",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeDBProxyEndpoints",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeDBProxyTargetGroups",
+      "status": "working",
+      "message": "likely implemented (DBProxyNotFoundFault: The specified proxy name probe-test-value doesn't correspond)"
+    },
+    {
+      "operation": "DescribeDBProxyTargets",
+      "status": "working",
+      "message": "likely implemented (DBProxyNotFoundFault: The specified proxy name probe-test-value doesn't correspond)"
+    },
+    {
+      "operation": "DescribeDBRecommendations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeDBSecurityGroups",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeDBShardGroups",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeDBSnapshotAttributes",
+      "status": "working",
+      "message": "likely implemented (DBSnapshotNotFound: DBSnapshot probe-test-value not found.)"
+    },
+    {
+      "operation": "DescribeDBSnapshotTenantDatabases",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeDBSnapshots",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeDBSubnetGroups",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeEngineDefaultClusterParameters",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeEngineDefaultParameters",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeEventCategories",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeEventSubscriptions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeEvents",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeExportTasks",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeGlobalClusters",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeIntegrations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeOptionGroupOptions",
+      "status": "working",
+      "message": "implemented (InvalidParameterValue)"
+    },
+    {
+      "operation": "DescribeOptionGroups",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeOrderableDBInstanceOptions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribePendingMaintenanceActions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeReservedDBInstances",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeReservedDBInstancesOfferings",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeSourceRegions",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeTenantDatabases",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeValidDBInstanceModifications",
+      "status": "working",
+      "message": "likely implemented (DBInstanceNotFound: DBInstance probe-test-value not found.)"
+    },
+    {
+      "operation": "DisableHttpEndpoint",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DownloadDBLogFilePortion",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "EnableHttpEndpoint",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "FailoverDBCluster",
+      "status": "working",
+      "message": "likely implemented (DBClusterNotFoundFault: The source cluster could not be found or cannot be accessed:)"
+    },
+    {
+      "operation": "FailoverGlobalCluster",
+      "status": "working",
+      "message": "likely implemented (GlobalClusterNotFoundFault: Global Cluster probe-test-value not found.)"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "working",
+      "message": "implemented (InvalidParameterValue)"
+    },
+    {
+      "operation": "ModifyActivityStream",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ModifyCertificates",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ModifyCurrentDBClusterCapacity",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ModifyCustomDBEngineVersion",
+      "status": "working",
+      "message": "likely implemented (CustomDBEngineVersionNotFoundFault: Custom engine version probe-test-value probe-test-value not )"
+    },
+    {
+      "operation": "ModifyDBCluster",
+      "status": "working",
+      "message": "likely implemented (DBClusterNotFoundFault: DBCluster probe-test-value not found.)"
+    },
+    {
+      "operation": "ModifyDBClusterEndpoint",
+      "status": "working",
+      "message": "likely implemented (DBClusterEndpointNotFoundFault: The specified custom endpoint probe-test-value was not found)"
+    },
+    {
+      "operation": "ModifyDBClusterParameterGroup",
+      "status": "working",
+      "message": "likely implemented (DBParameterGroupNotFound: DBClusterParameterGroup not found: probe-test-value)"
+    },
+    {
+      "operation": "ModifyDBClusterSnapshotAttribute",
+      "status": "working",
+      "message": "likely implemented (DBClusterSnapshotNotFoundFault: DBClusterSnapshot probe-test-value not found.)"
+    },
+    {
+      "operation": "ModifyDBInstance",
+      "status": "working",
+      "message": "likely implemented (DBInstanceNotFound: DBInstance probe-test-value not found.)"
+    },
+    {
+      "operation": "ModifyDBParameterGroup",
+      "status": "working",
+      "message": "likely implemented (DBParameterGroupNotFound: DB Parameter Group probe-test-value not found.)"
+    },
+    {
+      "operation": "ModifyDBProxy",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ModifyDBProxyEndpoint",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ModifyDBProxyTargetGroup",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "ModifyDBRecommendation",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ModifyDBShardGroup",
+      "status": "working",
+      "message": "likely implemented (DBShardGroupNotFound: DBShardGroup probe-test-value not found.)"
+    },
+    {
+      "operation": "ModifyDBSnapshot",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ModifyDBSnapshotAttribute",
+      "status": "working",
+      "message": "likely implemented (DBSnapshotNotFound: DBSnapshot probe-test-value not found.)"
+    },
+    {
+      "operation": "ModifyDBSubnetGroup",
+      "status": "working",
+      "message": "likely implemented (DBSubnetGroupNotFoundFault: Subnet Group probe-test-value not found.)"
+    },
+    {
+      "operation": "ModifyEventSubscription",
+      "status": "working",
+      "message": "likely implemented (SubscriptionNotFound: Subscription probe-test-value not found.)"
+    },
+    {
+      "operation": "ModifyGlobalCluster",
+      "status": "working",
+      "message": "likely implemented (GlobalClusterNotFoundFault: Global Cluster probe-test-value not found.)"
+    },
+    {
+      "operation": "ModifyIntegration",
+      "status": "working",
+      "message": "likely implemented (IntegrationNotFoundFault: Integration probe-test-value not found.)"
+    },
+    {
+      "operation": "ModifyOptionGroup",
+      "status": "working",
+      "message": "likely implemented (OptionGroupNotFoundFault: Specified OptionGroupName: probe-test-value not found.)"
+    },
+    {
+      "operation": "ModifyTenantDatabase",
+      "status": "working",
+      "message": "likely implemented (TenantDatabaseNotFound: Tenant database probe-test-value not found.)"
+    },
+    {
+      "operation": "PromoteReadReplica",
+      "status": "working",
+      "message": "likely implemented (DBInstanceNotFound: DBInstance probe-test-value not found.)"
+    },
+    {
+      "operation": "PromoteReadReplicaDBCluster",
+      "status": "working",
+      "message": "likely implemented (DBClusterNotFoundFault: DBCluster probe-test-value not found.)"
+    },
+    {
+      "operation": "PurchaseReservedDBInstancesOffering",
+      "status": "working",
+      "message": "likely implemented (ReservedDBInstancesOfferingNotFound: Offering probe-test-value not found.)"
+    },
+    {
+      "operation": "RebootDBCluster",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "RebootDBInstance",
+      "status": "working",
+      "message": "likely implemented (DBInstanceNotFound: DBInstance probe-test-value not found.)"
+    },
+    {
+      "operation": "RebootDBShardGroup",
+      "status": "working",
+      "message": "likely implemented (DBShardGroupNotFound: DBShardGroup probe-test-value not found.)"
+    },
+    {
+      "operation": "RegisterDBProxyTargets",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "RemoveFromGlobalCluster",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "RemoveRoleFromDBCluster",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "RemoveRoleFromDBInstance",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "RemoveSourceIdentifierFromSubscription",
+      "status": "working",
+      "message": "likely implemented (SubscriptionNotFound: Subscription probe-test-value not found.)"
+    },
+    {
+      "operation": "RemoveTagsFromResource",
+      "status": "working",
+      "message": "implemented (InvalidParameterValue)"
+    },
+    {
+      "operation": "ResetDBClusterParameterGroup",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ResetDBParameterGroup",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "RestoreDBClusterFromS3",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "RestoreDBClusterFromSnapshot",
+      "status": "working",
+      "message": "likely implemented (DBClusterSnapshotNotFoundFault: DBClusterSnapshot probe-test-value not found.)"
+    },
+    {
+      "operation": "RestoreDBClusterToPointInTime",
+      "status": "500_error",
+      "message": "server crash (InternalError: RDSBackend.restore_db_cluster_to_point_in_time() missing 1 r)"
+    },
+    {
+      "operation": "RestoreDBInstanceFromDBSnapshot",
+      "status": "working",
+      "message": "likely implemented (DBSnapshotNotFound: DBSnapshot  not found.)"
+    },
+    {
+      "operation": "RestoreDBInstanceFromS3",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "RestoreDBInstanceToPointInTime",
+      "status": "working",
+      "message": "likely implemented (DBInstanceNotFound: DBInstance  not found.)"
+    },
+    {
+      "operation": "RevokeDBSecurityGroupIngress",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StartActivityStream",
+      "status": "working",
+      "message": "likely implemented (DBClusterNotFoundFault: DBCluster arn:aws:rds:us-east-1:123456789012:thing/probe-tes)"
+    },
+    {
+      "operation": "StartDBCluster",
+      "status": "working",
+      "message": "likely implemented (DBClusterNotFoundFault: DBCluster probe-test-value not found.)"
+    },
+    {
+      "operation": "StartDBInstance",
+      "status": "working",
+      "message": "likely implemented (DBInstanceNotFound: DBInstance probe-test-value not found.)"
+    },
+    {
+      "operation": "StartDBInstanceAutomatedBackupsReplication",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StartExportTask",
+      "status": "working",
+      "message": "implemented (InvalidParameterValue)"
+    },
+    {
+      "operation": "StopActivityStream",
+      "status": "working",
+      "message": "likely implemented (DBClusterNotFoundFault: DBCluster arn:aws:rds:us-east-1:123456789012:thing/probe-tes)"
+    },
+    {
+      "operation": "StopDBCluster",
+      "status": "working",
+      "message": "likely implemented (DBClusterNotFoundFault: DBCluster probe-test-value not found.)"
+    },
+    {
+      "operation": "StopDBInstance",
+      "status": "working",
+      "message": "likely implemented (DBInstanceNotFound: DBInstance probe-test-value not found.)"
+    },
+    {
+      "operation": "StopDBInstanceAutomatedBackupsReplication",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "SwitchoverBlueGreenDeployment",
+      "status": "working",
+      "message": "likely implemented (BlueGreenDeploymentNotFoundFault: BlueGreenDeploymentIdentifier probe-test-value doesn't refer)"
+    },
+    {
+      "operation": "SwitchoverGlobalCluster",
+      "status": "working",
+      "message": "likely implemented (GlobalClusterNotFoundFault: Global Cluster probe-test-value not found.)"
+    },
+    {
+      "operation": "SwitchoverReadReplica",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    }
+  ]
+}

--- a/probes/redshift.json
+++ b/probes/redshift.json
@@ -1,0 +1,711 @@
+{
+  "service": "redshift",
+  "counts": {
+    "working": 127,
+    "needs_params": 2,
+    "not_implemented": 11,
+    "500_error": 0
+  },
+  "operations": [
+    {
+      "operation": "AcceptReservedNodeExchange",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "AddPartner",
+      "status": "working",
+      "message": "likely implemented (ClusterNotFound: Cluster probe-test-value not found.)"
+    },
+    {
+      "operation": "AssociateDataShareConsumer",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "AuthorizeClusterSecurityGroupIngress",
+      "status": "working",
+      "message": "likely implemented (ClusterSecurityGroupNotFound: The cluster security group name does not refer to an existin)"
+    },
+    {
+      "operation": "AuthorizeDataShare",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "AuthorizeEndpointAccess",
+      "status": "working",
+      "message": "likely implemented (ClusterNotFound: Cluster None not found.)"
+    },
+    {
+      "operation": "AuthorizeSnapshotAccess",
+      "status": "working",
+      "message": "likely implemented (ClusterSnapshotNotFound: Snapshot None not found.)"
+    },
+    {
+      "operation": "BatchDeleteClusterSnapshots",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "BatchModifyClusterSnapshots",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CancelResize",
+      "status": "working",
+      "message": "likely implemented (ClusterNotFound: Cluster probe-test-value not found.)"
+    },
+    {
+      "operation": "CopyClusterSnapshot",
+      "status": "working",
+      "message": "likely implemented (ClusterSnapshotNotFound: Snapshot probe-test-value not found.)"
+    },
+    {
+      "operation": "CreateAuthenticationProfile",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateCluster",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateClusterParameterGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateClusterSecurityGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateClusterSnapshot",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateClusterSubnetGroup",
+      "status": "working",
+      "message": "likely implemented (InvalidSubnet: Subnet [] not found.)"
+    },
+    {
+      "operation": "CreateCustomDomainAssociation",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateEndpointAccess",
+      "status": "working",
+      "message": "likely implemented (ClusterNotFound: Cluster None not found.)"
+    },
+    {
+      "operation": "CreateEventSubscription",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateHsmClientCertificate",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateHsmConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateIntegration",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateRedshiftIdcApplication",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateScheduledAction",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateSnapshotCopyGrant",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateSnapshotSchedule",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateTags",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundFault)"
+    },
+    {
+      "operation": "CreateUsageLimit",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeauthorizeDataShare",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteAuthenticationProfile",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteClusterParameterGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteClusterSecurityGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteClusterSnapshot",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteClusterSubnetGroup",
+      "status": "working",
+      "message": "likely implemented (ClusterSubnetGroupNotFoundFault: Subnet group probe-test-value not found.)"
+    },
+    {
+      "operation": "DeleteCustomDomainAssociation",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteEndpointAccess",
+      "status": "working",
+      "message": "likely implemented (EndpointNotFound: Endpoint probe-test-value not found.)"
+    },
+    {
+      "operation": "DeleteEventSubscription",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteHsmClientCertificate",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteHsmConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteIntegration",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeletePartner",
+      "status": "working",
+      "message": "likely implemented (PartnerNotFound: Partner probe-test-value not found.)"
+    },
+    {
+      "operation": "DeleteRedshiftIdcApplication",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteResourcePolicy",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundFault)"
+    },
+    {
+      "operation": "DeleteScheduledAction",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteSnapshotCopyGrant",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteSnapshotSchedule",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundFault)"
+    },
+    {
+      "operation": "DeleteTags",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundFault)"
+    },
+    {
+      "operation": "DeleteUsageLimit",
+      "status": "working",
+      "message": "likely implemented (UsageLimitNotFound: Usage limit probe-test-value not found.)"
+    },
+    {
+      "operation": "DeregisterNamespace",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DescribeAccountAttributes",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeAuthenticationProfiles",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeClusterDbRevisions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeClusterParameterGroups",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeClusterParameters",
+      "status": "working",
+      "message": "likely implemented (ClusterParameterGroupNotFound: ClusterParameterGroup not found: probe-test-value)"
+    },
+    {
+      "operation": "DescribeClusterSecurityGroups",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeClusterSnapshots",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeClusterSubnetGroups",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeClusterTracks",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeClusterVersions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeClusters",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeCustomDomainAssociations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeDataShares",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeDataSharesForConsumer",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeDataSharesForProducer",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeDefaultClusterParameters",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeEndpointAccess",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeEndpointAuthorization",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeEventCategories",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeEventSubscriptions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeEvents",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeHsmClientCertificates",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeHsmConfigurations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeInboundIntegrations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeIntegrations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeLoggingStatus",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeNodeConfigurationOptions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeOrderableClusterOptions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribePartners",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeRedshiftIdcApplications",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeReservedNodeExchangeStatus",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeReservedNodeOfferings",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeReservedNodes",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeResize",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeScheduledActions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeSnapshotCopyGrants",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeSnapshotSchedules",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeStorage",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeTableRestoreStatus",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeTags",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeUsageLimits",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DisableLogging",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DisableSnapshotCopy",
+      "status": "working",
+      "message": "likely implemented (SnapshotCopyAlreadyDisabledFault: Snapshot Copy is already disabled on Cluster probe-test-valu)"
+    },
+    {
+      "operation": "DisassociateDataShareConsumer",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "EnableLogging",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "EnableSnapshotCopy",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "FailoverPrimaryCompute",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetClusterCredentials",
+      "status": "working",
+      "message": "likely implemented (ClusterNotFound: Cluster None not found.)"
+    },
+    {
+      "operation": "GetClusterCredentialsWithIAM",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetIdentityCenterAuthToken",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetReservedNodeExchangeConfigurationOptions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetReservedNodeExchangeOfferings",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetResourcePolicy",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundFault)"
+    },
+    {
+      "operation": "ListRecommendations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ModifyAquaConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ModifyAuthenticationProfile",
+      "status": "working",
+      "message": "likely implemented (AuthenticationProfileNotFoundFault: Authentication profile probe-test-value not found.)"
+    },
+    {
+      "operation": "ModifyCluster",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ModifyClusterDbRevision",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ModifyClusterIamRoles",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ModifyClusterMaintenance",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ModifyClusterParameterGroup",
+      "status": "working",
+      "message": "likely implemented (ClusterParameterGroupNotFound: ClusterParameterGroup not found: probe-test-value)"
+    },
+    {
+      "operation": "ModifyClusterSnapshot",
+      "status": "working",
+      "message": "likely implemented (ClusterSnapshotNotFound: Snapshot probe-test-value not found.)"
+    },
+    {
+      "operation": "ModifyClusterSnapshotSchedule",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ModifyClusterSubnetGroup",
+      "status": "working",
+      "message": "likely implemented (ClusterSubnetGroupNotFoundFault: Subnet group probe-test-value not found.)"
+    },
+    {
+      "operation": "ModifyCustomDomainAssociation",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ModifyEndpointAccess",
+      "status": "working",
+      "message": "likely implemented (EndpointNotFound: Endpoint probe-test-value not found.)"
+    },
+    {
+      "operation": "ModifyEventSubscription",
+      "status": "working",
+      "message": "likely implemented (SubscriptionNotFound: Subscription probe-test-value not found.)"
+    },
+    {
+      "operation": "ModifyIntegration",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ModifyLakehouseConfiguration",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ModifyRedshiftIdcApplication",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ModifyScheduledAction",
+      "status": "working",
+      "message": "likely implemented (ScheduledActionNotFound: Scheduled Action probe-test-value not found.)"
+    },
+    {
+      "operation": "ModifySnapshotCopyRetentionPeriod",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ModifySnapshotSchedule",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundFault)"
+    },
+    {
+      "operation": "ModifyUsageLimit",
+      "status": "working",
+      "message": "likely implemented (UsageLimitNotFound: Usage limit probe-test-value not found.)"
+    },
+    {
+      "operation": "PauseCluster",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PurchaseReservedNodeOffering",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "PutResourcePolicy",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "RebootCluster",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "RegisterNamespace",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "RejectDataShare",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ResetClusterParameterGroup",
+      "status": "working",
+      "message": "likely implemented (ClusterParameterGroupNotFound: ClusterParameterGroup not found: probe-test-value)"
+    },
+    {
+      "operation": "ResizeCluster",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "RestoreFromClusterSnapshot",
+      "status": "working",
+      "message": "likely implemented (ClusterAlreadyExists: Cluster already exists)"
+    },
+    {
+      "operation": "RestoreTableFromClusterSnapshot",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ResumeCluster",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "RevokeClusterSecurityGroupIngress",
+      "status": "working",
+      "message": "likely implemented (ClusterSecurityGroupNotFound: The cluster security group name does not refer to an existin)"
+    },
+    {
+      "operation": "RevokeEndpointAccess",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "RevokeSnapshotAccess",
+      "status": "working",
+      "message": "likely implemented (ClusterSnapshotNotFound: Snapshot None not found.)"
+    },
+    {
+      "operation": "RotateEncryptionKey",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdatePartnerStatus",
+      "status": "working",
+      "message": "likely implemented (PartnerNotFound: Partner probe-test-value not found.)"
+    }
+  ]
+}

--- a/probes/rekognition.json
+++ b/probes/rekognition.json
@@ -1,0 +1,386 @@
+{
+  "service": "rekognition",
+  "counts": {
+    "working": 55,
+    "needs_params": 6,
+    "not_implemented": 14,
+    "500_error": 0
+  },
+  "operations": [
+    {
+      "operation": "AssociateFaces",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CompareFaces",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CopyProjectVersion",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateCollection",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateDataset",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "CreateFaceLivenessSession",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateProject",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateProjectVersion",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "CreateStreamProcessor",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateUser",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteCollection",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteDataset",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteFaces",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DeleteProject",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteProjectPolicy",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteProjectVersion",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteStreamProcessor",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteUser",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeCollection",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeDataset",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeProjectVersions",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeProjects",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeStreamProcessor",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DetectCustomLabels",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DetectFaces",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DetectLabels",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DetectModerationLabels",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DetectProtectiveEquipment",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DetectText",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DisassociateFaces",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DistributeDatasetEntries",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "GetCelebrityInfo",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetCelebrityRecognition",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetContentModeration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetFaceDetection",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetFaceLivenessSessionResults",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "GetFaceSearch",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetLabelDetection",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetMediaAnalysisJob",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetPersonTracking",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetSegmentDetection",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetTextDetection",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "IndexFaces",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListCollections",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListDatasetEntries",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListDatasetLabels",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListFaces",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListMediaAnalysisJobs",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListProjectPolicies",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListStreamProcessors",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListUsers",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "PutProjectPolicy",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "RecognizeCelebrities",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "SearchFaces",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "SearchFacesByImage",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "SearchUsers",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "SearchUsersByImage",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StartCelebrityRecognition",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartContentModeration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartFaceDetection",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartFaceSearch",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartLabelDetection",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartMediaAnalysisJob",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StartPersonTracking",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartProjectVersion",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "StartSegmentDetection",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "StartStreamProcessor",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "StartTextDetection",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StopProjectVersion",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "StopStreamProcessor",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "TagResource",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateDatasetEntries",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateStreamProcessor",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    }
+  ]
+}

--- a/probes/resourcegroupstaggingapi.json
+++ b/probes/resourcegroupstaggingapi.json
@@ -1,0 +1,56 @@
+{
+  "service": "resourcegroupstaggingapi",
+  "counts": {
+    "working": 6,
+    "needs_params": 2,
+    "not_implemented": 1,
+    "500_error": 0
+  },
+  "operations": [
+    {
+      "operation": "DescribeReportCreation",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetComplianceSummary",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetResources",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetTagKeys",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetTagValues",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListRequiredTags",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartReportCreation",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "TagResources",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UntagResources",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    }
+  ]
+}

--- a/probes/route53.json
+++ b/probes/route53.json
@@ -1,0 +1,366 @@
+{
+  "service": "route53",
+  "counts": {
+    "working": 43,
+    "needs_params": 3,
+    "not_implemented": 21,
+    "500_error": 4
+  },
+  "operations": [
+    {
+      "operation": "ActivateKeySigningKey",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "AssociateVPCWithHostedZone",
+      "status": "working",
+      "message": "implemented (NoSuchHostedZone)"
+    },
+    {
+      "operation": "ChangeCidrCollection",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "ChangeResourceRecordSets",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "ChangeTagsForResource",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateCidrCollection",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateHealthCheck",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateHostedZone",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateKeySigningKey",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateQueryLoggingConfig",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateReusableDelegationSet",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateTrafficPolicy",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateTrafficPolicyInstance",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateTrafficPolicyVersion",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateVPCAssociationAuthorization",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'NoneType' object is not subscriptable)"
+    },
+    {
+      "operation": "DeactivateKeySigningKey",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteCidrCollection",
+      "status": "working",
+      "message": "likely implemented (NoSuchCidrCollectionException: The CIDR collection with ID probe-test-value does not exist.)"
+    },
+    {
+      "operation": "DeleteHealthCheck",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteHostedZone",
+      "status": "working",
+      "message": "implemented (NoSuchHostedZone)"
+    },
+    {
+      "operation": "DeleteKeySigningKey",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteQueryLoggingConfig",
+      "status": "working",
+      "message": "likely implemented (NoSuchQueryLoggingConfig: The query logging configuration does not exist)"
+    },
+    {
+      "operation": "DeleteReusableDelegationSet",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteTrafficPolicy",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteTrafficPolicyInstance",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteVPCAssociationAuthorization",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'NoneType' object is not subscriptable)"
+    },
+    {
+      "operation": "DisableHostedZoneDNSSEC",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DisassociateVPCFromHostedZone",
+      "status": "working",
+      "message": "implemented (NoSuchHostedZone)"
+    },
+    {
+      "operation": "EnableHostedZoneDNSSEC",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetAccountLimit",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetChange",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetCheckerIpRanges",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetDNSSEC",
+      "status": "working",
+      "message": "implemented (NoSuchHostedZone)"
+    },
+    {
+      "operation": "GetGeoLocation",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetHealthCheck",
+      "status": "working",
+      "message": "likely implemented (NoSuchHealthCheck: A health check with id probe-test-value does not exist.)"
+    },
+    {
+      "operation": "GetHealthCheckCount",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetHealthCheckLastFailureReason",
+      "status": "working",
+      "message": "likely implemented (NoSuchHealthCheck: A health check with id probe-test-value does not exist.)"
+    },
+    {
+      "operation": "GetHealthCheckStatus",
+      "status": "working",
+      "message": "likely implemented (NoSuchHealthCheck: A health check with id probe-test-value does not exist.)"
+    },
+    {
+      "operation": "GetHostedZone",
+      "status": "working",
+      "message": "implemented (NoSuchHostedZone)"
+    },
+    {
+      "operation": "GetHostedZoneCount",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetHostedZoneLimit",
+      "status": "working",
+      "message": "implemented (NoSuchHostedZone)"
+    },
+    {
+      "operation": "GetQueryLoggingConfig",
+      "status": "working",
+      "message": "likely implemented (NoSuchQueryLoggingConfig: The query logging configuration does not exist)"
+    },
+    {
+      "operation": "GetReusableDelegationSet",
+      "status": "working",
+      "message": "likely implemented (NoSuchDelegationSet: probe-test-value)"
+    },
+    {
+      "operation": "GetReusableDelegationSetLimit",
+      "status": "working",
+      "message": "likely implemented (NoSuchDelegationSet: probe-test-value)"
+    },
+    {
+      "operation": "GetTrafficPolicy",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetTrafficPolicyInstance",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetTrafficPolicyInstanceCount",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListCidrBlocks",
+      "status": "working",
+      "message": "likely implemented (NoSuchCidrCollectionException: The CIDR collection with ID probe-test-value does not exist.)"
+    },
+    {
+      "operation": "ListCidrCollections",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListCidrLocations",
+      "status": "working",
+      "message": "likely implemented (NoSuchCidrCollectionException: The CIDR collection with ID probe-test-value does not exist.)"
+    },
+    {
+      "operation": "ListGeoLocations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListHealthChecks",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListHostedZones",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListHostedZonesByName",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListHostedZonesByVPC",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListQueryLoggingConfigs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListResourceRecordSets",
+      "status": "working",
+      "message": "implemented (NoSuchHostedZone)"
+    },
+    {
+      "operation": "ListReusableDelegationSets",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListTagsForResources",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "ListTrafficPolicies",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTrafficPolicyInstances",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTrafficPolicyInstancesByHostedZone",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListTrafficPolicyInstancesByPolicy",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListTrafficPolicyVersions",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListVPCAssociationAuthorizations",
+      "status": "working",
+      "message": "implemented (NoSuchHostedZone)"
+    },
+    {
+      "operation": "TestDNSAnswer",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateHealthCheck",
+      "status": "500_error",
+      "message": "server crash (InternalError: no element found: line 1, column 0)"
+    },
+    {
+      "operation": "UpdateHostedZoneComment",
+      "status": "500_error",
+      "message": "server crash (InternalError: no element found: line 1, column 0)"
+    },
+    {
+      "operation": "UpdateHostedZoneFeatures",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateTrafficPolicyComment",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateTrafficPolicyInstance",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    }
+  ]
+}

--- a/probes/route53resolver.json
+++ b/probes/route53resolver.json
@@ -1,0 +1,351 @@
+{
+  "service": "route53resolver",
+  "counts": {
+    "working": 49,
+    "needs_params": 1,
+    "not_implemented": 17,
+    "500_error": 1
+  },
+  "operations": [
+    {
+      "operation": "AssociateFirewallRuleGroup",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "AssociateResolverEndpointIpAddress",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "AssociateResolverQueryLogConfig",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "AssociateResolverRule",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "CreateFirewallDomainList",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateFirewallRule",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "CreateFirewallRuleGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateOutpostResolver",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateResolverEndpoint",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateResolverQueryLogConfig",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateResolverRule",
+      "status": "500_error",
+      "message": "server crash (InternalError: object of type 'NoneType' has no len())"
+    },
+    {
+      "operation": "DeleteFirewallDomainList",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteFirewallRule",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteFirewallRuleGroup",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteOutpostResolver",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteResolverEndpoint",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteResolverQueryLogConfig",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteResolverRule",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DisassociateFirewallRuleGroup",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DisassociateResolverEndpointIpAddress",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DisassociateResolverQueryLogConfig",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DisassociateResolverRule",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetFirewallConfig",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetFirewallDomainList",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetFirewallRuleGroup",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetFirewallRuleGroupAssociation",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetFirewallRuleGroupPolicy",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetOutpostResolver",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetResolverConfig",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetResolverDnssecConfig",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetResolverEndpoint",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetResolverQueryLogConfig",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetResolverQueryLogConfigAssociation",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetResolverQueryLogConfigPolicy",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetResolverRule",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetResolverRuleAssociation",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetResolverRulePolicy",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ImportFirewallDomains",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListFirewallConfigs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListFirewallDomainLists",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListFirewallDomains",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListFirewallRuleGroupAssociations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListFirewallRuleGroups",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListFirewallRules",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListOutpostResolvers",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListResolverConfigs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListResolverDnssecConfigs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListResolverEndpointIpAddresses",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListResolverEndpoints",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListResolverQueryLogConfigAssociations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListResolverQueryLogConfigs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListResolverRuleAssociations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListResolverRules",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "PutFirewallRuleGroupPolicy",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "PutResolverQueryLogConfigPolicy",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "PutResolverRulePolicy",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "TagResource",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateFirewallConfig",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateFirewallDomains",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateFirewallRule",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateFirewallRuleGroupAssociation",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateOutpostResolver",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateResolverConfig",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateResolverDnssecConfig",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateResolverEndpoint",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateResolverRule",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    }
+  ]
+}

--- a/probes/s3.json
+++ b/probes/s3.json
@@ -1,0 +1,561 @@
+{
+  "service": "s3",
+  "counts": {
+    "working": 97,
+    "needs_params": 1,
+    "not_implemented": 1,
+    "500_error": 11
+  },
+  "operations": [
+    {
+      "operation": "AbortMultipartUpload",
+      "status": "working",
+      "message": "implemented (NoSuchBucket)"
+    },
+    {
+      "operation": "CompleteMultipartUpload",
+      "status": "working",
+      "message": "implemented (NoSuchBucket)"
+    },
+    {
+      "operation": "CopyObject",
+      "status": "working",
+      "message": "implemented (NoSuchBucket)"
+    },
+    {
+      "operation": "CreateBucket",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateBucketMetadataConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateBucketMetadataTableConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateMultipartUpload",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateSession",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteBucketAnalyticsConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteBucketCors",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteBucketEncryption",
+      "status": "working",
+      "message": "implemented (NoSuchBucket)"
+    },
+    {
+      "operation": "DeleteBucketIntelligentTieringConfiguration",
+      "status": "working",
+      "message": "implemented (NoSuchBucket)"
+    },
+    {
+      "operation": "DeleteBucketInventoryConfiguration",
+      "status": "working",
+      "message": "implemented (NoSuchBucket)"
+    },
+    {
+      "operation": "DeleteBucketLifecycle",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteBucketMetadataConfiguration",
+      "status": "working",
+      "message": "implemented (NoSuchBucket)"
+    },
+    {
+      "operation": "DeleteBucketMetadataTableConfiguration",
+      "status": "working",
+      "message": "implemented (NoSuchBucket)"
+    },
+    {
+      "operation": "DeleteBucketMetricsConfiguration",
+      "status": "working",
+      "message": "implemented (NoSuchBucket)"
+    },
+    {
+      "operation": "DeleteBucketOwnershipControls",
+      "status": "working",
+      "message": "implemented (NoSuchBucket)"
+    },
+    {
+      "operation": "DeleteBucketPolicy",
+      "status": "working",
+      "message": "implemented (NoSuchBucket)"
+    },
+    {
+      "operation": "DeleteBucketReplication",
+      "status": "working",
+      "message": "implemented (NoSuchBucket)"
+    },
+    {
+      "operation": "DeleteBucketTagging",
+      "status": "working",
+      "message": "implemented (NoSuchBucket)"
+    },
+    {
+      "operation": "DeleteBucketWebsite",
+      "status": "working",
+      "message": "implemented (NoSuchBucket)"
+    },
+    {
+      "operation": "DeleteObject",
+      "status": "working",
+      "message": "implemented (NoSuchBucket)"
+    },
+    {
+      "operation": "DeleteObjectTagging",
+      "status": "working",
+      "message": "implemented (NoSuchBucket)"
+    },
+    {
+      "operation": "DeleteObjects",
+      "status": "working",
+      "message": "likely implemented (MalformedXML: The XML you provided was not well-formed or did not validate)"
+    },
+    {
+      "operation": "DeletePublicAccessBlock",
+      "status": "working",
+      "message": "implemented (NoSuchBucket)"
+    },
+    {
+      "operation": "GetBucketAbac",
+      "status": "working",
+      "message": "implemented (NoSuchBucket)"
+    },
+    {
+      "operation": "GetBucketAccelerateConfiguration",
+      "status": "working",
+      "message": "implemented (NoSuchBucket)"
+    },
+    {
+      "operation": "GetBucketAcl",
+      "status": "working",
+      "message": "implemented (NoSuchBucket)"
+    },
+    {
+      "operation": "GetBucketAnalyticsConfiguration",
+      "status": "working",
+      "message": "implemented (NoSuchBucket)"
+    },
+    {
+      "operation": "GetBucketCors",
+      "status": "working",
+      "message": "likely implemented (NoSuchCORSConfiguration: The CORS configuration does not exist)"
+    },
+    {
+      "operation": "GetBucketEncryption",
+      "status": "working",
+      "message": "implemented (NoSuchBucket)"
+    },
+    {
+      "operation": "GetBucketIntelligentTieringConfiguration",
+      "status": "working",
+      "message": "implemented (NoSuchBucket)"
+    },
+    {
+      "operation": "GetBucketInventoryConfiguration",
+      "status": "working",
+      "message": "implemented (NoSuchBucket)"
+    },
+    {
+      "operation": "GetBucketLifecycle",
+      "status": "working",
+      "message": "likely implemented (NoSuchLifecycleConfiguration: The lifecycle configuration does not exist)"
+    },
+    {
+      "operation": "GetBucketLifecycleConfiguration",
+      "status": "working",
+      "message": "likely implemented (NoSuchLifecycleConfiguration: The lifecycle configuration does not exist)"
+    },
+    {
+      "operation": "GetBucketLocation",
+      "status": "working",
+      "message": "implemented (NoSuchBucket)"
+    },
+    {
+      "operation": "GetBucketLogging",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetBucketMetadataConfiguration",
+      "status": "working",
+      "message": "implemented (NoSuchBucket)"
+    },
+    {
+      "operation": "GetBucketMetadataTableConfiguration",
+      "status": "working",
+      "message": "implemented (NoSuchBucket)"
+    },
+    {
+      "operation": "GetBucketMetricsConfiguration",
+      "status": "working",
+      "message": "implemented (NoSuchBucket)"
+    },
+    {
+      "operation": "GetBucketNotification",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetBucketNotificationConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetBucketOwnershipControls",
+      "status": "working",
+      "message": "implemented (NoSuchBucket)"
+    },
+    {
+      "operation": "GetBucketPolicy",
+      "status": "working",
+      "message": "implemented (NoSuchBucket)"
+    },
+    {
+      "operation": "GetBucketPolicyStatus",
+      "status": "working",
+      "message": "implemented (NoSuchBucket)"
+    },
+    {
+      "operation": "GetBucketReplication",
+      "status": "working",
+      "message": "implemented (NoSuchBucket)"
+    },
+    {
+      "operation": "GetBucketRequestPayment",
+      "status": "working",
+      "message": "implemented (NoSuchBucket)"
+    },
+    {
+      "operation": "GetBucketTagging",
+      "status": "working",
+      "message": "implemented (NoSuchBucket)"
+    },
+    {
+      "operation": "GetBucketVersioning",
+      "status": "working",
+      "message": "implemented (NoSuchBucket)"
+    },
+    {
+      "operation": "GetBucketWebsite",
+      "status": "working",
+      "message": "implemented (NoSuchBucket)"
+    },
+    {
+      "operation": "GetObject",
+      "status": "working",
+      "message": "implemented (NoSuchBucket)"
+    },
+    {
+      "operation": "GetObjectAcl",
+      "status": "working",
+      "message": "implemented (NoSuchBucket)"
+    },
+    {
+      "operation": "GetObjectAttributes",
+      "status": "working",
+      "message": "implemented (NoSuchBucket)"
+    },
+    {
+      "operation": "GetObjectLegalHold",
+      "status": "working",
+      "message": "likely implemented (NoSuchKey: Legal hold not set)"
+    },
+    {
+      "operation": "GetObjectLockConfiguration",
+      "status": "working",
+      "message": "likely implemented (ObjectLockConfigurationNotFoundError: Object Lock configuration does not exist for this bucket)"
+    },
+    {
+      "operation": "GetObjectRetention",
+      "status": "working",
+      "message": "implemented (NoSuchBucket)"
+    },
+    {
+      "operation": "GetObjectTagging",
+      "status": "working",
+      "message": "implemented (NoSuchBucket)"
+    },
+    {
+      "operation": "GetObjectTorrent",
+      "status": "working",
+      "message": "implemented (NoSuchBucket)"
+    },
+    {
+      "operation": "GetPublicAccessBlock",
+      "status": "working",
+      "message": "implemented (NoSuchBucket)"
+    },
+    {
+      "operation": "HeadBucket",
+      "status": "working",
+      "message": "likely implemented (404: Not Found)"
+    },
+    {
+      "operation": "HeadObject",
+      "status": "working",
+      "message": "likely implemented (404: Not Found)"
+    },
+    {
+      "operation": "ListBucketAnalyticsConfigurations",
+      "status": "working",
+      "message": "implemented (NoSuchBucket)"
+    },
+    {
+      "operation": "ListBucketIntelligentTieringConfigurations",
+      "status": "working",
+      "message": "implemented (NoSuchBucket)"
+    },
+    {
+      "operation": "ListBucketInventoryConfigurations",
+      "status": "working",
+      "message": "implemented (NoSuchBucket)"
+    },
+    {
+      "operation": "ListBucketMetricsConfigurations",
+      "status": "working",
+      "message": "implemented (NoSuchBucket)"
+    },
+    {
+      "operation": "ListBuckets",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListDirectoryBuckets",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListMultipartUploads",
+      "status": "working",
+      "message": "implemented (NoSuchBucket)"
+    },
+    {
+      "operation": "ListObjectVersions",
+      "status": "working",
+      "message": "implemented (NoSuchBucket)"
+    },
+    {
+      "operation": "ListObjects",
+      "status": "working",
+      "message": "implemented (NoSuchBucket)"
+    },
+    {
+      "operation": "ListObjectsV2",
+      "status": "working",
+      "message": "implemented (NoSuchBucket)"
+    },
+    {
+      "operation": "ListParts",
+      "status": "working",
+      "message": "implemented (NoSuchBucket)"
+    },
+    {
+      "operation": "PutBucketAbac",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutBucketAccelerateConfiguration",
+      "status": "working",
+      "message": "likely implemented (MalformedXML: The XML you provided was not well-formed or did not validate)"
+    },
+    {
+      "operation": "PutBucketAcl",
+      "status": "500_error",
+      "message": "server crash (InternalError: no element found: line 1, column 0)"
+    },
+    {
+      "operation": "PutBucketAnalyticsConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutBucketCors",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutBucketEncryption",
+      "status": "working",
+      "message": "likely implemented (MalformedXML: The XML you provided was not well-formed or did not validate)"
+    },
+    {
+      "operation": "PutBucketIntelligentTieringConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutBucketInventoryConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutBucketLifecycle",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutBucketLifecycleConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutBucketLogging",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutBucketMetricsConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutBucketNotification",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutBucketNotificationConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutBucketOwnershipControls",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'Rule')"
+    },
+    {
+      "operation": "PutBucketPolicy",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutBucketReplication",
+      "status": "working",
+      "message": "likely implemented (InvalidRequest: Versioning must be 'Enabled' on the bucket to apply a replic)"
+    },
+    {
+      "operation": "PutBucketRequestPayment",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutBucketTagging",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutBucketVersioning",
+      "status": "working",
+      "message": "likely implemented (404: Not Found)"
+    },
+    {
+      "operation": "PutBucketWebsite",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutObject",
+      "status": "500_error",
+      "message": "server crash (InternalError: Expecting value: line 1 column 1 (char 0))"
+    },
+    {
+      "operation": "PutObjectAcl",
+      "status": "500_error",
+      "message": "server crash (InternalError: Expecting value: line 1 column 1 (char 0))"
+    },
+    {
+      "operation": "PutObjectLegalHold",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutObjectLockConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutObjectRetention",
+      "status": "500_error",
+      "message": "server crash (InternalError: Expecting value: line 1 column 1 (char 0))"
+    },
+    {
+      "operation": "PutObjectTagging",
+      "status": "500_error",
+      "message": "server crash (InternalError: Expecting value: line 1 column 1 (char 0))"
+    },
+    {
+      "operation": "PutPublicAccessBlock",
+      "status": "working",
+      "message": "likely implemented (InvalidRequest: Must specify at least one configuration.)"
+    },
+    {
+      "operation": "RenameObject",
+      "status": "500_error",
+      "message": "server crash (InternalError: Expecting value: line 1 column 1 (char 0))"
+    },
+    {
+      "operation": "RestoreObject",
+      "status": "500_error",
+      "message": "server crash (InternalError: Expecting value: line 1 column 1 (char 0))"
+    },
+    {
+      "operation": "SelectObjectContent",
+      "status": "500_error",
+      "message": "server crash (InternalError: Expecting value: line 1 column 1 (char 0))"
+    },
+    {
+      "operation": "UpdateBucketMetadataInventoryTableConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateBucketMetadataJournalTableConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateObjectEncryption",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UploadPart",
+      "status": "500_error",
+      "message": "server crash (InternalError: Expecting value: line 1 column 1 (char 0))"
+    },
+    {
+      "operation": "UploadPartCopy",
+      "status": "500_error",
+      "message": "server crash (InternalError: Expecting value: line 1 column 1 (char 0))"
+    },
+    {
+      "operation": "WriteGetObjectResponse",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    }
+  ]
+}

--- a/probes/s3control.json
+++ b/probes/s3control.json
@@ -1,0 +1,491 @@
+{
+  "service": "s3control",
+  "counts": {
+    "working": 77,
+    "needs_params": 0,
+    "not_implemented": 14,
+    "500_error": 5
+  },
+  "operations": [
+    {
+      "operation": "AssociateAccessGrantsIdentityCenter",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateAccessGrant",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'None' has no attribute 'get')"
+    },
+    {
+      "operation": "CreateAccessGrantsInstance",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateAccessGrantsLocation",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateAccessPoint",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateAccessPointForObjectLambda",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateBucket",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateJob",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateMultiRegionAccessPoint",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateStorageLensGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteAccessGrant",
+      "status": "working",
+      "message": "likely implemented (NoSuchAccessGrant: The specified access grant does not exist: probe-test-value)"
+    },
+    {
+      "operation": "DeleteAccessGrantsInstance",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteAccessGrantsInstanceResourcePolicy",
+      "status": "working",
+      "message": "likely implemented (NoSuchAccessGrantsInstance: The Access Grants instance does not exist)"
+    },
+    {
+      "operation": "DeleteAccessGrantsLocation",
+      "status": "working",
+      "message": "likely implemented (NoSuchAccessGrantsLocation: The specified access grants location does not exist: probe-t)"
+    },
+    {
+      "operation": "DeleteAccessPoint",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteAccessPointForObjectLambda",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteAccessPointPolicy",
+      "status": "working",
+      "message": "likely implemented (NoSuchAccessPoint: The specified accesspoint does not exist)"
+    },
+    {
+      "operation": "DeleteAccessPointPolicyForObjectLambda",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteAccessPointScope",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteBucketLifecycleConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteBucketPolicy",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteBucketReplication",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteBucketTagging",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteJobTagging",
+      "status": "working",
+      "message": "likely implemented (NoSuchJob: The specified job does not exist: probe-test-value)"
+    },
+    {
+      "operation": "DeleteMultiRegionAccessPoint",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeletePublicAccessBlock",
+      "status": "working",
+      "message": "likely implemented (AccessDenied: Access Denied)"
+    },
+    {
+      "operation": "DeleteStorageLensConfiguration",
+      "status": "working",
+      "message": "likely implemented (AccessDenied: Access Denied)"
+    },
+    {
+      "operation": "DeleteStorageLensConfigurationTagging",
+      "status": "working",
+      "message": "likely implemented (AccessDenied: Access Denied)"
+    },
+    {
+      "operation": "DeleteStorageLensGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeJob",
+      "status": "working",
+      "message": "likely implemented (NoSuchJob: The specified job does not exist: probe-test-value)"
+    },
+    {
+      "operation": "DescribeMultiRegionAccessPointOperation",
+      "status": "working",
+      "message": "likely implemented (NoSuchAsyncRequest: The specified async request does not exist)"
+    },
+    {
+      "operation": "DissociateAccessGrantsIdentityCenter",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetAccessGrant",
+      "status": "working",
+      "message": "likely implemented (NoSuchAccessGrant: The specified access grant does not exist: probe-test-value)"
+    },
+    {
+      "operation": "GetAccessGrantsInstance",
+      "status": "working",
+      "message": "likely implemented (NoSuchAccessGrantsInstance: The Access Grants instance does not exist)"
+    },
+    {
+      "operation": "GetAccessGrantsInstanceForPrefix",
+      "status": "working",
+      "message": "likely implemented (NoSuchAccessGrantsInstance: The Access Grants instance does not exist)"
+    },
+    {
+      "operation": "GetAccessGrantsInstanceResourcePolicy",
+      "status": "working",
+      "message": "likely implemented (NoSuchAccessGrantsInstance: The Access Grants instance does not exist)"
+    },
+    {
+      "operation": "GetAccessGrantsLocation",
+      "status": "working",
+      "message": "likely implemented (NoSuchAccessGrantsLocation: The specified access grants location does not exist: probe-t)"
+    },
+    {
+      "operation": "GetAccessPoint",
+      "status": "working",
+      "message": "likely implemented (NoSuchAccessPoint: The specified accesspoint does not exist)"
+    },
+    {
+      "operation": "GetAccessPointConfigurationForObjectLambda",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetAccessPointForObjectLambda",
+      "status": "working",
+      "message": "likely implemented (NoSuchAccessPoint: The specified accesspoint does not exist)"
+    },
+    {
+      "operation": "GetAccessPointPolicy",
+      "status": "working",
+      "message": "likely implemented (NoSuchAccessPoint: The specified accesspoint does not exist)"
+    },
+    {
+      "operation": "GetAccessPointPolicyForObjectLambda",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetAccessPointPolicyStatus",
+      "status": "working",
+      "message": "likely implemented (NoSuchAccessPoint: The specified accesspoint does not exist)"
+    },
+    {
+      "operation": "GetAccessPointPolicyStatusForObjectLambda",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetAccessPointScope",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetBucket",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetBucketLifecycleConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetBucketPolicy",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetBucketReplication",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetBucketTagging",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetBucketVersioning",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetDataAccess",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetJobTagging",
+      "status": "working",
+      "message": "likely implemented (NoSuchJob: The specified job does not exist: probe-test-value)"
+    },
+    {
+      "operation": "GetMultiRegionAccessPoint",
+      "status": "working",
+      "message": "likely implemented (NoSuchMultiRegionAccessPoint: The specified multi-region access point does not exist)"
+    },
+    {
+      "operation": "GetMultiRegionAccessPointPolicy",
+      "status": "working",
+      "message": "likely implemented (NoSuchMultiRegionAccessPoint: The specified multi-region access point does not exist)"
+    },
+    {
+      "operation": "GetMultiRegionAccessPointPolicyStatus",
+      "status": "working",
+      "message": "likely implemented (NoSuchMultiRegionAccessPoint: The specified multi-region access point does not exist)"
+    },
+    {
+      "operation": "GetMultiRegionAccessPointRoutes",
+      "status": "working",
+      "message": "likely implemented (NoSuchMultiRegionAccessPoint: The specified multi-region access point does not exist)"
+    },
+    {
+      "operation": "GetPublicAccessBlock",
+      "status": "working",
+      "message": "likely implemented (AccessDenied: Access Denied)"
+    },
+    {
+      "operation": "GetStorageLensConfiguration",
+      "status": "working",
+      "message": "likely implemented (NoSuchConfiguration: The specified configuration does not exist: probe-test-value)"
+    },
+    {
+      "operation": "GetStorageLensConfigurationTagging",
+      "status": "working",
+      "message": "likely implemented (AccessDenied: Access Denied)"
+    },
+    {
+      "operation": "GetStorageLensGroup",
+      "status": "working",
+      "message": "likely implemented (NoSuchStorageLensGroup: The specified Storage Lens group does not exist: probe-test-)"
+    },
+    {
+      "operation": "ListAccessGrants",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListAccessGrantsInstances",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListAccessGrantsLocations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListAccessPoints",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListAccessPointsForDirectoryBuckets",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListAccessPointsForObjectLambda",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListCallerAccessGrants",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListJobs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListMultiRegionAccessPoints",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListRegionalBuckets",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListStorageLensConfigurations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListStorageLensGroups",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "PutAccessGrantsInstanceResourcePolicy",
+      "status": "working",
+      "message": "likely implemented (NoSuchAccessGrantsInstance: The Access Grants instance does not exist)"
+    },
+    {
+      "operation": "PutAccessPointConfigurationForObjectLambda",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "PutAccessPointPolicy",
+      "status": "working",
+      "message": "likely implemented (NoSuchAccessPoint: The specified accesspoint does not exist)"
+    },
+    {
+      "operation": "PutAccessPointPolicyForObjectLambda",
+      "status": "working",
+      "message": "likely implemented (NoSuchAccessPoint: The specified accesspoint does not exist)"
+    },
+    {
+      "operation": "PutAccessPointScope",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutBucketLifecycleConfiguration",
+      "status": "500_error",
+      "message": "server crash (InternalError: no element found: line 1, column 0)"
+    },
+    {
+      "operation": "PutBucketPolicy",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutBucketReplication",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutBucketTagging",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutBucketVersioning",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'PutBucketVersioningRequest')"
+    },
+    {
+      "operation": "PutJobTagging",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'NoneType' object has no attribute 'get')"
+    },
+    {
+      "operation": "PutMultiRegionAccessPointPolicy",
+      "status": "working",
+      "message": "likely implemented (NoSuchMultiRegionAccessPoint: The specified multi-region access point does not exist)"
+    },
+    {
+      "operation": "PutPublicAccessBlock",
+      "status": "working",
+      "message": "likely implemented (AccessDenied: Access Denied)"
+    },
+    {
+      "operation": "PutStorageLensConfiguration",
+      "status": "working",
+      "message": "likely implemented (AccessDenied: Access Denied)"
+    },
+    {
+      "operation": "PutStorageLensConfigurationTagging",
+      "status": "working",
+      "message": "likely implemented (AccessDenied: Access Denied)"
+    },
+    {
+      "operation": "SubmitMultiRegionAccessPointRoutes",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'NoneType' object has no attribute 'get')"
+    },
+    {
+      "operation": "TagResource",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateAccessGrantsLocation",
+      "status": "working",
+      "message": "likely implemented (NoSuchAccessGrantsLocation: The specified access grants location does not exist: probe-t)"
+    },
+    {
+      "operation": "UpdateJobPriority",
+      "status": "working",
+      "message": "likely implemented (NoSuchJob: The specified job does not exist: probe-test-value)"
+    },
+    {
+      "operation": "UpdateJobStatus",
+      "status": "working",
+      "message": "likely implemented (NoSuchJob: The specified job does not exist: probe-test-value)"
+    },
+    {
+      "operation": "UpdateStorageLensGroup",
+      "status": "working",
+      "message": "likely implemented (NoSuchStorageLensGroup: The specified Storage Lens group does not exist: probe-test-)"
+    }
+  ]
+}

--- a/probes/s3tables.json
+++ b/probes/s3tables.json
@@ -1,0 +1,251 @@
+{
+  "service": "s3tables",
+  "counts": {
+    "working": 43,
+    "needs_params": 3,
+    "not_implemented": 0,
+    "500_error": 2
+  },
+  "operations": [
+    {
+      "operation": "CreateNamespace",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateTable",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "CreateTableBucket",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteNamespace",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeleteTableBucket",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeleteTableBucketEncryption",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeleteTableBucketMetricsConfiguration",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeleteTableBucketPolicy",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeleteTableBucketReplication",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeleteTablePolicy",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeleteTableReplication",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetNamespace",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetTable",
+      "status": "500_error",
+      "message": "server crash (InternalError: argument of type 'NoneType' is not iterable)"
+    },
+    {
+      "operation": "GetTableBucket",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetTableBucketEncryption",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetTableBucketMaintenanceConfiguration",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetTableBucketMetricsConfiguration",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetTableBucketPolicy",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetTableBucketReplication",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetTableBucketStorageClass",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetTableEncryption",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetTableMaintenanceConfiguration",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetTableMaintenanceJobStatus",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetTableMetadataLocation",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetTablePolicy",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetTableRecordExpirationConfiguration",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetTableRecordExpirationJobStatus",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetTableReplication",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetTableReplicationStatus",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetTableStorageClass",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "ListNamespaces",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "ListTableBuckets",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTables",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutTableBucketEncryption",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "PutTableBucketMaintenanceConfiguration",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "PutTableBucketMetricsConfiguration",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "PutTableBucketPolicy",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "PutTableBucketReplication",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "PutTableBucketStorageClass",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "PutTableMaintenanceConfiguration",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "PutTablePolicy",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "PutTableRecordExpirationConfiguration",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'tableArn')"
+    },
+    {
+      "operation": "PutTableReplication",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "RenameTable",
+      "status": "working",
+      "message": "likely implemented (BadRequestException: Neither a new namespace name nor a new table name is specifi)"
+    },
+    {
+      "operation": "TagResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateTableMetadataLocation",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    }
+  ]
+}

--- a/probes/s3vectors.json
+++ b/probes/s3vectors.json
@@ -1,0 +1,106 @@
+{
+  "service": "s3vectors",
+  "counts": {
+    "working": 12,
+    "needs_params": 4,
+    "not_implemented": 3,
+    "500_error": 0
+  },
+  "operations": [
+    {
+      "operation": "CreateIndex",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "CreateVectorBucket",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteIndex",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeleteVectorBucket",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteVectorBucketPolicy",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeleteVectors",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "GetIndex",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetVectorBucket",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetVectorBucketPolicy",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetVectors",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "ListIndexes",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListVectorBuckets",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListVectors",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "PutVectorBucketPolicy",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "PutVectors",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "QueryVectors",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "TagResource",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    }
+  ]
+}

--- a/probes/sagemaker.json
+++ b/probes/sagemaker.json
@@ -1,0 +1,1901 @@
+{
+  "service": "sagemaker",
+  "counts": {
+    "working": 351,
+    "needs_params": 21,
+    "not_implemented": 0,
+    "500_error": 6
+  },
+  "operations": [
+    {
+      "operation": "AddAssociation",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "AddTags",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'NoneType' object has no attribute 'get')"
+    },
+    {
+      "operation": "AssociateTrialComponent",
+      "status": "working",
+      "message": "likely implemented (ResourceNotFound: Trial 'arn:aws:sagemaker:us-east-1:123456789012:experiment-t)"
+    },
+    {
+      "operation": "AttachClusterNodeVolume",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "BatchAddClusterNodes",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "BatchDeleteClusterNodes",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "BatchDescribeModelPackage",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "BatchRebootClusterNodes",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "BatchReplaceClusterNodes",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateAction",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateAlgorithm",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateApp",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateAppImageConfig",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateArtifact",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateAutoMLJob",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateAutoMLJobV2",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateCluster",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'NoneType' object is not iterable)"
+    },
+    {
+      "operation": "CreateClusterSchedulerConfig",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateCodeRepository",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateCompilationJob",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "CreateComputeQuota",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateContext",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateDataQualityJobDefinition",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateDeviceFleet",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateDomain",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateEdgeDeploymentPlan",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateEdgeDeploymentStage",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateEdgePackagingJob",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateEndpoint",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "CreateEndpointConfig",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateExperiment",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateFeatureGroup",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateFlowDefinition",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateHub",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateHubContentPresignedUrls",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateHubContentReference",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateHumanTaskUi",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateHyperParameterTuningJob",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateImage",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateImageVersion",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateInferenceComponent",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateInferenceExperiment",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateInferenceRecommendationsJob",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateLabelingJob",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateMlflowApp",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateMlflowTrackingServer",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateModel",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateModelBiasJobDefinition",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateModelCard",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateModelCardExportJob",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateModelExplainabilityJobDefinition",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateModelPackage",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "CreateModelPackageGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateModelQualityJobDefinition",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateMonitoringSchedule",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateNotebookInstance",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "CreateNotebookInstanceLifecycleConfig",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateOptimizationJob",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreatePartnerApp",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreatePartnerAppPresignedUrl",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreatePipeline",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreatePresignedDomainUrl",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreatePresignedMlflowAppUrl",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreatePresignedMlflowTrackingServerUrl",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreatePresignedNotebookInstanceUrl",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateProcessingJob",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateProject",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateSpace",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateStudioLifecycleConfig",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateTrainingJob",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'NoneType' object does not support item assignment)"
+    },
+    {
+      "operation": "CreateTrainingPlan",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateTransformJob",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateTrial",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateTrialComponent",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateUserProfile",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateWorkforce",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateWorkteam",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DeleteAction",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteAlgorithm",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteApp",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteAppImageConfig",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteArtifact",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteAssociation",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteClusterSchedulerConfig",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteCodeRepository",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteCompilationJob",
+      "status": "working",
+      "message": "likely implemented (ResourceNotFound: Could not find compilation job 'probe-test-value'.)"
+    },
+    {
+      "operation": "DeleteComputeQuota",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteContext",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteDataQualityJobDefinition",
+      "status": "working",
+      "message": "likely implemented (ResourceNotFound: Job definition probe-test-value not found)"
+    },
+    {
+      "operation": "DeleteDeviceFleet",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteDomain",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DeleteEdgeDeploymentPlan",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteEdgeDeploymentStage",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteEndpoint",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DeleteEndpointConfig",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DeleteExperiment",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteFeatureGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteFlowDefinition",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteHub",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteHubContent",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteHubContentReference",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteHumanTaskUi",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteHyperParameterTuningJob",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteImage",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteImageVersion",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteInferenceComponent",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteInferenceExperiment",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteMlflowApp",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteMlflowTrackingServer",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteModel",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteModelBiasJobDefinition",
+      "status": "working",
+      "message": "likely implemented (ResourceNotFound: Job definition probe-test-value not found)"
+    },
+    {
+      "operation": "DeleteModelCard",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteModelExplainabilityJobDefinition",
+      "status": "working",
+      "message": "likely implemented (ResourceNotFound: Could not find model explainability job definition with name)"
+    },
+    {
+      "operation": "DeleteModelPackage",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteModelPackageGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteModelPackageGroupPolicy",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteModelQualityJobDefinition",
+      "status": "working",
+      "message": "likely implemented (ResourceNotFound: Could not find model quality job definition 'probe-test-valu)"
+    },
+    {
+      "operation": "DeleteMonitoringSchedule",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteNotebookInstance",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DeleteNotebookInstanceLifecycleConfig",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteOptimizationJob",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeletePartnerApp",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeletePipeline",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DeleteProcessingJob",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteProject",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteSpace",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteStudioLifecycleConfig",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteTags",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DeleteTrainingJob",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteTrial",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteTrialComponent",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteUserProfile",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteWorkforce",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteWorkteam",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeregisterDevices",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeAction",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DescribeAlgorithm",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DescribeApp",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DescribeAppImageConfig",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DescribeArtifact",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DescribeAutoMLJob",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeAutoMLJobV2",
+      "status": "working",
+      "message": "likely implemented (ResourceNotFound: Could not find AutoML job with name probe-test-value.)"
+    },
+    {
+      "operation": "DescribeCluster",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DescribeClusterEvent",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeClusterNode",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DescribeClusterSchedulerConfig",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeCodeRepository",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DescribeCompilationJob",
+      "status": "working",
+      "message": "likely implemented (ResourceNotFound: Could not find compilation job 'probe-test-value'.)"
+    },
+    {
+      "operation": "DescribeComputeQuota",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeContext",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DescribeDataQualityJobDefinition",
+      "status": "working",
+      "message": "likely implemented (ResourceNotFound: Job definition probe-test-value not found)"
+    },
+    {
+      "operation": "DescribeDevice",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeDeviceFleet",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DescribeDomain",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DescribeEdgeDeploymentPlan",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DescribeEdgePackagingJob",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeEndpoint",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DescribeEndpointConfig",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DescribeExperiment",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "DescribeFeatureGroup",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'arn:aws:sagemaker:us-east-1:123456789012:feature-group/prob)"
+    },
+    {
+      "operation": "DescribeFeatureMetadata",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeFlowDefinition",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DescribeHub",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DescribeHubContent",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeHumanTaskUi",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DescribeHyperParameterTuningJob",
+      "status": "working",
+      "message": "likely implemented (ResourceNotFound: Could not find hyper parameter tuning job 'probe-test-value')"
+    },
+    {
+      "operation": "DescribeImage",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DescribeImageVersion",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeInferenceComponent",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DescribeInferenceExperiment",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DescribeInferenceRecommendationsJob",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeLabelingJob",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DescribeLineageGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeMlflowApp",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DescribeMlflowTrackingServer",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DescribeModel",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DescribeModelBiasJobDefinition",
+      "status": "working",
+      "message": "likely implemented (ResourceNotFound: Job definition probe-test-value not found)"
+    },
+    {
+      "operation": "DescribeModelCard",
+      "status": "working",
+      "message": "likely implemented (ResourceNotFound: Modelcard probe-test-value does not exist)"
+    },
+    {
+      "operation": "DescribeModelCardExportJob",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeModelExplainabilityJobDefinition",
+      "status": "working",
+      "message": "likely implemented (ResourceNotFound: Could not find model explainability job definition with name)"
+    },
+    {
+      "operation": "DescribeModelPackage",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DescribeModelPackageGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeModelQualityJobDefinition",
+      "status": "working",
+      "message": "likely implemented (ResourceNotFound: Could not find model quality job definition 'probe-test-valu)"
+    },
+    {
+      "operation": "DescribeMonitoringSchedule",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DescribeNotebookInstance",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DescribeNotebookInstanceLifecycleConfig",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DescribeOptimizationJob",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DescribePartnerApp",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DescribePipeline",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DescribePipelineDefinitionForExecution",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DescribePipelineExecution",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DescribeProcessingJob",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeProject",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DescribeReservedCapacity",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeSpace",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DescribeStudioLifecycleConfig",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DescribeSubscribedWorkteam",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeTrainingJob",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DescribeTrainingPlan",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeTransformJob",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeTrial",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DescribeTrialComponent",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DescribeUserProfile",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DescribeWorkforce",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DescribeWorkteam",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DetachClusterNodeVolume",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DisableSagemakerServicecatalogPortfolio",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DisassociateTrialComponent",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "EnableSagemakerServicecatalogPortfolio",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetDeviceFleetReport",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetLineageGroupPolicy",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetModelPackageGroupPolicy",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetSagemakerServicecatalogPortfolioStatus",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetScalingConfigurationRecommendation",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetSearchSuggestions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ImportHubContent",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListActions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListAlgorithms",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListAliases",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListAppImageConfigs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListApps",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListArtifacts",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListAssociations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListAutoMLJobs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListCandidatesForAutoMLJob",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListClusterEvents",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListClusterNodes",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "ListClusterSchedulerConfigs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListClusters",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListCodeRepositories",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListCompilationJobs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListComputeQuotas",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListContexts",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListDataQualityJobDefinitions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListDeviceFleets",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListDevices",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListDomains",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListEdgeDeploymentPlans",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListEdgePackagingJobs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListEndpointConfigs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListEndpoints",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListExperiments",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListFeatureGroups",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListFlowDefinitions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListHubContentVersions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListHubContents",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListHubs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListHumanTaskUis",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListHyperParameterTuningJobs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListImageVersions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListImages",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListInferenceComponents",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListInferenceExperiments",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListInferenceRecommendationsJobSteps",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListInferenceRecommendationsJobs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListLabelingJobs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListLabelingJobsForWorkteam",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListLineageGroups",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListMlflowApps",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListMlflowTrackingServers",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListModelBiasJobDefinitions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListModelCardExportJobs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListModelCardVersions",
+      "status": "working",
+      "message": "likely implemented (ResourceNotFound: Modelcard probe-test-value does not exist)"
+    },
+    {
+      "operation": "ListModelCards",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListModelExplainabilityJobDefinitions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListModelMetadata",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListModelPackageGroups",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListModelPackages",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListModelQualityJobDefinitions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListModels",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListMonitoringAlertHistory",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListMonitoringAlerts",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListMonitoringExecutions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListMonitoringSchedules",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListNotebookInstanceLifecycleConfigs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListNotebookInstances",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListOptimizationJobs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListPartnerApps",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListPipelineExecutionSteps",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListPipelineExecutions",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "ListPipelineParametersForExecution",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "ListPipelineVersions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListPipelines",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListProcessingJobs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListProjects",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListResourceCatalogs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListSpaces",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListStageDevices",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListStudioLifecycleConfigs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListSubscribedWorkteams",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTags",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'NoneType' object has no attribute 'get')"
+    },
+    {
+      "operation": "ListTrainingJobs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTrainingJobsForHyperParameterTuningJob",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTrainingPlans",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTransformJobs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTrialComponents",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTrials",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListUltraServersByReservedCapacity",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListUserProfiles",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListWorkforces",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListWorkteams",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutModelPackageGroupPolicy",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "QueryLineage",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "RegisterDevices",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "RenderUiTemplate",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "RetryPipelineExecution",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "Search",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "SearchTrainingPlanOfferings",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "SendPipelineExecutionStepFailure",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "SendPipelineExecutionStepSuccess",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartEdgeDeploymentStage",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartInferenceExperiment",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartMlflowTrackingServer",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartMonitoringSchedule",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartNotebookInstance",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "StartPipelineExecution",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "StartSession",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StopAutoMLJob",
+      "status": "working",
+      "message": "likely implemented (ResourceNotFound: Could not find AutoML job with name probe-test-value.)"
+    },
+    {
+      "operation": "StopCompilationJob",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StopEdgeDeploymentStage",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StopEdgePackagingJob",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StopHyperParameterTuningJob",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StopInferenceExperiment",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StopInferenceRecommendationsJob",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StopLabelingJob",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StopMlflowTrackingServer",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StopMonitoringSchedule",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StopNotebookInstance",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "StopOptimizationJob",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StopPipelineExecution",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "StopProcessingJob",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StopTrainingJob",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StopTransformJob",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateAction",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "UpdateAppImageConfig",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "UpdateArtifact",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "UpdateCluster",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateClusterSchedulerConfig",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateClusterSoftware",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateCodeRepository",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "UpdateComputeQuota",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateContext",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "UpdateDeviceFleet",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "UpdateDevices",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateDomain",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateEndpoint",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateEndpointWeightsAndCapacities",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UpdateExperiment",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateFeatureGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateFeatureMetadata",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateHub",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "UpdateHubContent",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateHubContentReference",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateImage",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "UpdateImageVersion",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateInferenceComponent",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "UpdateInferenceComponentRuntimeConfig",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateInferenceExperiment",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "UpdateMlflowApp",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "UpdateMlflowTrackingServer",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "UpdateModelCard",
+      "status": "working",
+      "message": "likely implemented (ResourceNotFound: Modelcard probe-test-value does not exist.)"
+    },
+    {
+      "operation": "UpdateModelPackage",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "UpdateMonitoringAlert",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateMonitoringSchedule",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "UpdateNotebookInstance",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateNotebookInstanceLifecycleConfig",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdatePartnerApp",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "UpdatePipeline",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "UpdatePipelineExecution",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdatePipelineVersion",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateProject",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "UpdateSpace",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "UpdateTrainingJob",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateTrial",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateTrialComponent",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "UpdateUserProfile",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "UpdateWorkforce",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "UpdateWorkteam",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    }
+  ]
+}

--- a/probes/secretsmanager.json
+++ b/probes/secretsmanager.json
@@ -1,0 +1,126 @@
+{
+  "service": "secretsmanager",
+  "counts": {
+    "working": 20,
+    "needs_params": 2,
+    "not_implemented": 1,
+    "500_error": 0
+  },
+  "operations": [
+    {
+      "operation": "BatchGetSecretValue",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CancelRotateSecret",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "CreateSecret",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteResourcePolicy",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteSecret",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeSecret",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetRandomPassword",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetResourcePolicy",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetSecretValue",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "ListSecretVersionIds",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListSecrets",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutResourcePolicy",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutSecretValue",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "RemoveRegionsFromReplication",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "ReplicateSecretToRegions",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "RestoreSecret",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "RotateSecret",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StopReplicationToReplica",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "TagResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateSecret",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateSecretVersionStage",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ValidateResourcePolicy",
+      "status": "working",
+      "message": "OK"
+    }
+  ]
+}

--- a/probes/securityhub.json
+++ b/probes/securityhub.json
@@ -1,0 +1,546 @@
+{
+  "service": "securityhub",
+  "counts": {
+    "working": 93,
+    "needs_params": 14,
+    "not_implemented": 0,
+    "500_error": 0
+  },
+  "operations": [
+    {
+      "operation": "AcceptAdministratorInvitation",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "AcceptInvitation",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "BatchDeleteAutomationRules",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "BatchDisableStandards",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "BatchEnableStandards",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "BatchGetAutomationRules",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "BatchGetConfigurationPolicyAssociations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "BatchGetSecurityControls",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "BatchGetStandardsControlAssociations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "BatchImportFindings",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "BatchUpdateAutomationRules",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "BatchUpdateFindings",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "BatchUpdateFindingsV2",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "BatchUpdateStandardsControlAssociations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateActionTarget",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateAggregatorV2",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateAutomationRule",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateAutomationRuleV2",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateConfigurationPolicy",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateConnectorV2",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateFindingAggregator",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateInsight",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateMembers",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateTicketV2",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeclineInvitations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteActionTarget",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteAggregatorV2",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteAutomationRuleV2",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteConfigurationPolicy",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteConnectorV2",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteFindingAggregator",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteInsight",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteInvitations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteMembers",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeActionTargets",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeHub",
+      "status": "working",
+      "message": "likely implemented (InvalidAccessException: <?xml version=\"1.0\" encoding=\"UTF-8\"?>\n  <ErrorResponse>\n   )"
+    },
+    {
+      "operation": "DescribeOrganizationConfiguration",
+      "status": "working",
+      "message": "implemented (AccessDeniedException)"
+    },
+    {
+      "operation": "DescribeProducts",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeProductsV2",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeSecurityHubV2",
+      "status": "working",
+      "message": "likely implemented (InvalidAccessException: <?xml version=\"1.0\" encoding=\"UTF-8\"?>\n  <ErrorResponse>\n   )"
+    },
+    {
+      "operation": "DescribeStandards",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeStandardsControls",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DisableImportFindingsForProduct",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DisableOrganizationAdminAccount",
+      "status": "working",
+      "message": "likely implemented (AWSOrganizationsNotInUseException: Your account is not a member of an organization.)"
+    },
+    {
+      "operation": "DisableSecurityHub",
+      "status": "working",
+      "message": "likely implemented (InvalidAccessException: <?xml version=\"1.0\" encoding=\"UTF-8\"?>\n  <ErrorResponse>\n   )"
+    },
+    {
+      "operation": "DisableSecurityHubV2",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DisassociateFromAdministratorAccount",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DisassociateFromMasterAccount",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DisassociateMembers",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "EnableImportFindingsForProduct",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "EnableOrganizationAdminAccount",
+      "status": "working",
+      "message": "likely implemented (AWSOrganizationsNotInUseException: Your account is not a member of an organization.)"
+    },
+    {
+      "operation": "EnableSecurityHub",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "EnableSecurityHubV2",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetAdministratorAccount",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetAggregatorV2",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetAutomationRuleV2",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetConfigurationPolicy",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetConfigurationPolicyAssociation",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "GetConnectorV2",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetEnabledStandards",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetFindingAggregator",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetFindingHistory",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetFindingStatisticsV2",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetFindings",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetFindingsTrendsV2",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetFindingsV2",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetInsightResults",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetInsights",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetInvitationsCount",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetMasterAccount",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetMembers",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetResourcesStatisticsV2",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetResourcesTrendsV2",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetResourcesV2",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetSecurityControlDefinition",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "InviteMembers",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListAggregatorsV2",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListAutomationRules",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListAutomationRulesV2",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListConfigurationPolicies",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListConfigurationPolicyAssociations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListConnectorsV2",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListEnabledProductsForImport",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListFindingAggregators",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListInvitations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListMembers",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListOrganizationAdminAccounts",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListSecurityControlDefinitions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListStandardsControlAssociations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "RegisterConnectorV2",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartConfigurationPolicyAssociation",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "StartConfigurationPolicyDisassociation",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "TagResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UpdateActionTarget",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateAggregatorV2",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateAutomationRuleV2",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateConfigurationPolicy",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateConnectorV2",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateFindingAggregator",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateFindings",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateInsight",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateOrganizationConfiguration",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateSecurityControl",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateSecurityHubConfiguration",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateStandardsControl",
+      "status": "working",
+      "message": "OK"
+    }
+  ]
+}

--- a/probes/servicecatalog.json
+++ b/probes/servicecatalog.json
@@ -1,0 +1,461 @@
+{
+  "service": "servicecatalog",
+  "counts": {
+    "working": 84,
+    "needs_params": 2,
+    "not_implemented": 3,
+    "500_error": 1
+  },
+  "operations": [
+    {
+      "operation": "AcceptPortfolioShare",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "AssociateBudgetWithResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "AssociatePrincipalWithPortfolio",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "AssociateProductWithPortfolio",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "AssociateServiceActionWithProvisioningArtifact",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "AssociateTagOptionWithResource",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "BatchAssociateServiceActionWithProvisioningArtifact",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "BatchDisassociateServiceActionFromProvisioningArtifact",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CopyProduct",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateConstraint",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "CreatePortfolio",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreatePortfolioShare",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateProduct",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateProvisionedProductPlan",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateProvisioningArtifact",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "CreateServiceAction",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateTagOption",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteConstraint",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeletePortfolio",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeletePortfolioShare",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteProduct",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteProvisionedProductPlan",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteProvisioningArtifact",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteServiceAction",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteTagOption",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeConstraint",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeCopyProductStatus",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribePortfolio",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribePortfolioShareStatus",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribePortfolioShares",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeProduct",
+      "status": "working",
+      "message": "likely implemented (InvalidParametersException: Either Id or Name must be specified.)"
+    },
+    {
+      "operation": "DescribeProductAsAdmin",
+      "status": "working",
+      "message": "likely implemented (InvalidParametersException: Either Id or Name must be specified.)"
+    },
+    {
+      "operation": "DescribeProductView",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeProvisionedProduct",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeProvisionedProductPlan",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeProvisioningArtifact",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeProvisioningParameters",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeRecord",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeServiceAction",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeServiceActionExecutionParameters",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeTagOption",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DisableAWSOrganizationsAccess",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DisassociateBudgetFromResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DisassociatePrincipalFromPortfolio",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DisassociateProductFromPortfolio",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DisassociateServiceActionFromProvisioningArtifact",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DisassociateTagOptionFromResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "EnableAWSOrganizationsAccess",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ExecuteProvisionedProductPlan",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ExecuteProvisionedProductServiceAction",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetAWSOrganizationsAccessStatus",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetProvisionedProductOutputs",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ImportAsProvisionedProduct",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListAcceptedPortfolioShares",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListBudgetsForResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListConstraintsForPortfolio",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListLaunchPaths",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListOrganizationPortfolioAccess",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListPortfolioAccess",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListPortfolios",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListPortfoliosForProduct",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListPrincipalsForPortfolio",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListProvisionedProductPlans",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListProvisioningArtifacts",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListProvisioningArtifactsForServiceAction",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListRecordHistory",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListResourcesForTagOption",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListServiceActions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListServiceActionsForProvisioningArtifact",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListStackInstancesForProvisionedProduct",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTagOptions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "NotifyProvisionProductEngineWorkflowResult",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "NotifyTerminateProvisionedProductEngineWorkflowResult",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "NotifyUpdateProvisionedProductEngineWorkflowResult",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ProvisionProduct",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "RejectPortfolioShare",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ScanProvisionedProducts",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "SearchProducts",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'list' object has no attribute 'items')"
+    },
+    {
+      "operation": "SearchProductsAsAdmin",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "SearchProvisionedProducts",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "TerminateProvisionedProduct",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateConstraint",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdatePortfolio",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdatePortfolioShare",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateProduct",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateProvisionedProduct",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateProvisionedProductProperties",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateProvisioningArtifact",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateServiceAction",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateTagOption",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    }
+  ]
+}

--- a/probes/servicediscovery.json
+++ b/probes/servicediscovery.json
@@ -1,0 +1,161 @@
+{
+  "service": "servicediscovery",
+  "counts": {
+    "working": 25,
+    "needs_params": 1,
+    "not_implemented": 2,
+    "500_error": 2
+  },
+  "operations": [
+    {
+      "operation": "CreateHttpNamespace",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreatePrivateDnsNamespace",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreatePublicDnsNamespace",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateService",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteNamespace",
+      "status": "working",
+      "message": "likely implemented (NamespaceNotFound: probe-test-value)"
+    },
+    {
+      "operation": "DeleteService",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteServiceAttributes",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DeregisterInstance",
+      "status": "working",
+      "message": "likely implemented (ServiceNotFound: probe-test-value)"
+    },
+    {
+      "operation": "DiscoverInstances",
+      "status": "500_error",
+      "message": "exception: Could not connect to the endpoint URL: \"http://data-localhos"
+    },
+    {
+      "operation": "DiscoverInstancesRevision",
+      "status": "500_error",
+      "message": "exception: Could not connect to the endpoint URL: \"http://data-localhos"
+    },
+    {
+      "operation": "GetInstance",
+      "status": "working",
+      "message": "likely implemented (ServiceNotFound: probe-test-value)"
+    },
+    {
+      "operation": "GetInstancesHealthStatus",
+      "status": "working",
+      "message": "likely implemented (ServiceNotFound: probe-test-value)"
+    },
+    {
+      "operation": "GetNamespace",
+      "status": "working",
+      "message": "likely implemented (NamespaceNotFound: probe-test-value)"
+    },
+    {
+      "operation": "GetOperation",
+      "status": "working",
+      "message": "likely implemented (OperationNotFound: )"
+    },
+    {
+      "operation": "GetService",
+      "status": "working",
+      "message": "likely implemented (ServiceNotFound: probe-test-value)"
+    },
+    {
+      "operation": "GetServiceAttributes",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListInstances",
+      "status": "working",
+      "message": "likely implemented (ServiceNotFound: probe-test-value)"
+    },
+    {
+      "operation": "ListNamespaces",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListOperations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListServices",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "RegisterInstance",
+      "status": "working",
+      "message": "likely implemented (ServiceNotFound: probe-test-value)"
+    },
+    {
+      "operation": "TagResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateHttpNamespace",
+      "status": "working",
+      "message": "likely implemented (NamespaceNotFound: probe-test-value)"
+    },
+    {
+      "operation": "UpdateInstanceCustomHealthStatus",
+      "status": "working",
+      "message": "likely implemented (CustomHealthNotFound: probe-test-value)"
+    },
+    {
+      "operation": "UpdatePrivateDnsNamespace",
+      "status": "working",
+      "message": "likely implemented (NamespaceNotFound: probe-test-value)"
+    },
+    {
+      "operation": "UpdatePublicDnsNamespace",
+      "status": "working",
+      "message": "likely implemented (NamespaceNotFound: probe-test-value)"
+    },
+    {
+      "operation": "UpdateService",
+      "status": "working",
+      "message": "likely implemented (ServiceNotFound: probe-test-value)"
+    },
+    {
+      "operation": "UpdateServiceAttributes",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    }
+  ]
+}

--- a/probes/ses.json
+++ b/probes/ses.json
@@ -1,0 +1,366 @@
+{
+  "service": "ses",
+  "counts": {
+    "working": 53,
+    "needs_params": 0,
+    "not_implemented": 16,
+    "500_error": 2
+  },
+  "operations": [
+    {
+      "operation": "CloneReceiptRuleSet",
+      "status": "working",
+      "message": "likely implemented (RuleSetDoesNotExist: Rule set does not exist: probe-test-value)"
+    },
+    {
+      "operation": "CreateConfigurationSet",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateConfigurationSetEventDestination",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateConfigurationSetTrackingOptions",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateCustomVerificationEmailTemplate",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateReceiptFilter",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateReceiptRule",
+      "status": "working",
+      "message": "likely implemented (RuleSetDoesNotExist: RuleSetDoesNotExist: Rule set does not exist: probe-test-val)"
+    },
+    {
+      "operation": "CreateReceiptRuleSet",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateTemplate",
+      "status": "working",
+      "message": "implemented (InvalidParameterValue)"
+    },
+    {
+      "operation": "DeleteConfigurationSet",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteConfigurationSetEventDestination",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteConfigurationSetTrackingOptions",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteCustomVerificationEmailTemplate",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteIdentity",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteIdentityPolicy",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteReceiptFilter",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteReceiptRule",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteReceiptRuleSet",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteTemplate",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "DeleteVerifiedEmailAddress",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeActiveReceiptRuleSet",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeConfigurationSet",
+      "status": "working",
+      "message": "likely implemented (ConfigurationSetDoesNotExist: Configuration set <probe-test-value> does not exist.)"
+    },
+    {
+      "operation": "DescribeReceiptRule",
+      "status": "working",
+      "message": "likely implemented (RuleSetDoesNotExist: Rule set does not exist: probe-test-value)"
+    },
+    {
+      "operation": "DescribeReceiptRuleSet",
+      "status": "working",
+      "message": "likely implemented (RuleSetDoesNotExist: Rule set does not exist: probe-test-value)"
+    },
+    {
+      "operation": "GetAccountSendingEnabled",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetCustomVerificationEmailTemplate",
+      "status": "working",
+      "message": "likely implemented (CustomVerificationEmailTemplateDoesNotExist: Custom verification email template does not exist: probe-tes)"
+    },
+    {
+      "operation": "GetIdentityDkimAttributes",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetIdentityMailFromDomainAttributes",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetIdentityNotificationAttributes",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetIdentityPolicies",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetIdentityVerificationAttributes",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetSendQuota",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetSendStatistics",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetTemplate",
+      "status": "working",
+      "message": "likely implemented (TemplateDoesNotExist: Invalid Template Name.)"
+    },
+    {
+      "operation": "ListConfigurationSets",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListCustomVerificationEmailTemplates",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListIdentities",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListIdentityPolicies",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListReceiptFilters",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListReceiptRuleSets",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTemplates",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListVerifiedEmailAddresses",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutConfigurationSetDeliveryOptions",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "PutIdentityPolicy",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ReorderReceiptRuleSet",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "SendBounce",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "SendBulkTemplatedEmail",
+      "status": "working",
+      "message": "likely implemented (MessageRejected: Email address not verified probe-test-value)"
+    },
+    {
+      "operation": "SendCustomVerificationEmail",
+      "status": "working",
+      "message": "likely implemented (CustomVerificationEmailTemplateDoesNotExist: Custom verification email template does not exist: probe-tes)"
+    },
+    {
+      "operation": "SendEmail",
+      "status": "working",
+      "message": "likely implemented (MessageRejected: Email address not verified probe-test-value)"
+    },
+    {
+      "operation": "SendRawEmail",
+      "status": "working",
+      "message": "likely implemented (MessageRejected: Source not specified)"
+    },
+    {
+      "operation": "SendTemplatedEmail",
+      "status": "working",
+      "message": "likely implemented (MessageRejected: Email address not verified probe-test-value)"
+    },
+    {
+      "operation": "SetActiveReceiptRuleSet",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "SetIdentityDkimEnabled",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "SetIdentityFeedbackForwardingEnabled",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "SetIdentityHeadersInNotificationsEnabled",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "SetIdentityMailFromDomain",
+      "status": "working",
+      "message": "implemented (InvalidParameterValue)"
+    },
+    {
+      "operation": "SetIdentityNotificationTopic",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'SESBackend' object has no attribute 'domains')"
+    },
+    {
+      "operation": "SetReceiptRulePosition",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "TestRenderTemplate",
+      "status": "working",
+      "message": "likely implemented (TemplateDoesNotExist: Invalid Template Name.)"
+    },
+    {
+      "operation": "UpdateAccountSendingEnabled",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateConfigurationSetEventDestination",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateConfigurationSetReputationMetricsEnabled",
+      "status": "working",
+      "message": "likely implemented (ConfigurationSetDoesNotExist: Configuration set <probe-test-value> does not exist)"
+    },
+    {
+      "operation": "UpdateConfigurationSetSendingEnabled",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateConfigurationSetTrackingOptions",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateCustomVerificationEmailTemplate",
+      "status": "working",
+      "message": "likely implemented (CustomVerificationEmailTemplateDoesNotExist: Custom verification email template does not exist: probe-tes)"
+    },
+    {
+      "operation": "UpdateReceiptRule",
+      "status": "working",
+      "message": "likely implemented (RuleSetDoesNotExist: Rule set does not exist: probe-test-value)"
+    },
+    {
+      "operation": "UpdateTemplate",
+      "status": "working",
+      "message": "likely implemented (TemplateDoesNotExist: Invalid Template Name.)"
+    },
+    {
+      "operation": "VerifyDomainDkim",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "VerifyDomainIdentity",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "VerifyEmailAddress",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "VerifyEmailIdentity",
+      "status": "working",
+      "message": "OK"
+    }
+  ]
+}

--- a/probes/sesv2.json
+++ b/probes/sesv2.json
@@ -1,0 +1,561 @@
+{
+  "service": "sesv2",
+  "counts": {
+    "working": 108,
+    "needs_params": 1,
+    "not_implemented": 1,
+    "500_error": 0
+  },
+  "operations": [
+    {
+      "operation": "BatchGetMetricData",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CancelExportJob",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "CreateConfigurationSet",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateConfigurationSetEventDestination",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateContact",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "CreateContactList",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateCustomVerificationEmailTemplate",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateDedicatedIpPool",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateDeliverabilityTestReport",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateEmailIdentity",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateEmailIdentityPolicy",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateEmailTemplate",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateExportJob",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateImportJob",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateMultiRegionEndpoint",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateTenant",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateTenantResourceAssociation",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteConfigurationSet",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteConfigurationSetEventDestination",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeleteContact",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeleteContactList",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteCustomVerificationEmailTemplate",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteDedicatedIpPool",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteEmailIdentity",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteEmailIdentityPolicy",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeleteEmailTemplate",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteMultiRegionEndpoint",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteSuppressedDestination",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "DeleteTenant",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteTenantResourceAssociation",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetAccount",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetBlacklistReports",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetConfigurationSet",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetConfigurationSetEventDestinations",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetContact",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetContactList",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetCustomVerificationEmailTemplate",
+      "status": "working",
+      "message": "likely implemented (CustomVerificationEmailTemplateDoesNotExistException: Custom verification email template does not exist: probe-tes)"
+    },
+    {
+      "operation": "GetDedicatedIp",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetDedicatedIpPool",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetDedicatedIps",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetDeliverabilityDashboardOptions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetDeliverabilityTestReport",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetDomainDeliverabilityCampaign",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetDomainStatisticsReport",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetEmailAddressInsights",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetEmailIdentity",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetEmailIdentityPolicies",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetEmailTemplate",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetExportJob",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetImportJob",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetMessageInsights",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetMultiRegionEndpoint",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetReputationEntity",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetSuppressedDestination",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "GetTenant",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListConfigurationSets",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListContactLists",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListContacts",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "ListCustomVerificationEmailTemplates",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListDedicatedIpPools",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListDeliverabilityTestReports",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListDomainDeliverabilityCampaigns",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListEmailIdentities",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListEmailTemplates",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListExportJobs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListImportJobs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListMultiRegionEndpoints",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListRecommendations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListReputationEntities",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListResourceTenants",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListSuppressedDestinations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTenantResources",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTenants",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutAccountDedicatedIpWarmupAttributes",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutAccountDetails",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutAccountSendingAttributes",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutAccountSuppressionAttributes",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutAccountVdmAttributes",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutConfigurationSetArchivingOptions",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "PutConfigurationSetDeliveryOptions",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "PutConfigurationSetReputationOptions",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "PutConfigurationSetSendingOptions",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "PutConfigurationSetSuppressionOptions",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "PutConfigurationSetTrackingOptions",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "PutConfigurationSetVdmOptions",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "PutDedicatedIpInPool",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutDedicatedIpPoolScalingAttributes",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "PutDedicatedIpWarmupAttributes",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutDeliverabilityDashboardOption",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutEmailIdentityConfigurationSetAttributes",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "PutEmailIdentityDkimAttributes",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "PutEmailIdentityDkimSigningAttributes",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "PutEmailIdentityFeedbackAttributes",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "PutEmailIdentityMailFromAttributes",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "PutSuppressedDestination",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "SendBulkEmail",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "SendCustomVerificationEmail",
+      "status": "working",
+      "message": "likely implemented (CustomVerificationEmailTemplateDoesNotExistException: Custom verification email template does not exist: probe-tes)"
+    },
+    {
+      "operation": "SendEmail",
+      "status": "working",
+      "message": "likely implemented (MessageRejected: Email address not verified None)"
+    },
+    {
+      "operation": "TagResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "TestRenderEmailTemplate",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateConfigurationSetEventDestination",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UpdateContact",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UpdateContactList",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UpdateCustomVerificationEmailTemplate",
+      "status": "working",
+      "message": "likely implemented (CustomVerificationEmailTemplateDoesNotExistException: Custom verification email template does not exist: probe-tes)"
+    },
+    {
+      "operation": "UpdateEmailIdentityPolicy",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UpdateEmailTemplate",
+      "status": "working",
+      "message": "implemented (NotFoundException)"
+    },
+    {
+      "operation": "UpdateReputationEntityCustomerManagedStatus",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateReputationEntityPolicy",
+      "status": "working",
+      "message": "OK"
+    }
+  ]
+}

--- a/probes/shield.json
+++ b/probes/shield.json
@@ -1,0 +1,191 @@
+{
+  "service": "shield",
+  "counts": {
+    "working": 32,
+    "needs_params": 3,
+    "not_implemented": 0,
+    "500_error": 1
+  },
+  "operations": [
+    {
+      "operation": "AssociateDRTLogBucket",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "AssociateDRTRole",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "AssociateHealthCheck",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "AssociateProactiveEngagementDetails",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateProtection",
+      "status": "working",
+      "message": "likely implemented (InvalidResourceException: Unrecognized resource 'thing' of service 'shield'.)"
+    },
+    {
+      "operation": "CreateProtectionGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateSubscription",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteProtection",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DeleteProtectionGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteSubscription",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeAttack",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeAttackStatistics",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeDRTAccess",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeEmergencyContactSettings",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeProtection",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'NoneType' object has no attribute 'to_dict')"
+    },
+    {
+      "operation": "DescribeProtectionGroup",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeSubscription",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DisableApplicationLayerAutomaticResponse",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DisableProactiveEngagement",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DisassociateDRTLogBucket",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DisassociateDRTRole",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DisassociateHealthCheck",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "EnableApplicationLayerAutomaticResponse",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "EnableProactiveEngagement",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetSubscriptionState",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListAttacks",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListProtectionGroups",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListProtections",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListResourcesInProtectionGroup",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "TagResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateApplicationLayerAutomaticResponse",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateEmergencyContactSettings",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateProtectionGroup",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateSubscription",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    }
+  ]
+}

--- a/probes/signer.json
+++ b/probes/signer.json
@@ -1,0 +1,106 @@
+{
+  "service": "signer",
+  "counts": {
+    "working": 16,
+    "needs_params": 1,
+    "not_implemented": 0,
+    "500_error": 2
+  },
+  "operations": [
+    {
+      "operation": "AddProfilePermission",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "CancelSigningProfile",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "DescribeSigningJob",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetRevocationStatus",
+      "status": "500_error",
+      "message": "exception: Could not connect to the endpoint URL: \"http://data-localhos"
+    },
+    {
+      "operation": "GetSigningPlatform",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetSigningProfile",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListProfilePermissions",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListSigningJobs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListSigningPlatforms",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListSigningProfiles",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutSigningProfile",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "RemoveProfilePermission",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "RevokeSignature",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "RevokeSigningProfile",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "SignPayload",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartSigningJob",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "TagResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    }
+  ]
+}

--- a/probes/sns.json
+++ b/probes/sns.json
@@ -1,0 +1,216 @@
+{
+  "service": "sns",
+  "counts": {
+    "working": 36,
+    "needs_params": 0,
+    "not_implemented": 5,
+    "500_error": 0
+  },
+  "operations": [
+    {
+      "operation": "AddPermission",
+      "status": "working",
+      "message": "likely implemented (NotFound: Topic does not exist)"
+    },
+    {
+      "operation": "CheckIfPhoneNumberIsOptedOut",
+      "status": "working",
+      "message": "implemented (InvalidParameter)"
+    },
+    {
+      "operation": "ConfirmSubscription",
+      "status": "working",
+      "message": "likely implemented (NotFound: No pending subscription for topic arn:aws:sns:us-east-1:1234)"
+    },
+    {
+      "operation": "CreatePlatformApplication",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreatePlatformEndpoint",
+      "status": "working",
+      "message": "likely implemented (NotFound: PlatformApplication does not exist)"
+    },
+    {
+      "operation": "CreateSMSSandboxPhoneNumber",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateTopic",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteEndpoint",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeletePlatformApplication",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteSMSSandboxPhoneNumber",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetDataProtectionPolicy",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetEndpointAttributes",
+      "status": "working",
+      "message": "likely implemented (NotFound: Endpoint arn:aws:sns:us-east-1:123456789012:thing/probe-test)"
+    },
+    {
+      "operation": "GetPlatformApplicationAttributes",
+      "status": "working",
+      "message": "likely implemented (NotFound: Platform application arn:aws:sns:us-east-1:123456789012:thin)"
+    },
+    {
+      "operation": "GetSMSAttributes",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetSMSSandboxAccountStatus",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetSubscriptionAttributes",
+      "status": "working",
+      "message": "likely implemented (NotFound: Subscription arn:aws:sns:us-east-1:123456789012:thing/probe-)"
+    },
+    {
+      "operation": "GetTopicAttributes",
+      "status": "working",
+      "message": "likely implemented (NotFound: Topic arn:aws:sns:us-east-1:123456789012:thing/probe-test no)"
+    },
+    {
+      "operation": "ListEndpointsByPlatformApplication",
+      "status": "working",
+      "message": "likely implemented (NotFound: Platform application arn:aws:sns:us-east-1:123456789012:thin)"
+    },
+    {
+      "operation": "ListOriginationNumbers",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListPhoneNumbersOptedOut",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListPlatformApplications",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListSMSSandboxPhoneNumbers",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListSubscriptions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListSubscriptionsByTopic",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "working",
+      "message": "likely implemented (ResourceNotFound: Resource arn:aws:sns:us-east-1:123456789012:thing/probe-test)"
+    },
+    {
+      "operation": "ListTopics",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "OptInPhoneNumber",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "Publish",
+      "status": "working",
+      "message": "likely implemented (NotFound: Topic  not found)"
+    },
+    {
+      "operation": "PublishBatch",
+      "status": "working",
+      "message": "likely implemented (NotFound: Topic arn:aws:sns:us-east-1:123456789012:thing/probe-test no)"
+    },
+    {
+      "operation": "PutDataProtectionPolicy",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "RemovePermission",
+      "status": "working",
+      "message": "likely implemented (NotFound: Topic does not exist)"
+    },
+    {
+      "operation": "SetEndpointAttributes",
+      "status": "working",
+      "message": "likely implemented (NotFound: Endpoint arn:aws:sns:us-east-1:123456789012:thing/probe-test)"
+    },
+    {
+      "operation": "SetPlatformApplicationAttributes",
+      "status": "working",
+      "message": "likely implemented (NotFound: Platform application arn:aws:sns:us-east-1:123456789012:thin)"
+    },
+    {
+      "operation": "SetSMSAttributes",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "SetSubscriptionAttributes",
+      "status": "working",
+      "message": "likely implemented (NotFound: Subscription arn:aws:sns:us-east-1:123456789012:thing/probe-)"
+    },
+    {
+      "operation": "SetTopicAttributes",
+      "status": "working",
+      "message": "likely implemented (NotFound: Topic arn:aws:sns:us-east-1:123456789012:thing/probe-test no)"
+    },
+    {
+      "operation": "Subscribe",
+      "status": "working",
+      "message": "likely implemented (NotFound: Topic arn:aws:sns:us-east-1:123456789012:thing/probe-test no)"
+    },
+    {
+      "operation": "TagResource",
+      "status": "working",
+      "message": "likely implemented (ResourceNotFound: Resource arn:aws:sns:us-east-1:123456789012:thing/probe-test)"
+    },
+    {
+      "operation": "Unsubscribe",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "working",
+      "message": "likely implemented (ResourceNotFound: Resource arn:aws:sns:us-east-1:123456789012:thing/probe-test)"
+    },
+    {
+      "operation": "VerifySMSSandboxPhoneNumber",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    }
+  ]
+}

--- a/probes/ssm.json
+++ b/probes/ssm.json
@@ -1,0 +1,741 @@
+{
+  "service": "ssm",
+  "counts": {
+    "working": 101,
+    "needs_params": 45,
+    "not_implemented": 0,
+    "500_error": 0
+  },
+  "operations": [
+    {
+      "operation": "AddTagsToResource",
+      "status": "working",
+      "message": "likely implemented (InvalidResourceType: Invalid Resource Type)"
+    },
+    {
+      "operation": "AssociateOpsItemRelatedItem",
+      "status": "working",
+      "message": "likely implemented (DoesNotExistException: Maintenance window probe-test-value does not exist)"
+    },
+    {
+      "operation": "CancelCommand",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CancelMaintenanceWindowExecution",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateActivation",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateAssociation",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateAssociationBatch",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateDocument",
+      "status": "working",
+      "message": "likely implemented (InvalidDocumentContent: The content for the document is not valid.)"
+    },
+    {
+      "operation": "CreateMaintenanceWindow",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateOpsItem",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateOpsMetadata",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreatePatchBaseline",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateResourceDataSync",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteActivation",
+      "status": "working",
+      "message": "likely implemented (DoesNotExistException: Maintenance window probe-test-value does not exist)"
+    },
+    {
+      "operation": "DeleteAssociation",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteDocument",
+      "status": "working",
+      "message": "likely implemented (InvalidDocument: The specified document does not exist.)"
+    },
+    {
+      "operation": "DeleteInventory",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteMaintenanceWindow",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DeleteOpsItem",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteOpsMetadata",
+      "status": "working",
+      "message": "likely implemented (DoesNotExistException: Maintenance window arn:aws:ssm:us-east-1:123456789012:thing/)"
+    },
+    {
+      "operation": "DeleteParameter",
+      "status": "working",
+      "message": "implemented (ParameterNotFound)"
+    },
+    {
+      "operation": "DeleteParameters",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DeletePatchBaseline",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DeleteResourceDataSync",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteResourcePolicy",
+      "status": "working",
+      "message": "likely implemented (DoesNotExistException: Maintenance window arn:aws:ssm:us-east-1:123456789012:thing/)"
+    },
+    {
+      "operation": "DeregisterManagedInstance",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DeregisterPatchBaselineForPatchGroup",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DeregisterTargetFromMaintenanceWindow",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DeregisterTaskFromMaintenanceWindow",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DescribeActivations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeAssociation",
+      "status": "working",
+      "message": "likely implemented (DoesNotExistException: Maintenance window  does not exist)"
+    },
+    {
+      "operation": "DescribeAssociationExecutionTargets",
+      "status": "working",
+      "message": "likely implemented (DoesNotExistException: Maintenance window probe-test-value does not exist)"
+    },
+    {
+      "operation": "DescribeAssociationExecutions",
+      "status": "working",
+      "message": "likely implemented (DoesNotExistException: Maintenance window probe-test-value does not exist)"
+    },
+    {
+      "operation": "DescribeAutomationExecutions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeAutomationStepExecutions",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DescribeAvailablePatches",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeDocument",
+      "status": "working",
+      "message": "likely implemented (InvalidDocument: The specified document does not exist.)"
+    },
+    {
+      "operation": "DescribeDocumentPermission",
+      "status": "working",
+      "message": "likely implemented (InvalidDocument: The specified document does not exist.)"
+    },
+    {
+      "operation": "DescribeEffectiveInstanceAssociations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeEffectivePatchesForPatchBaseline",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DescribeInstanceAssociationsStatus",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeInstanceInformation",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeInstancePatchStates",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeInstancePatchStatesForPatchGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeInstancePatches",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeInstanceProperties",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeInventoryDeletions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeMaintenanceWindowExecutionTaskInvocations",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DescribeMaintenanceWindowExecutionTasks",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DescribeMaintenanceWindowExecutions",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DescribeMaintenanceWindowSchedule",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeMaintenanceWindowTargets",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DescribeMaintenanceWindowTasks",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DescribeMaintenanceWindows",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeMaintenanceWindowsForTarget",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeOpsItems",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeParameters",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribePatchBaselines",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribePatchGroupState",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribePatchGroups",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribePatchProperties",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeSessions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DisassociateOpsItemRelatedItem",
+      "status": "working",
+      "message": "likely implemented (DoesNotExistException: Maintenance window probe-test-value does not exist)"
+    },
+    {
+      "operation": "GetAccessToken",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetAutomationExecution",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "GetCalendarState",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetCommandInvocation",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "GetConnectionStatus",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetDefaultPatchBaseline",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetDeployablePatchSnapshotForInstance",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "GetDocument",
+      "status": "working",
+      "message": "likely implemented (InvalidDocument: The specified document does not exist.)"
+    },
+    {
+      "operation": "GetExecutionPreview",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "GetInventory",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetInventorySchema",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetMaintenanceWindow",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "GetMaintenanceWindowExecution",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "GetMaintenanceWindowExecutionTask",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "GetMaintenanceWindowExecutionTaskInvocation",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "GetMaintenanceWindowTask",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "GetOpsItem",
+      "status": "working",
+      "message": "likely implemented (DoesNotExistException: Maintenance window probe-test-value does not exist)"
+    },
+    {
+      "operation": "GetOpsMetadata",
+      "status": "working",
+      "message": "likely implemented (DoesNotExistException: Maintenance window arn:aws:ssm:us-east-1:123456789012:thing/)"
+    },
+    {
+      "operation": "GetOpsSummary",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetParameter",
+      "status": "working",
+      "message": "implemented (ParameterNotFound)"
+    },
+    {
+      "operation": "GetParameterHistory",
+      "status": "working",
+      "message": "implemented (ParameterNotFound)"
+    },
+    {
+      "operation": "GetParameters",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "GetParametersByPath",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetPatchBaseline",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "GetPatchBaselineForPatchGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetResourcePolicies",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetServiceSetting",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "LabelParameterVersion",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "ListAssociationVersions",
+      "status": "working",
+      "message": "likely implemented (DoesNotExistException: Maintenance window probe-test-value does not exist)"
+    },
+    {
+      "operation": "ListAssociations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListCommandInvocations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListCommands",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListComplianceItems",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListComplianceSummaries",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListDocumentMetadataHistory",
+      "status": "working",
+      "message": "likely implemented (InvalidDocument: The specified document does not exist.)"
+    },
+    {
+      "operation": "ListDocumentVersions",
+      "status": "working",
+      "message": "likely implemented (InvalidDocument: The specified document does not exist.)"
+    },
+    {
+      "operation": "ListDocuments",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListInventoryEntries",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListNodes",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListNodesSummary",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "ListOpsItemEvents",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListOpsItemRelatedItems",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListOpsMetadata",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListResourceComplianceSummaries",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListResourceDataSync",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "working",
+      "message": "likely implemented (InvalidResourceType: Invalid Resource Type)"
+    },
+    {
+      "operation": "ModifyDocumentPermission",
+      "status": "working",
+      "message": "likely implemented (InvalidPermissionType: Value 'probe-test-value' at 'permissionType' failed to satis)"
+    },
+    {
+      "operation": "PutComplianceItems",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutInventory",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "PutParameter",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "PutResourcePolicy",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "RegisterDefaultPatchBaseline",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "RegisterPatchBaselineForPatchGroup",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "RegisterTargetWithMaintenanceWindow",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "RegisterTaskWithMaintenanceWindow",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "RemoveTagsFromResource",
+      "status": "working",
+      "message": "likely implemented (InvalidResourceType: Invalid Resource Type)"
+    },
+    {
+      "operation": "ResetServiceSetting",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ResumeSession",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "SendAutomationSignal",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "SendCommand",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartAccessRequest",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartAssociationsOnce",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "StartAutomationExecution",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartChangeRequestExecution",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "StartExecutionPreview",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartSession",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StopAutomationExecution",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "TerminateSession",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UnlabelParameterVersion",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UpdateAssociation",
+      "status": "working",
+      "message": "likely implemented (DoesNotExistException: Maintenance window probe-test-value does not exist)"
+    },
+    {
+      "operation": "UpdateAssociationStatus",
+      "status": "working",
+      "message": "likely implemented (DoesNotExistException: Maintenance window probe-test-value-probe-test-value does no)"
+    },
+    {
+      "operation": "UpdateDocument",
+      "status": "working",
+      "message": "likely implemented (InvalidDocument: The specified document does not exist.)"
+    },
+    {
+      "operation": "UpdateDocumentDefaultVersion",
+      "status": "working",
+      "message": "likely implemented (InvalidDocument: The specified document does not exist.)"
+    },
+    {
+      "operation": "UpdateDocumentMetadata",
+      "status": "working",
+      "message": "likely implemented (InvalidDocument: probe-test-value)"
+    },
+    {
+      "operation": "UpdateMaintenanceWindow",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UpdateMaintenanceWindowTarget",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UpdateMaintenanceWindowTask",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UpdateManagedInstanceRole",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UpdateOpsItem",
+      "status": "working",
+      "message": "likely implemented (DoesNotExistException: Maintenance window probe-test-value does not exist)"
+    },
+    {
+      "operation": "UpdateOpsMetadata",
+      "status": "working",
+      "message": "likely implemented (DoesNotExistException: Maintenance window arn:aws:ssm:us-east-1:123456789012:thing/)"
+    },
+    {
+      "operation": "UpdatePatchBaseline",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UpdateResourceDataSync",
+      "status": "working",
+      "message": "likely implemented (DoesNotExistException: Maintenance window probe-test-value does not exist)"
+    },
+    {
+      "operation": "UpdateServiceSetting",
+      "status": "working",
+      "message": "OK"
+    }
+  ]
+}

--- a/probes/stepfunctions.json
+++ b/probes/stepfunctions.json
@@ -1,0 +1,196 @@
+{
+  "service": "stepfunctions",
+  "counts": {
+    "working": 27,
+    "needs_params": 1,
+    "not_implemented": 6,
+    "500_error": 3
+  },
+  "operations": [
+    {
+      "operation": "CreateActivity",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateStateMachine",
+      "status": "500_error",
+      "message": "server crash (InternalError: Expecting value: line 1 column 1 (char 0))"
+    },
+    {
+      "operation": "CreateStateMachineAlias",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DeleteActivity",
+      "status": "working",
+      "message": "likely implemented (InvalidArn: Invalid Activity Arn: 'arn:aws:stepfunctions:us-east-1:12345)"
+    },
+    {
+      "operation": "DeleteStateMachine",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteStateMachineAlias",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteStateMachineVersion",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DescribeActivity",
+      "status": "working",
+      "message": "likely implemented (InvalidArn: Invalid Activity Arn: 'arn:aws:stepfunctions:us-east-1:12345)"
+    },
+    {
+      "operation": "DescribeExecution",
+      "status": "working",
+      "message": "likely implemented (ExecutionDoesNotExist: Execution not found: arn:aws:stepfunctions:us-east-1:1234567)"
+    },
+    {
+      "operation": "DescribeMapRun",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeStateMachine",
+      "status": "working",
+      "message": "likely implemented (StateMachineDoesNotExist: State machine not found: arn:aws:stepfunctions:us-east-1:123)"
+    },
+    {
+      "operation": "DescribeStateMachineAlias",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DescribeStateMachineForExecution",
+      "status": "working",
+      "message": "likely implemented (ExecutionDoesNotExist: Execution arn:aws:stepfunctions:us-east-1:123456789012:thing)"
+    },
+    {
+      "operation": "GetActivityTask",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetExecutionHistory",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListActivities",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListExecutions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListMapRuns",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListStateMachineAliases",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListStateMachineVersions",
+      "status": "working",
+      "message": "likely implemented (StateMachineDoesNotExist: State machine not found: arn:aws:stepfunctions:us-east-1:123)"
+    },
+    {
+      "operation": "ListStateMachines",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PublishStateMachineVersion",
+      "status": "working",
+      "message": "likely implemented (StateMachineDoesNotExist: State machine not found: arn:aws:stepfunctions:us-east-1:123)"
+    },
+    {
+      "operation": "RedriveExecution",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "SendTaskFailure",
+      "status": "working",
+      "message": "likely implemented (TaskDoesNotExist: Task token not found: probe-test-value)"
+    },
+    {
+      "operation": "SendTaskHeartbeat",
+      "status": "working",
+      "message": "likely implemented (TaskDoesNotExist: Task token not found: probe-test-value)"
+    },
+    {
+      "operation": "SendTaskSuccess",
+      "status": "working",
+      "message": "likely implemented (TaskDoesNotExist: Task token not found: probe-test-value)"
+    },
+    {
+      "operation": "StartExecution",
+      "status": "working",
+      "message": "likely implemented (StateMachineDoesNotExist: State machine not found: arn:aws:stepfunctions:us-east-1:123)"
+    },
+    {
+      "operation": "StartSyncExecution",
+      "status": "500_error",
+      "message": "exception: Could not connect to the endpoint URL: \"http://sync-localhos"
+    },
+    {
+      "operation": "StopExecution",
+      "status": "working",
+      "message": "likely implemented (ExecutionDoesNotExist: Execution not found: arn:aws:stepfunctions:us-east-1:1234567)"
+    },
+    {
+      "operation": "TagResource",
+      "status": "working",
+      "message": "likely implemented (ResourceNotFound: Resource not found: arn:aws:stepfunctions:us-east-1:12345678)"
+    },
+    {
+      "operation": "TestState",
+      "status": "500_error",
+      "message": "exception: Could not connect to the endpoint URL: \"http://sync-localhos"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "working",
+      "message": "likely implemented (ResourceNotFound: Resource not found: arn:aws:stepfunctions:us-east-1:12345678)"
+    },
+    {
+      "operation": "UpdateMapRun",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateStateMachine",
+      "status": "working",
+      "message": "likely implemented (StateMachineDoesNotExist: State machine not found: arn:aws:stepfunctions:us-east-1:123)"
+    },
+    {
+      "operation": "UpdateStateMachineAlias",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ValidateStateMachineDefinition",
+      "status": "working",
+      "message": "OK"
+    }
+  ]
+}

--- a/probes/sts.json
+++ b/probes/sts.json
@@ -1,0 +1,66 @@
+{
+  "service": "sts",
+  "counts": {
+    "working": 10,
+    "needs_params": 1,
+    "not_implemented": 0,
+    "500_error": 0
+  },
+  "operations": [
+    {
+      "operation": "AssumeRole",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "AssumeRoleWithSAML",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "AssumeRoleWithWebIdentity",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "AssumeRoot",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DecodeAuthorizationMessage",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetAccessKeyInfo",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetCallerIdentity",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetDelegatedAccessToken",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetFederationToken",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetSessionToken",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetWebIdentityToken",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    }
+  ]
+}

--- a/probes/support.json
+++ b/probes/support.json
@@ -1,0 +1,91 @@
+{
+  "service": "support",
+  "counts": {
+    "working": 16,
+    "needs_params": 0,
+    "not_implemented": 0,
+    "500_error": 0
+  },
+  "operations": [
+    {
+      "operation": "AddAttachmentsToSet",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "AddCommunicationToCase",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateCase",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeAttachment",
+      "status": "working",
+      "message": "likely implemented (AttachmentIdNotFound: Attachment ID not found: probe-test-value)"
+    },
+    {
+      "operation": "DescribeCases",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeCommunications",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeCreateCaseOptions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeServices",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeSeverityLevels",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeSupportedLanguages",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeTrustedAdvisorCheckRefreshStatuses",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeTrustedAdvisorCheckResult",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeTrustedAdvisorCheckSummaries",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeTrustedAdvisorChecks",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "RefreshTrustedAdvisorCheck",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ResolveCase",
+      "status": "working",
+      "message": "OK"
+    }
+  ]
+}

--- a/probes/synthetics.json
+++ b/probes/synthetics.json
@@ -1,0 +1,121 @@
+{
+  "service": "synthetics",
+  "counts": {
+    "working": 20,
+    "needs_params": 1,
+    "not_implemented": 1,
+    "500_error": 0
+  },
+  "operations": [
+    {
+      "operation": "AssociateResource",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "CreateCanary",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteCanary",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeCanaries",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeCanariesLastRun",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeRuntimeVersions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DisassociateResource",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetCanary",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetCanaryRuns",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "GetGroup",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListAssociatedGroups",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListGroupResources",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ListGroups",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartCanary",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "StartCanaryDryRun",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "StopCanary",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "TagResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UpdateCanary",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    }
+  ]
+}

--- a/probes/textract.json
+++ b/probes/textract.json
@@ -1,0 +1,136 @@
+{
+  "service": "textract",
+  "counts": {
+    "working": 5,
+    "needs_params": 1,
+    "not_implemented": 19,
+    "500_error": 0
+  },
+  "operations": [
+    {
+      "operation": "AnalyzeDocument",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "AnalyzeExpense",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "AnalyzeID",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateAdapter",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "CreateAdapterVersion",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteAdapter",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteAdapterVersion",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DetectDocumentText",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetAdapter",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetAdapterVersion",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetDocumentAnalysis",
+      "status": "working",
+      "message": "likely implemented (InvalidJobIdException: An invalid job identifier was passed.)"
+    },
+    {
+      "operation": "GetDocumentTextDetection",
+      "status": "working",
+      "message": "likely implemented (InvalidJobIdException: An invalid job identifier was passed.)"
+    },
+    {
+      "operation": "GetExpenseAnalysis",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetLendingAnalysis",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetLendingAnalysisSummary",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListAdapterVersions",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListAdapters",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StartDocumentAnalysis",
+      "status": "working",
+      "message": "implemented (InvalidParameterException)"
+    },
+    {
+      "operation": "StartDocumentTextDetection",
+      "status": "working",
+      "message": "implemented (InvalidParameterException)"
+    },
+    {
+      "operation": "StartExpenseAnalysis",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StartLendingAnalysis",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "TagResource",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateAdapter",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    }
+  ]
+}

--- a/probes/transcribe.json
+++ b/probes/transcribe.json
@@ -1,0 +1,226 @@
+{
+  "service": "transcribe",
+  "counts": {
+    "working": 28,
+    "needs_params": 4,
+    "not_implemented": 11,
+    "500_error": 0
+  },
+  "operations": [
+    {
+      "operation": "CreateCallAnalyticsCategory",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateLanguageModel",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateMedicalVocabulary",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateVocabulary",
+      "status": "working",
+      "message": "likely implemented (BadRequestException: Either Phrases or VocabularyFileUri field should be provided)"
+    },
+    {
+      "operation": "CreateVocabularyFilter",
+      "status": "working",
+      "message": "likely implemented (BadRequestException: Either Words or VocabularyFilterFileUri field should be prov)"
+    },
+    {
+      "operation": "DeleteCallAnalyticsCategory",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteCallAnalyticsJob",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteLanguageModel",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteMedicalScribeJob",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "DeleteMedicalTranscriptionJob",
+      "status": "working",
+      "message": "likely implemented (BadRequestException: The requested job couldn't be found. Check the job name and )"
+    },
+    {
+      "operation": "DeleteMedicalVocabulary",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteTranscriptionJob",
+      "status": "working",
+      "message": "likely implemented (BadRequestException: The requested job couldn't be found. Check the job name and )"
+    },
+    {
+      "operation": "DeleteVocabulary",
+      "status": "working",
+      "message": "likely implemented (BadRequestException: The requested vocabulary couldn't be found. Check the vocabu)"
+    },
+    {
+      "operation": "DeleteVocabularyFilter",
+      "status": "working",
+      "message": "likely implemented (BadRequestException: The requested vocabulary filter couldn't be found. Check the)"
+    },
+    {
+      "operation": "DescribeLanguageModel",
+      "status": "working",
+      "message": "likely implemented (BadRequestException: The requested language model couldn't be found. Check the la)"
+    },
+    {
+      "operation": "GetCallAnalyticsCategory",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetCallAnalyticsJob",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetMedicalScribeJob",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetMedicalTranscriptionJob",
+      "status": "working",
+      "message": "likely implemented (BadRequestException: The requested job couldn't be found. Check the job name and )"
+    },
+    {
+      "operation": "GetMedicalVocabulary",
+      "status": "working",
+      "message": "likely implemented (BadRequestException: The requested vocabulary couldn't be found. Check the vocabu)"
+    },
+    {
+      "operation": "GetTranscriptionJob",
+      "status": "working",
+      "message": "likely implemented (BadRequestException: The requested job couldn't be found. Check the job name and )"
+    },
+    {
+      "operation": "GetVocabulary",
+      "status": "working",
+      "message": "likely implemented (BadRequestException: The requested vocabulary couldn't be found. Check the vocabu)"
+    },
+    {
+      "operation": "GetVocabularyFilter",
+      "status": "working",
+      "message": "likely implemented (BadRequestException: The requested vocabulary filter couldn't be found. Check the)"
+    },
+    {
+      "operation": "ListCallAnalyticsCategories",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListCallAnalyticsJobs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListLanguageModels",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListMedicalScribeJobs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListMedicalTranscriptionJobs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListMedicalVocabularies",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "ListTranscriptionJobs",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListVocabularies",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListVocabularyFilters",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartCallAnalyticsJob",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StartMedicalScribeJob",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "StartMedicalTranscriptionJob",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartTranscriptionJob",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "TagResource",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UpdateCallAnalyticsCategory",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UpdateMedicalVocabulary",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateVocabulary",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateVocabularyFilter",
+      "status": "working",
+      "message": "likely implemented (BadRequestException: The requested vocabulary filter couldn't be found. Check the)"
+    }
+  ]
+}

--- a/probes/wafv2.json
+++ b/probes/wafv2.json
@@ -1,0 +1,286 @@
+{
+  "service": "wafv2",
+  "counts": {
+    "working": 49,
+    "needs_params": 4,
+    "not_implemented": 1,
+    "500_error": 1
+  },
+  "operations": [
+    {
+      "operation": "AssociateWebACL",
+      "status": "working",
+      "message": "likely implemented (WAFNonexistentItemException: AWS WAF couldn\u2019t perform the operation because your resource)"
+    },
+    {
+      "operation": "CheckCapacity",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateAPIKey",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateIPSet",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateRegexPatternSet",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateRuleGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateWebACL",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteAPIKey",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteFirewallManagerRuleGroups",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteIPSet",
+      "status": "working",
+      "message": "likely implemented (WAFNonexistentItemException: AWS WAF couldn\u2019t perform the operation because your resource)"
+    },
+    {
+      "operation": "DeleteLoggingConfiguration",
+      "status": "working",
+      "message": "likely implemented (WAFNonexistentItemException: AWS WAF couldn\u2019t perform the operation because your resource)"
+    },
+    {
+      "operation": "DeletePermissionPolicy",
+      "status": "working",
+      "message": "likely implemented (WAFNonexistentItemException: AWS WAF couldn\u2019t perform the operation because your resource)"
+    },
+    {
+      "operation": "DeleteRegexPatternSet",
+      "status": "working",
+      "message": "likely implemented (WAFNonexistentItemException: AWS WAF couldn\u2019t perform the operation because your resource)"
+    },
+    {
+      "operation": "DeleteRuleGroup",
+      "status": "working",
+      "message": "likely implemented (WAFNonexistentItemException: AWS WAF couldn\u2019t perform the operation because your resource)"
+    },
+    {
+      "operation": "DeleteWebACL",
+      "status": "working",
+      "message": "likely implemented (WAFNonexistentItemException: AWS WAF couldn\u2019t perform the operation because your resource)"
+    },
+    {
+      "operation": "DescribeAllManagedProducts",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeManagedProductsByVendor",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeManagedRuleGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DisassociateWebACL",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GenerateMobileSdkReleaseUrl",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetDecryptedAPIKey",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetIPSet",
+      "status": "working",
+      "message": "likely implemented (WAFNonexistentItemException: AWS WAF couldn\u2019t perform the operation because your resource)"
+    },
+    {
+      "operation": "GetLoggingConfiguration",
+      "status": "working",
+      "message": "likely implemented (WAFNonexistentItemException: AWS WAF couldn\u2019t perform the operation because your resource)"
+    },
+    {
+      "operation": "GetManagedRuleSet",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetMobileSdkRelease",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetPermissionPolicy",
+      "status": "working",
+      "message": "likely implemented (WAFNonexistentItemException: AWS WAF couldn\u2019t perform the operation because your resource)"
+    },
+    {
+      "operation": "GetRateBasedStatementManagedKeys",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetRegexPatternSet",
+      "status": "working",
+      "message": "likely implemented (WAFNonexistentItemException: AWS WAF couldn\u2019t perform the operation because your resource)"
+    },
+    {
+      "operation": "GetRuleGroup",
+      "status": "working",
+      "message": "likely implemented (AcessDeniedException: Critical information is missing in your request: GetRuleGrou)"
+    },
+    {
+      "operation": "GetSampledRequests",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetTopPathStatisticsByTraffic",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetWebACL",
+      "status": "working",
+      "message": "likely implemented (WAFNonexistentItemException: AWS WAF couldn\u2019t perform the operation because your resource)"
+    },
+    {
+      "operation": "GetWebACLForResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListAPIKeys",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListAvailableManagedRuleGroupVersions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListAvailableManagedRuleGroups",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListIPSets",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListLoggingConfigurations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListManagedRuleSets",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListMobileSdkReleases",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListRegexPatternSets",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListResourcesForWebACL",
+      "status": "working",
+      "message": "likely implemented (WAFNonexistentItemException: AWS WAF couldn\u2019t perform the operation because your resource)"
+    },
+    {
+      "operation": "ListRuleGroups",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListWebACLs",
+      "status": "500_error",
+      "message": "exception: 'WAFV2' object has no attribute 'list_web_ac_ls'"
+    },
+    {
+      "operation": "PutLoggingConfiguration",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "PutManagedRuleSetVersions",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutPermissionPolicy",
+      "status": "working",
+      "message": "likely implemented (WAFInvalidParameterException: The ARN isn't valid. A valid ARN starts with arn: and includ)"
+    },
+    {
+      "operation": "TagResource",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UpdateIPSet",
+      "status": "working",
+      "message": "likely implemented (WAFNonexistentItemException: AWS WAF couldn\u2019t perform the operation because your resource)"
+    },
+    {
+      "operation": "UpdateManagedRuleSetVersionExpiryDate",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateRegexPatternSet",
+      "status": "working",
+      "message": "likely implemented (WAFNonexistentItemException: AWS WAF couldn\u2019t perform the operation because your resource)"
+    },
+    {
+      "operation": "UpdateRuleGroup",
+      "status": "working",
+      "message": "likely implemented (WAFNonexistentItemException: AWS WAF couldn\u2019t perform the operation because your resource)"
+    },
+    {
+      "operation": "UpdateWebACL",
+      "status": "working",
+      "message": "likely implemented (WAFNonexistentItemException: AWS WAF couldn\u2019t perform the operation because your resource)"
+    }
+  ]
+}

--- a/probes/workspaces.json
+++ b/probes/workspaces.json
@@ -1,0 +1,466 @@
+{
+  "service": "workspaces",
+  "counts": {
+    "working": 74,
+    "needs_params": 12,
+    "not_implemented": 0,
+    "500_error": 5
+  },
+  "operations": [
+    {
+      "operation": "AcceptAccountLinkInvitation",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "AssociateConnectionAlias",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "AssociateIpGroups",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "AssociateWorkspaceApplication",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "AuthorizeIpRules",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "CopyWorkspaceImage",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateAccountLinkInvitation",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateConnectClientAddIn",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateConnectionAlias",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateIpGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateStandbyWorkspaces",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateTags",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateUpdatedWorkspaceImage",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateWorkspaceBundle",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateWorkspaceImage",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "CreateWorkspaces",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "CreateWorkspacesPool",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteAccountLinkInvitation",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteClientBranding",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DeleteConnectClientAddIn",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DeleteConnectionAlias",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteIpGroup",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DeleteTags",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteWorkspaceBundle",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteWorkspaceImage",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeployWorkspaceApplications",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeregisterWorkspaceDirectory",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "DescribeAccount",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeAccountModifications",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeApplicationAssociations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeApplications",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeBundleAssociations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeClientBranding",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeClientProperties",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DescribeConnectClientAddIns",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeConnectionAliasPermissions",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeConnectionAliases",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeCustomWorkspaceImageImport",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeImageAssociations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeIpGroups",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeTags",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeWorkspaceAssociations",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeWorkspaceBundles",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeWorkspaceDirectories",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeWorkspaceImagePermissions",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "DescribeWorkspaceImages",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeWorkspaceSnapshots",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeWorkspaces",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeWorkspacesConnectionStatus",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DescribeWorkspacesPoolSessions",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DescribeWorkspacesPools",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DisassociateConnectionAlias",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DisassociateIpGroups",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "DisassociateWorkspaceApplication",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetAccountLink",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ImportClientBranding",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ImportCustomWorkspaceImage",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "ImportWorkspaceImage",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListAccountLinks",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListAvailableManagementCidrRanges",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "MigrateWorkspace",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ModifyAccount",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ModifyCertificateBasedAuthProperties",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ModifyClientProperties",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "ModifyEndpointEncryptionMode",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ModifySamlProperties",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ModifySelfservicePermissions",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "ModifyStreamingProperties",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ModifyWorkspaceAccessProperties",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ModifyWorkspaceCreationProperties",
+      "status": "working",
+      "message": "implemented (ValidationException)"
+    },
+    {
+      "operation": "ModifyWorkspaceProperties",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "ModifyWorkspaceState",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "RebootWorkspaces",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "RebuildWorkspaces",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "RegisterWorkspaceDirectory",
+      "status": "500_error",
+      "message": "server crash (InternalError: expected string or bytes-like object, got 'NoneType')"
+    },
+    {
+      "operation": "RejectAccountLinkInvitation",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "RestoreWorkspace",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "RevokeIpRules",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "StartWorkspaces",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "StartWorkspacesPool",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "StopWorkspaces",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "StopWorkspacesPool",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "TerminateWorkspaces",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "TerminateWorkspacesPool",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "TerminateWorkspacesPoolSession",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UpdateConnectClientAddIn",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UpdateConnectionAliasPermission",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateRulesOfIpGroup",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateWorkspaceBundle",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    },
+    {
+      "operation": "UpdateWorkspaceImagePermission",
+      "status": "500_error",
+      "message": "server crash (InternalError: 'probe-test-value')"
+    },
+    {
+      "operation": "UpdateWorkspacesPool",
+      "status": "working",
+      "message": "implemented (ResourceNotFoundException)"
+    }
+  ]
+}

--- a/probes/xray.json
+++ b/probes/xray.json
@@ -1,0 +1,201 @@
+{
+  "service": "xray",
+  "counts": {
+    "working": 32,
+    "needs_params": 2,
+    "not_implemented": 4,
+    "500_error": 0
+  },
+  "operations": [
+    {
+      "operation": "BatchGetTraces",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CancelTraceRetrieval",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "CreateSamplingRule",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "DeleteGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteResourcePolicy",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "DeleteSamplingRule",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetEncryptionConfig",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetGroup",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetGroups",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetIndexingRules",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetInsight",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "GetInsightEvents",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "GetInsightImpactGraph",
+      "status": "working",
+      "message": "implemented (InvalidRequestException)"
+    },
+    {
+      "operation": "GetInsightSummaries",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetRetrievedTracesGraph",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetSamplingRules",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetSamplingStatisticSummaries",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetSamplingTargets",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetServiceGraph",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetTimeSeriesServiceStatistics",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetTraceGraph",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "GetTraceSegmentDestination",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "GetTraceSummaries",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListResourcePolicies",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListRetrievedTraces",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "ListTagsForResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutEncryptionConfig",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutResourcePolicy",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutTelemetryRecords",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "PutTraceSegments",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "StartTraceRetrieval",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "TagResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UntagResource",
+      "status": "working",
+      "message": "OK"
+    },
+    {
+      "operation": "UpdateGroup",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateIndexingRule",
+      "status": "needs_params",
+      "message": "client-side validation (never contacted server)"
+    },
+    {
+      "operation": "UpdateSamplingRule",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    },
+    {
+      "operation": "UpdateTraceSegmentDestination",
+      "status": "not_implemented",
+      "message": "not implemented (501)"
+    }
+  ]
+}

--- a/prompts/20260318-191900-ses-gap-coverage.md
+++ b/prompts/20260318-191900-ses-gap-coverage.md
@@ -1,0 +1,37 @@
+---
+session: "ab5de642"
+timestamp: "2026-03-18T19:19:00Z"
+model: claude-sonnet-4-6
+tools: [bash, glob, grep, read, edit, write]
+---
+
+## Human
+
+Expand compat tests for the **ses** service (SES v1). Target the untested-but-working operations (gap=16).
+
+Steps:
+1. Run chunk_service.py to see which operations need tests
+2. Probe each untested operation against the live server before writing tests
+3. Write tests in tests/compatibility/test_ses_compat.py
+
+## Assistant
+
+## Key decisions
+
+**Discovery**: chunk_service.py reported 16 untested operations across 11 chunks for SES. All 16 were returning 501 NotImplemented — none were working yet. The probe showed: ConfigurationSetTrackingOptions (3 ops), ConfigurationSetDeliveryOptions, ConfigurationSetSendingEnabled, ConfigurationSetEventDestination delete/update, IdentityPolicies (4 ops), SetIdentityHeadersInNotificationsEnabled, SetReceiptRulePosition, ReorderReceiptRuleSet, DeleteVerifiedEmailAddress, SendBounce.
+
+**Implementation approach**: Rather than writing tests against broken endpoints, implemented all 16 operations in the native SES provider at `src/robotocore/services/ses/provider.py`. Each handler operates directly on the Moto backend data structures (config_sets, receipt_rule_set, email_identities) since Moto's responses.py didn't expose these operations.
+
+**Identity policies storage**: Moto's SESBackend has no `identity_policies` attribute. Added it dynamically via `hasattr` check + lazy initialization pattern to avoid modifying Moto source.
+
+**ConfigurationSet error handling**: Used the existing `SesError` class with `ConfigurationSetDoesNotExist` code to match AWS behavior for invalid config set names.
+
+**SetReceiptRulePosition**: AWS allows repositioning a rule by specifying which rule it should come after. Implemented by removing the target from its current position and re-inserting after the named rule (or at front if no After parameter).
+
+**ReorderReceiptRuleSet**: Takes an ordered list of rule names and rearranges the rule_set.rules list accordingly, appending any unlisted rules at the end.
+
+**SendBounce**: Implemented as a simulation — returns a generated MessageId without actually processing bounce notifications (emulator behavior).
+
+**Server restart issue**: The main repo server (PID 61761) was already running on port 4566. Had to copy provider changes to the main repo and restart from there for tests to pick up the new implementations.
+
+**21 new tests added** covering all 16 operations: 4 for tracking options, 2 for delivery options, 2 for sending enabled, 2 for event destination CRUD, 5 for identity policies (including lifecycle and empty-list cases), 2 for notification headers, 2 for receipt rule position/reorder, 1 for delete verified email, 1 for send bounce. All verified against live server with 0 no-server-contact rate.


### PR DESCRIPTION
## Summary
- Adds `chunks/*.json` (102 files): per-service operation groupings with tested/untested/working metadata
- Adds `probes/*.json` (102 files): per-service probe results classifying every operation as working/not_implemented/500_error
- Adds orphaned SES prompt log (`prompts/20260318-191900-ses-gap-coverage.md`)

These data files power `scripts/overnight.sh`, `scripts/next_service.py`, and `scripts/chunk_service.py`. Without them committed, anyone cloning the repo must re-probe all 102 services from scratch.

## Test plan
- [ ] CI passes (no source/test changes, only data + prompt log)
- [ ] `uv run python scripts/next_service.py` reads chunk/probe data correctly
- [ ] `uv run python scripts/chunk_service.py --service ses --with-probe` shows SES chunks with probe overlay

🤖 Generated with [Claude Code](https://claude.com/claude-code)