### PR TITLE
feat: add 9 AppMesh compat tests for working operations

### DIFF
--- a/prompts/20260319-120000-appmesh-error-path-tests.md
+++ b/prompts/20260319-120000-appmesh-error-path-tests.md
@@ -1,0 +1,25 @@
+---
+session: "agent-a9762f3c"
+timestamp: "2026-03-19T12:00:00Z"
+model: claude-opus-4-6
+---
+
+## Human
+
+Write compat tests for 9 working AppMesh operations covering error paths
+(NotFound errors for nonexistent meshes/resources) and ListMeshes empty response.
+
+## Assistant
+
+## Key decisions
+
+Added 9 error-path tests in a new `TestErrorPaths` class to the existing
+`test_appmesh_compat.py` file. The file already had happy-path tests for all
+9 operations; these new tests verify proper error responses when resources
+don't exist.
+
+**Pattern used**: `pytest.raises(ClientError)` with assertion that the error
+code contains "NotFound". For ListMeshes, asserted the "meshes" key exists
+in the response (no error expected for listing with no results).
+
+All 9 tests pass against the live server on port 4566.

--- a/tests/compatibility/test_appmesh_compat.py
+++ b/tests/compatibility/test_appmesh_compat.py
@@ -3,6 +3,7 @@
 import uuid
 
 import pytest
+from botocore.exceptions import ClientError
 
 from tests.compatibility.conftest import make_client
 
@@ -397,3 +398,66 @@ class TestRouteOperations:
             appmesh_client.delete_route(
                 meshName=mesh_name, virtualRouterName=router_name, routeName=route_name
             )
+
+
+class TestErrorPaths:
+    """Tests that verify proper error responses for nonexistent resources."""
+
+    def test_list_meshes_empty(self, appmesh_client):
+        """ListMeshes returns a list even when no meshes exist."""
+        resp = appmesh_client.list_meshes()
+        assert "meshes" in resp
+
+    def test_describe_mesh_not_found(self, appmesh_client):
+        with pytest.raises(ClientError) as exc_info:
+            appmesh_client.describe_mesh(meshName="nonexistent-mesh-xyz")
+        assert "NotFound" in exc_info.value.response["Error"]["Code"]
+
+    def test_describe_route_mesh_not_found(self, appmesh_client):
+        with pytest.raises(ClientError) as exc_info:
+            appmesh_client.describe_route(
+                meshName="nonexistent-mesh-xyz",
+                virtualRouterName="nonexistent-router",
+                routeName="nonexistent-route",
+            )
+        assert "NotFound" in exc_info.value.response["Error"]["Code"]
+
+    def test_describe_virtual_node_mesh_not_found(self, appmesh_client):
+        with pytest.raises(ClientError) as exc_info:
+            appmesh_client.describe_virtual_node(
+                meshName="nonexistent-mesh-xyz",
+                virtualNodeName="nonexistent-node",
+            )
+        assert "NotFound" in exc_info.value.response["Error"]["Code"]
+
+    def test_describe_virtual_router_mesh_not_found(self, appmesh_client):
+        with pytest.raises(ClientError) as exc_info:
+            appmesh_client.describe_virtual_router(
+                meshName="nonexistent-mesh-xyz",
+                virtualRouterName="nonexistent-router",
+            )
+        assert "NotFound" in exc_info.value.response["Error"]["Code"]
+
+    def test_list_routes_mesh_not_found(self, appmesh_client):
+        with pytest.raises(ClientError) as exc_info:
+            appmesh_client.list_routes(
+                meshName="nonexistent-mesh-xyz",
+                virtualRouterName="nonexistent-router",
+            )
+        assert "NotFound" in exc_info.value.response["Error"]["Code"]
+
+    def test_list_virtual_nodes_mesh_not_found(self, appmesh_client):
+        with pytest.raises(ClientError) as exc_info:
+            appmesh_client.list_virtual_nodes(meshName="nonexistent-mesh-xyz")
+        assert "NotFound" in exc_info.value.response["Error"]["Code"]
+
+    def test_list_virtual_routers_mesh_not_found(self, appmesh_client):
+        with pytest.raises(ClientError) as exc_info:
+            appmesh_client.list_virtual_routers(meshName="nonexistent-mesh-xyz")
+        assert "NotFound" in exc_info.value.response["Error"]["Code"]
+
+    def test_list_tags_for_resource_not_found(self, appmesh_client):
+        fake_arn = "arn:aws:appmesh:us-east-1:123456789012:mesh/nonexistent-mesh-xyz"
+        with pytest.raises(ClientError) as exc_info:
+            appmesh_client.list_tags_for_resource(resourceArn=fake_arn)
+        assert "NotFound" in exc_info.value.response["Error"]["Code"]


### PR DESCRIPTION
## Summary
- Add 9 compat tests for working AppMesh operations (ListMeshes + 8 error-path Describe/List ops)
- All tests contact server and assert on response

## Test plan
- [x] 9 new tests pass
- [x] All existing AppMesh tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)