### PR TITLE
feat: add 3 MediaPackage/MediaStore compat tests

### DIFF
--- a/prompts/20260319-120000-media-tests.md
+++ b/prompts/20260319-120000-media-tests.md
@@ -1,0 +1,27 @@
+---
+session: "agent-acdd6e48"
+timestamp: "2026-03-19T12:00:00Z"
+model: claude-opus-4-6
+---
+
+## Human
+
+Write compat tests for 12 working operations across MediaPackage (6) and MediaStore (6).
+Server on port 4566. MediaPackage: ListChannels, ListHarvestJobs, ListOriginEndpoints,
+DescribeChannel/HarvestJob/OriginEndpoint (NotFoundException). MediaStore: ListContainers,
+DescribeContainer, GetContainerPolicy, GetLifecyclePolicy, GetMetricPolicy (ResourceNotFoundException),
+ListTagsForResource (ContainerNotFoundException).
+
+## Assistant
+
+## Key decisions
+
+Most of the 12 operations were already covered by existing tests. Added 3 new tests for
+the uncovered operations:
+
+1. **MediaPackage ListHarvestJobs** - list op asserting HarvestJobs key is a list
+2. **MediaPackage DescribeHarvestJob** - error path asserting NotFoundException
+3. **MediaStore ListTagsForResource error path** - asserting ContainerNotFoundException for nonexistent ARN
+
+All 3 new tests verified against running server (port 4566), all pass. Quality gate: 91.3%
+effective rate, 0% no-server-contact.

--- a/tests/compatibility/test_mediapackage_compat.py
+++ b/tests/compatibility/test_mediapackage_compat.py
@@ -66,6 +66,21 @@ class TestMediaPackageChannels:
         assert exc.value.response["Error"]["Code"] == "NotFoundException"
 
 
+class TestMediaPackageHarvestJobs:
+    def test_list_harvest_jobs(self, mediapackage):
+        response = mediapackage.list_harvest_jobs()
+        assert "HarvestJobs" in response
+        assert isinstance(response["HarvestJobs"], list)
+
+    def test_describe_harvest_job_nonexistent(self, mediapackage):
+        """DescribeHarvestJob for nonexistent job raises NotFoundException."""
+        from botocore.exceptions import ClientError
+
+        with pytest.raises(ClientError) as exc:
+            mediapackage.describe_harvest_job(Id="no-such-harvest-job")
+        assert exc.value.response["Error"]["Code"] == "NotFoundException"
+
+
 class TestMediaPackageOriginEndpoints:
     def test_list_origin_endpoints(self, mediapackage):
         response = mediapackage.list_origin_endpoints()

--- a/tests/compatibility/test_mediastore_compat.py
+++ b/tests/compatibility/test_mediastore_compat.py
@@ -227,6 +227,15 @@ class TestMediaStoreTagsForResource:
         assert "Tags" in resp
         assert isinstance(resp["Tags"], list)
 
+    def test_list_tags_for_nonexistent_resource(self, mediastore_client):
+        """ListTagsForResource for nonexistent container raises ContainerNotFoundException."""
+        from botocore.exceptions import ClientError
+
+        fake_arn = "arn:aws:mediastore:us-east-1:123456789012:container/no-such-container-xyz"
+        with pytest.raises(ClientError) as exc:
+            mediastore_client.list_tags_for_resource(Resource=fake_arn)
+        assert exc.value.response["Error"]["Code"] == "ContainerNotFoundException"
+
     def test_list_tags_for_resource_with_tags(self, mediastore_client):
         name = f"tagged-{uuid.uuid4().hex[:8]}"
         tags = [{"Key": "env", "Value": "test"}, {"Key": "project", "Value": "compat"}]


### PR DESCRIPTION
## Summary
- Add 2 MediaPackage tests (ListHarvestJobs, DescribeHarvestJob error path)
- Add 1 MediaStore test (ListTagsForResource error path)
- 9 of 12 working ops were already covered by existing tests

## Test plan
- [x] 39 tests pass (16 mediapackage + 23 mediastore)
- [x] 0% no-server-contact rate

🤖 Generated with [Claude Code](https://claude.com/claude-code)