### PR TITLE
Feat: Add SQS and Eventbridge persistence

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -341,11 +341,13 @@ for svc, status in sorted(h.get('services', {}).items()):
 
 ---
 
-## State is in-memory
+## State is in-memory by default
 
-All state is lost when the container stops. This is intentional — robotocore is for development and testing, not production.
+Runtime state lives in memory and is isolated per account and region. By default, restarting container resets that state.
 
-Reset all state by restarting:
+Optional persistence and snapshots exist when you configure `ROBOTOCORE_STATE_DIR` or use `/_robotocore/state/save` and `/_robotocore/state/load`. Native SQS and EventBridge state now participate in that save/load path too.
+
+Reset all in-memory state by restarting:
 
 ```bash
 docker restart robotocore

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,7 +142,7 @@ make status                            # Check if server is running
 1. **Gateway on port 4566**: Standard AWS emulator port so existing `aws --endpoint-url` configs work unchanged
 2. **Moto as the service layer**: Don't reimplement what Moto already does well. Wrap it, extend it, fix its gaps.
 3. **Protocol handling via botocore specs**: Use botocore's own service JSON specs to parse/serialize requests
-4. **In-memory state by default**: No persistence layer needed for dev/test use. Optional persistence can come later.
+4. **In-memory state by default**: Runtime state stays in memory unless snapshot/persistence features are enabled for local dev or test workflows.
 5. **Plugin system**: `RobotocorePlugin` base class with entry point, env var, and directory discovery.
 6. **ASGI with uvicorn**: Modern async-capable HTTP server
 

--- a/prompts/20260420-100515-sqs-eventbridge-persistence.md
+++ b/prompts/20260420-100515-sqs-eventbridge-persistence.md
@@ -1,0 +1,223 @@
+---
+session: "8f3c1a"
+timestamp: "2026-04-20T10:05:15Z"
+model: "gpt-5-codex"
+---
+
+## Human
+
+Implement native persistence for in-memory AWS services in this repo using
+existing state/snapshot framework. Do not build new persistence subsystem, disk
+cache layer, or event replay mechanism unless codebase proves existing
+framework cannot support requirement.
+
+First, read and follow repo guidance:
+- `AGENTS.md`
+- `README.md`
+- `CLAUDE.md`
+- `prompts/PROMPTLOG.md`
+- `.github/workflows/ci.yml`
+
+Goal:
+- Make native SQS queues/messages and native EventBridge state survive
+  existing snapshot/save/load flows and startup restore flows already
+  supported by repo.
+- Reuse same persistence pattern for native services that keep meaningful
+  in-memory provider state.
+- Keep solution generic to robotocore itself. Do not add app-specific or
+  environment-specific logic.
+
+Design constraints:
+- Reuse `StateManager.register_native_handler(...)` and current
+  `native_state.json` flow.
+- Keep patch surface small and aligned with current architecture.
+- Preserve existing native-service behavior as much as practical after
+  restore.
+- Prefer simple default-first control flow.
+- No destructive git operations.
+
+What to inspect before coding:
+- `src/robotocore/state/manager.py`
+- `src/robotocore/boot/components.py`
+- `src/robotocore/services/sqs/provider.py`
+- `src/robotocore/services/sqs/models.py`
+- `src/robotocore/services/events/provider.py`
+- `src/robotocore/services/events/models.py`
+- `src/robotocore/services/events/rule_scheduler.py`
+- Any existing state snapshot tests
+
+Implementation requirements:
+1. Register SQS as native persisted service through existing state manager
+   hooks.
+2. Ensure registration happens before startup load path so saved SQS state is
+   actually consumed.
+3. Serialize and restore enough native SQS state to make persistence useful
+   for local dev and tests:
+   - stores by account and region
+   - queue definitions, attributes, tags, timestamps
+   - visible, inflight, and delayed messages
+   - receipt handle mapping
+   - FIFO ordering state, including group queues and sequence continuity
+   - behavioral trackers needed to avoid obvious regressions after restore
+   - move-task state if needed for correctness
+4. Rebuild in-memory queue objects correctly on load.
+5. Keep implementation JSON-serializable through existing native state writer.
+6. Avoid adding persistence for data that is truly unnecessary unless needed
+   for correctness.
+7. Apply same native persistence seam to EventBridge for state that is
+   native and in-memory:
+   - per-account/per-region stores
+   - event buses, rules, targets, archives, replays, tags
+   - provider-owned connections, API destinations, and endpoints
+8. Keep debug/runtime-only state ephemeral where persistence would be
+   incorrect:
+   - EventBridge invocation log
+   - EventBridge scheduler last-fired monotonic cache
+
+Follow-up hardening requirements:
+1. Address hot-path registration overhead so state-handler registration is not
+   doing avoidable churn on steady-state request path.
+2. Reduce provider-level private-attribute reach-through by moving
+   snapshot/restore behavior into owner classes where practical.
+3. Make FIFO restore defensively correct, including heap invariant handling
+   when restoring group queues.
+4. Tighten lock scope and simplify snapshot flow where safe.
+5. Remove unnecessary serializer/deserializer indirection if it provides no
+   real flexibility.
+6. Simplify dataclass persistence where fields are primitive-safe.
+7. Normalize native snapshot shape and versioning where branch scope grows:
+   - top-level `schema_version`
+   - explicit warnings on unexpected future versions
+   - strict validation for restore invariants that should not be silently
+     repaired
+
+Testing requirements:
+- Add focused unit tests for SQS native export/import round trip.
+- Add focused test covering state-manager save/load round trip for SQS.
+- Cover at least:
+  - standard queue with visible/inflight/delayed messages
+  - FIFO queue ordering and sequence continuation after restore
+  - receipt-handle continuity after restore
+  - expired inflight message becoming receivable after restore
+  - multi-account and multi-region isolation
+  - dedup cache survival after restore, including duplicate rejection
+  - purge/delete behavioral tracker round trip
+  - move-task and recently-deleted state round trip
+  - DLQ behavior after restore
+  - binary message attributes through disk-backed state-manager path
+  - export/load idempotency
+- Add focused EventBridge persistence tests covering at least:
+  - buses, rules, targets, archives, replays, and tags round trip
+  - multi-account and multi-region isolation
+  - scheduled rules firing after restore with fresh scheduler cache
+  - provider-owned connections/api-destinations/endpoints via disk-backed
+    save/load
+  - load replacement semantics
+  - empty snapshot loads
+  - ignored unknown top-level and dataclass fields
+  - warnings on explicit future `schema_version`
+  - failure on invalid default-bus identity during restore
+- Tighten tests around real restore contracts and reduce brittle fixture/setup
+  coupling.
+- If compatibility/integration coverage is appropriate and cheap, add it. Do
+  not add speculative tests for behavior not verified.
+
+Verification requirements:
+- Run targeted tests for changed area.
+- Run relevant lint/format/type checks for changed files.
+- If any repo-standard check cannot run, report exact command and blocker.
+- Do not claim full validation if only targeted checks ran.
+
+Documentation / PR hygiene:
+- Update docs only if user-facing persistence behavior changes and docs are now
+  inaccurate.
+- Make prompt log and docs match resulting behavior.
+- Add prompt log entry in `prompts/` per repo rules, sanitized and formatted
+  correctly, so PR passes prompt-log requirement.
+
+Output expectations:
+- Make code changes directly.
+- Then summarize:
+  - what changed
+  - what was verified
+  - remaining risks or fidelity gaps
+
+## Assistant
+
+## Key decisions
+
+**Use existing native state hooks**: Chose `StateManager.register_native_handler`
+and `native_state.json` as persistence seam. This fit repo architecture, kept
+patch surface small, and avoided inventing a second persistence system for
+native providers.
+
+**Register before load**: Wired native state-handler registration into boot path
+so startup restore can actually consume native state before first request and
+before background engines start. Without this, saved blobs would exist on disk
+but never hydrate.
+
+**Persist behaviorally meaningful SQS state**: Saved and restored queue/store
+objects rather than request history. Coverage includes per-account/per-region
+stores, queue definitions, visible/inflight/delayed messages, receipt maps,
+FIFO group ordering state, dedup cache, sequence counters, move-task state, and
+purge/delete cooldown trackers.
+
+**Apply same seam to EventBridge**: EventBridge already had native in-memory
+stores plus provider-owned globals. Added native persistence for buses, rules,
+targets, archives, replays, tags, and connection/API-destination/endpoint
+state, while intentionally skipping debug invocation logs and scheduler
+runtime cache.
+
+**Push persistence ownership into SQS classes**: Reduced provider-level
+reach-through by adding `snapshot_state()` / `restore_state()` or
+`from_snapshot()` methods on behavioral trackers, messages, move tasks, queues,
+and stores. Provider now coordinates persistence instead of serializing private
+fields by hand.
+
+**Tighten concurrency and simplify structure**: Collapsed unnecessary
+serializer/deserializer wrapper indirection, moved per-object snapshot logic
+into owner classes, took FIFO snapshots under one mutex to avoid split-lock
+inconsistency, and shortened `_store_lock` hold time during export by copying
+store references first and serializing outside global lock.
+
+**Simplify safe dataclass persistence only where primitives allow it**:
+`MessageMoveTask` now uses dataclass helpers for snapshot/restore. `SqsMessage`
+stayed explicit because it contains JSON-hostile fields like sets and may carry
+binary message attributes. EventBridge dataclass restores filter unknown future
+fields so older code can load newer snapshots without crashing.
+
+**Update docs to match new semantics**: Existing docs said restart always loses
+SQS state. Updated repo docs to say state is in-memory by default, with
+optional snapshot/persistence support, and that native SQS and EventBridge now
+participate in that flow.
+
+**Strengthen tests around user-visible restore contracts**: Added focused unit
+coverage for standard queues, FIFO queues, multi-account/multi-region
+isolation, move tasks, recently-deleted state, purge/delete trackers,
+receipt-handle continuity, expired inflight redelivery after restore, DLQ
+routing after restore, disk-backed binary message attributes, and
+export/load idempotency. Added EventBridge round-trip, replacement,
+forward-compat, scheduler-after-restore, and provider-global persistence
+tests.
+
+**Improve fixture isolation**: Added direct test reset helpers for SQS provider
+globals and StateManager singleton so test setup no longer depends on
+`load_state({})` being healthy. This makes failures point at real restore bugs
+instead of collapsing the whole test file.
+
+**Reduce brittle test coupling**: Reworked heapify regression coverage to use a
+small hand-built queue snapshot at queue boundary instead of mutating the full
+exported nested snapshot payload. Split dense tests so failures isolate to one
+behavior at a time.
+
+**Validate snapshot shape explicitly on load**: Added `schema_version` to
+native provider snapshots and load-time warnings for unexpected future
+versions. EventBridge restore also validates that the restored default bus
+identity matches the `(account_id, region)` store key instead of silently
+rewriting mismatched snapshot data.
+
+**Keep backward loads quiet, future loads loud**: Missing `schema_version`
+means pre-versioned snapshot and loads silently. Explicit higher versions log a
+warning and continue with v1 logic so local snapshots stay usable while making
+unsupported forward loads visible. Applied symmetrically to EventBridge and
+SQS.

--- a/src/robotocore/boot/components.py
+++ b/src/robotocore/boot/components.py
@@ -63,9 +63,17 @@ def state_component() -> ServiceComponent:
     def start() -> None:
         nonlocal _ready
         if os.environ.get("ROBOTOCORE_STATE_DIR"):
+            from robotocore.services.events.provider import (
+                register_state_handler as register_events_state,
+            )
+            from robotocore.services.sqs.provider import (
+                register_state_handler as register_sqs_state,
+            )
             from robotocore.state.manager import get_state_manager
 
             manager = get_state_manager()
+            register_events_state(manager)
+            register_sqs_state(manager)
             if not manager.restore_on_startup():
                 manager.load()
         _ready = True

--- a/src/robotocore/services/events/models.py
+++ b/src/robotocore/services/events/models.py
@@ -1,8 +1,9 @@
 """EventBridge in-memory models: event buses, rules, targets, and archives."""
 
+import copy
 import threading
 import time
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field, fields
 
 
 @dataclass
@@ -14,6 +15,14 @@ class EventTarget:
     input_path: str | None = None
     input_transformer: dict | None = None
     dead_letter_config: dict | None = None
+
+    def snapshot_state(self) -> dict:
+        return asdict(self)
+
+    @classmethod
+    def from_snapshot(cls, data: dict) -> "EventTarget":
+        allowed = {field.name for field in fields(cls)}
+        return cls(**{key: value for key, value in dict(data).items() if key in allowed})
 
 
 @dataclass
@@ -48,6 +57,25 @@ class EventRule:
             return False
         return _match_pattern(self.event_pattern, event)
 
+    def snapshot_state(self) -> dict:
+        data = asdict(self)
+        data["targets"] = {
+            target_id: target.snapshot_state() for target_id, target in self.targets.items()
+        }
+        return data
+
+    @classmethod
+    def from_snapshot(cls, data: dict) -> "EventRule":
+        snapshot = dict(data)
+        targets = {
+            target_id: EventTarget.from_snapshot(target_data)
+            for target_id, target_data in snapshot.pop("targets", {}).items()
+        }
+        allowed = {field.name for field in fields(cls)}
+        rule = cls(**{key: value for key, value in snapshot.items() if key in allowed})
+        rule.targets = targets
+        return rule
+
 
 @dataclass
 class EventArchive:
@@ -68,6 +96,18 @@ class EventArchive:
     def arn(self) -> str:
         return f"arn:aws:events:{self.region}:{self.account_id}:archive/{self.name}"
 
+    def snapshot_state(self) -> dict:
+        data = asdict(self)
+        data["events"] = copy.deepcopy(self.events)
+        return data
+
+    @classmethod
+    def from_snapshot(cls, data: dict) -> "EventArchive":
+        snapshot = dict(data)
+        snapshot["events"] = copy.deepcopy(snapshot.get("events", []))
+        allowed = {field.name for field in fields(cls)}
+        return cls(**{key: value for key, value in snapshot.items() if key in allowed})
+
 
 @dataclass
 class EventReplay:
@@ -86,6 +126,14 @@ class EventReplay:
     def arn(self) -> str:
         return f"arn:aws:events:{self.region}:{self.account_id}:replay/{self.name}"
 
+    def snapshot_state(self) -> dict:
+        return asdict(self)
+
+    @classmethod
+    def from_snapshot(cls, data: dict) -> "EventReplay":
+        allowed = {field.name for field in fields(cls)}
+        return cls(**{key: value for key, value in dict(data).items() if key in allowed})
+
 
 @dataclass
 class EventBus:
@@ -97,6 +145,28 @@ class EventBus:
     @property
     def arn(self) -> str:
         return f"arn:aws:events:{self.region}:{self.account_id}:event-bus/{self.name}"
+
+    def snapshot_state(self) -> dict:
+        return {
+            "name": self.name,
+            "region": self.region,
+            "account_id": self.account_id,
+            "rules": {rule_name: rule.snapshot_state() for rule_name, rule in self.rules.items()},
+        }
+
+    @classmethod
+    def from_snapshot(cls, data: dict) -> "EventBus":
+        snapshot = dict(data)
+        bus = cls(
+            name=snapshot["name"],
+            region=snapshot["region"],
+            account_id=snapshot["account_id"],
+        )
+        bus.rules = {
+            rule_name: EventRule.from_snapshot(rule_data)
+            for rule_name, rule_data in snapshot.get("rules", {}).items()
+        }
+        return bus
 
 
 class EventsStore:
@@ -357,6 +427,54 @@ class EventsStore:
 
     def get_replay(self, name: str) -> EventReplay | None:
         return self.replays.get(name)
+
+    def snapshot_state(self) -> dict:
+        with self.mutex:
+            return {
+                "buses": {bus_name: bus.snapshot_state() for bus_name, bus in self.buses.items()},
+                "archives": {
+                    archive_name: archive.snapshot_state()
+                    for archive_name, archive in self.archives.items()
+                },
+                "replays": {
+                    replay_name: replay.snapshot_state()
+                    for replay_name, replay in self.replays.items()
+                },
+                "tags": copy.deepcopy(self.tags),
+            }
+
+    @classmethod
+    def from_snapshot(cls, data: dict, *, region: str, account_id: str) -> "EventsStore":
+        snapshot = data or {}
+        store = cls()
+        with store.mutex:
+            store.buses = {
+                bus_name: EventBus.from_snapshot(bus_data)
+                for bus_name, bus_data in snapshot.get("buses", {}).items()
+            }
+            store.archives = {
+                archive_name: EventArchive.from_snapshot(archive_data)
+                for archive_name, archive_data in snapshot.get("archives", {}).items()
+            }
+            store.replays = {
+                replay_name: EventReplay.from_snapshot(replay_data)
+                for replay_name, replay_data in snapshot.get("replays", {}).items()
+            }
+            store.tags = copy.deepcopy(snapshot.get("tags", {}))
+            if "default" not in store.buses:
+                store.buses["default"] = EventBus(
+                    name="default",
+                    region=region,
+                    account_id=account_id,
+                )
+            else:
+                default_bus = store.buses["default"]
+                if default_bus.region != region or default_bus.account_id != account_id:
+                    raise ValueError(
+                        f"default bus identity {default_bus.account_id}/{default_bus.region} "
+                        f"does not match store key {account_id}/{region}"
+                    )
+        return store
 
     # -- Tag operations --
 

--- a/src/robotocore/services/events/provider.py
+++ b/src/robotocore/services/events/provider.py
@@ -20,8 +20,9 @@ from robotocore.services.events.models import EventsStore
 
 logger = logging.getLogger(__name__)
 
-_stores: dict[str, EventsStore] = {}
+_stores: dict[tuple[str, str], EventsStore] = {}
 _store_lock = threading.Lock()
+_default_state_handler_registered = False
 
 # Invocation log for cross-service target dispatch (useful for testing)
 _invocation_log: list[dict] = []
@@ -56,9 +57,27 @@ def _log_invocation(
         )
 
 
+def register_state_handler(manager=None) -> None:
+    """Register EventBridge native state save/load hooks with state manager."""
+    global _default_state_handler_registered
+
+    is_default_manager = manager is None
+    if manager is None:
+        if _default_state_handler_registered:
+            return
+        from robotocore.state.manager import get_state_manager
+
+        manager = get_state_manager()
+
+    manager.register_native_handler("events", export_state, load_state)
+    if is_default_manager:
+        _default_state_handler_registered = True
+
+
 def _get_store(region: str = "us-east-1", account_id: str = "123456789012") -> EventsStore:
+    register_state_handler()
     with _store_lock:
-        key = f"{account_id}:{region}"
+        key = (account_id, region)
         if key not in _stores:
             _stores[key] = EventsStore()
         store = _stores[key]
@@ -1438,3 +1457,72 @@ _ACTION_MAP = {
     "DeleteEndpoint": _delete_endpoint,
     "UpdateEndpoint": _update_endpoint,
 }
+
+
+def export_state() -> dict:
+    """Export EventBridge state as JSON-serializable data."""
+    with _store_lock:
+        items = sorted(_stores.items())
+
+    stores: dict[str, dict[str, dict]] = {}
+    for (account_id, region), store in items:
+        stores.setdefault(account_id, {})[region] = store.snapshot_state()
+
+    return {
+        "schema_version": 1,
+        "stores": stores,
+        "connections": {name: dict(conn) for name, conn in _connections.items()},
+        "api_destinations": {
+            name: dict(destination) for name, destination in _api_destinations.items()
+        },
+        "endpoints": {name: dict(endpoint) for name, endpoint in _endpoints.items()},
+    }
+
+
+def load_state(data: dict) -> None:
+    """Replace in-memory EventBridge state from exported snapshot."""
+    data = data or {}
+    version = data.get("schema_version")
+    if version is not None and version != 1:
+        logger.warning(
+            "events snapshot schema_version=%s; expected 1. "
+            "Loading with v1 logic; fields may be dropped or misinterpreted.",
+            version,
+        )
+    stores_data = data.get("stores", {})
+
+    with _store_lock:
+        _stores.clear()
+        for account_id, regions in stores_data.items():
+            for region, store_data in regions.items():
+                _stores[(account_id, region)] = EventsStore.from_snapshot(
+                    store_data,
+                    region=region,
+                    account_id=account_id,
+                )
+
+    _connections.clear()
+    _connections.update({name: dict(conn) for name, conn in data.get("connections", {}).items()})
+    _api_destinations.clear()
+    _api_destinations.update(
+        {name: dict(destination) for name, destination in data.get("api_destinations", {}).items()}
+    )
+    _endpoints.clear()
+    _endpoints.update(
+        {name: dict(endpoint) for name, endpoint in data.get("endpoints", {}).items()}
+    )
+    # Invocation log is ephemeral debug state; restored service state should start clean.
+    clear_invocation_log()
+
+
+def _reset_for_tests() -> None:
+    """Reset EventBridge provider globals without going through persistence code."""
+    global _default_state_handler_registered
+
+    with _store_lock:
+        _stores.clear()
+    _connections.clear()
+    _api_destinations.clear()
+    _endpoints.clear()
+    clear_invocation_log()
+    _default_state_handler_registered = False

--- a/src/robotocore/services/events/rule_scheduler.py
+++ b/src/robotocore/services/events/rule_scheduler.py
@@ -76,11 +76,7 @@ class EventBridgeRuleScheduler:
         now = time.monotonic()
 
         for store_key, store in list(_stores.items()):
-            # Parse account_id and region from store key "account_id:region"
-            parts = store_key.split(":", 1)
-            if len(parts) != 2:
-                continue
-            account_id, region = parts
+            account_id, region = store_key
 
             for bus in list(store.buses.values()):
                 for rule in list(bus.rules.values()):

--- a/src/robotocore/services/sqs/README.md
+++ b/src/robotocore/services/sqs/README.md
@@ -365,7 +365,7 @@ services:
 
 ### State management
 
-Robotocore state is in-memory. On container restart, all queues and messages are lost. To preserve state across restarts:
+Robotocore SQS state is in-memory by default. If no snapshot or persistence settings are enabled, container restart resets queues and messages. To preserve SQS state across restarts or between test phases:
 
 ```bash
 # Save state
@@ -380,6 +380,8 @@ curl -X POST http://localhost:4566/_robotocore/state/load \
 curl -X POST http://localhost:4566/_robotocore/state/save \
   -d '{"name": "sqs-only", "services": ["sqs"]}'
 ```
+
+You can also configure persistent startup/shutdown save behavior with `ROBOTOCORE_STATE_DIR` and persistence env vars. Native SQS queues, messages, receipts, and FIFO ordering state participate in that existing state-manager flow.
 
 ---
 

--- a/src/robotocore/services/sqs/behavioral.py
+++ b/src/robotocore/services/sqs/behavioral.py
@@ -71,6 +71,17 @@ class PurgeTracker:
         with self._lock:
             self._purge_times.pop(queue_name, None)
 
+    def snapshot_state(self) -> dict[str, float]:
+        """Return a serializable copy of purge cooldown state."""
+        with self._lock:
+            return dict(self._purge_times)
+
+    def restore_state(self, state: dict[str, float] | None) -> None:
+        """Replace purge cooldown state from a snapshot."""
+        with self._lock:
+            self._purge_times.clear()
+            self._purge_times.update(state or {})
+
 
 class QueueDeletedTracker:
     """Tracks recently-deleted queue names with timestamps. Thread-safe."""
@@ -97,6 +108,17 @@ class QueueDeletedTracker:
                 raise QueueDeletedRecentlyError(queue_name)
             # Clean up expired entry
             self._deletion_times.pop(queue_name, None)
+
+    def snapshot_state(self) -> dict[str, float]:
+        """Return a serializable copy of recent deletion state."""
+        with self._lock:
+            return dict(self._deletion_times)
+
+    def restore_state(self, state: dict[str, float] | None) -> None:
+        """Replace recent deletion state from a snapshot."""
+        with self._lock:
+            self._deletion_times.clear()
+            self._deletion_times.update(state or {})
 
 
 class RetentionScanner:

--- a/src/robotocore/services/sqs/models.py
+++ b/src/robotocore/services/sqs/models.py
@@ -1,5 +1,7 @@
 """In-memory SQS data models: messages, queues, and lifecycle management."""
 
+from __future__ import annotations
+
 import base64
 import hashlib
 import heapq
@@ -8,7 +10,7 @@ import threading
 import time
 import uuid
 from collections import OrderedDict
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field, fields
 from queue import Empty, Queue
 
 
@@ -69,6 +71,51 @@ class SqsMessage:
     def __lt__(self, other):
         return self.priority < other.priority
 
+    def snapshot_state(self) -> dict:
+        """Return a serializable snapshot of this message."""
+        return {
+            "message_id": self.message_id,
+            "body": self.body,
+            "md5_of_body": self.md5_of_body,
+            "attributes": dict(self.attributes),
+            "message_attributes": dict(self.message_attributes),
+            "system_attributes": dict(self.system_attributes),
+            "created": self.created,
+            "delay_seconds": self.delay_seconds,
+            "receive_count": self.receive_count,
+            "first_received": self.first_received,
+            "last_received": self.last_received,
+            "visibility_deadline": self.visibility_deadline,
+            "deleted": self.deleted,
+            "receipt_handles": sorted(self.receipt_handles),
+            "message_group_id": self.message_group_id,
+            "message_deduplication_id": self.message_deduplication_id,
+            "sequence_number": self.sequence_number,
+        }
+
+    @classmethod
+    def from_snapshot(cls, data: dict) -> SqsMessage:
+        """Rebuild a message from snapshot data."""
+        return cls(
+            message_id=data["message_id"],
+            body=data["body"],
+            md5_of_body=data["md5_of_body"],
+            attributes=dict(data.get("attributes", {})),
+            message_attributes=dict(data.get("message_attributes", {})),
+            system_attributes=dict(data.get("system_attributes", {})),
+            created=data.get("created", time.time()),
+            delay_seconds=data.get("delay_seconds", 0),
+            receive_count=data.get("receive_count", 0),
+            first_received=data.get("first_received"),
+            last_received=data.get("last_received"),
+            visibility_deadline=data.get("visibility_deadline"),
+            deleted=data.get("deleted", False),
+            receipt_handles=set(data.get("receipt_handles", [])),
+            message_group_id=data.get("message_group_id"),
+            message_deduplication_id=data.get("message_deduplication_id"),
+            sequence_number=data.get("sequence_number"),
+        )
+
 
 @dataclass
 class MessageMoveTask:
@@ -83,6 +130,16 @@ class MessageMoveTask:
     approximate_number_of_messages_to_move: int = 0
     started_timestamp: float = field(default_factory=time.time)
     failure_reason: str | None = None
+
+    def snapshot_state(self) -> dict:
+        """Return a serializable snapshot of this move task."""
+        return asdict(self)
+
+    @classmethod
+    def from_snapshot(cls, data: dict) -> MessageMoveTask:
+        """Rebuild a move task from snapshot data."""
+        allowed = {field.name for field in fields(cls)}
+        return cls(**{key: value for key, value in data.items() if key in allowed})
 
 
 class StandardQueue:
@@ -389,6 +446,77 @@ class StandardQueue:
         raw = f"{_new_id()} {self.arn} {message.message_id} {message.last_received}"
         return base64.b64encode(raw.encode()).decode()
 
+    def _snapshot_locked(self) -> dict:
+        """Build queue snapshot while caller holds self.mutex."""
+        all_messages = {
+            msg_id: message.snapshot_state() for msg_id, message in self._all_messages.items()
+        }
+        return {
+            "queue_type": "fifo" if self.is_fifo else "standard",
+            "created": self.created,
+            "attributes": dict(self.attributes),
+            "tags": dict(self.tags),
+            "last_purged_at": self.last_purged_at,
+            "visible_ids": [msg.message_id for msg in list(self._visible.queue)],
+            "inflight_ids": list(self._inflight.keys()),
+            "delayed_ids": list(self._delayed.keys()),
+            "messages": all_messages,
+            "receipts": {
+                receipt: message.message_id for receipt, message in self._receipts.items()
+            },
+        }
+
+    def snapshot_state(self) -> dict:
+        """Return a serializable snapshot of this queue."""
+        with self.mutex:
+            return self._snapshot_locked()
+
+    @classmethod
+    def from_snapshot(
+        cls,
+        data: dict,
+        *,
+        region: str,
+        account_id: str,
+        name: str,
+    ) -> StandardQueue:
+        """Rebuild a queue from snapshot data."""
+        queue_class = FifoQueue if data.get("queue_type") == "fifo" else StandardQueue
+        queue = queue_class(name, region, account_id, dict(data.get("attributes", {})))
+        messages = {
+            msg_id: SqsMessage.from_snapshot(msg_data)
+            for msg_id, msg_data in data.get("messages", {}).items()
+        }
+        queue.restore_state(data, messages)
+        return queue
+
+    def restore_state(self, data: dict, messages: dict[str, SqsMessage]) -> None:
+        """Replace queue internals from snapshot data."""
+        self.created = data.get("created", time.time())
+        self.tags = dict(data.get("tags", {}))
+        self.last_purged_at = data.get("last_purged_at")
+        self._all_messages = messages
+
+        visible_queue = Queue()
+        for msg_id in data.get("visible_ids", []):
+            if msg_id in messages:
+                visible_queue.put(messages[msg_id])
+        self._visible = visible_queue
+
+        self._inflight = OrderedDict(
+            (msg_id, messages[msg_id])
+            for msg_id in data.get("inflight_ids", [])
+            if msg_id in messages
+        )
+        self._delayed = {
+            msg_id: messages[msg_id] for msg_id in data.get("delayed_ids", []) if msg_id in messages
+        }
+        self._receipts = {
+            receipt: messages[msg_id]
+            for receipt, msg_id in data.get("receipts", {}).items()
+            if msg_id in messages
+        }
+
 
 class FifoQueue(StandardQueue):
     """FIFO SQS queue with message group ordering and deduplication."""
@@ -555,6 +683,51 @@ class FifoQueue(StandardQueue):
         for k in expired:
             del self._dedup_cache[k]
 
+    def snapshot_state(self) -> dict:
+        """Return a serializable snapshot of this FIFO queue."""
+        with self.mutex:
+            queue_data = self._snapshot_locked()
+            queue_data.update(
+                {
+                    "dedup_cache": {
+                        dedup_id: {"message_id": msg.message_id, "timestamp": ts}
+                        for dedup_id, (msg, ts) in self._dedup_cache.items()
+                    },
+                    "message_groups": {
+                        group_id: [msg.message_id for msg in messages]
+                        for group_id, messages in self._message_groups.items()
+                    },
+                    "inflight_groups": sorted(self._inflight_groups),
+                    "queued_groups": sorted(self._queued_groups),
+                    "group_queue": list(self._group_queue.queue),
+                    "sequence_counter": self._sequence_counter,
+                }
+            )
+        return queue_data
+
+    def restore_state(self, data: dict, messages: dict[str, SqsMessage]) -> None:
+        """Replace FIFO internals from snapshot data."""
+        super().restore_state(data, messages)
+
+        self._dedup_cache = {
+            dedup_id: (messages[msg["message_id"]], msg["timestamp"])
+            for dedup_id, msg in data.get("dedup_cache", {}).items()
+            if msg["message_id"] in messages
+        }
+        self._message_groups = {
+            group_id: [messages[msg_id] for msg_id in msg_ids if msg_id in messages]
+            for group_id, msg_ids in data.get("message_groups", {}).items()
+        }
+        for group_messages in self._message_groups.values():
+            heapq.heapify(group_messages)
+        self._inflight_groups = set(data.get("inflight_groups", []))
+        self._queued_groups = set(data.get("queued_groups", []))
+        group_queue = Queue()
+        for group_id in data.get("group_queue", []):
+            group_queue.put(group_id)
+        self._group_queue = group_queue
+        self._sequence_counter = data.get("sequence_counter", 0)
+
 
 class SqsStore:
     """Per-region SQS store managing all queues."""
@@ -701,3 +874,47 @@ class SqsStore:
         if task and task.status == "RUNNING":
             task.status = "CANCELLED"
         return task
+
+    def snapshot_state(self) -> dict:
+        """Return a serializable snapshot of this store."""
+        with self.mutex:
+            queues = {name: queue.snapshot_state() for name, queue in self.queues.items()}
+            move_tasks = {
+                handle: task.snapshot_state() for handle, task in self._move_tasks.items()
+            }
+            recently_deleted = dict(self._recently_deleted)
+
+        return {
+            "queues": queues,
+            "move_tasks": move_tasks,
+            "recently_deleted": recently_deleted,
+        }
+
+    @classmethod
+    def from_snapshot(
+        cls,
+        data: dict,
+        *,
+        region: str,
+        account_id: str,
+    ) -> SqsStore:
+        """Rebuild a store from snapshot data."""
+        store = cls()
+        queues_data = data.get("queues", {})
+        for name, queue_data in queues_data.items():
+            queue = StandardQueue.from_snapshot(
+                queue_data,
+                region=region,
+                account_id=account_id,
+                name=name,
+            )
+            queue._store = store
+            store.queues[name] = queue
+
+        store._move_tasks = {
+            handle: MessageMoveTask.from_snapshot(task_data)
+            for handle, task_data in data.get("move_tasks", {}).items()
+        }
+        store._recently_deleted = dict(data.get("recently_deleted", {}))
+        store.requeue_all()
+        return store

--- a/src/robotocore/services/sqs/provider.py
+++ b/src/robotocore/services/sqs/provider.py
@@ -32,6 +32,7 @@ _stores: dict[tuple[str, str], SqsStore] = {}
 _store_lock = threading.Lock()
 _worker_started = False
 _worker_lock = threading.Lock()
+_default_state_handler_registered = False
 
 # Behavioral fidelity singletons
 _purge_tracker = PurgeTracker()
@@ -42,7 +43,25 @@ _retention_scanner = RetentionScanner()
 logger = logging.getLogger(__name__)
 
 
+def register_state_handler(manager=None) -> None:
+    """Register SQS native state save/load hooks with a state manager."""
+    global _default_state_handler_registered
+
+    is_default_manager = manager is None
+    if manager is None:
+        if _default_state_handler_registered:
+            return
+        from robotocore.state.manager import get_state_manager
+
+        manager = get_state_manager()
+
+    manager.register_native_handler("sqs", export_state, load_state)
+    if is_default_manager:
+        _default_state_handler_registered = True
+
+
 def _get_store(region: str = "us-east-1", account_id: str = DEFAULT_ACCOUNT_ID) -> SqsStore:
+    register_state_handler()
     key = (account_id, region)
     with _store_lock:
         if key not in _stores:
@@ -906,3 +925,60 @@ _ACTION_MAP: dict[str, Callable] = {
     "CancelMessageMoveTask": _cancel_message_move_task,
     "ListMessageMoveTasks": _list_message_move_tasks,
 }
+
+
+def export_state() -> dict:
+    """Export all SQS store state as JSON-serializable data."""
+    with _store_lock:
+        items = sorted(_stores.items())
+
+    stores: dict[str, dict[str, dict]] = {}
+    for (account_id, region), store in items:
+        stores.setdefault(account_id, {})[region] = store.snapshot_state()
+
+    return {
+        "schema_version": 1,
+        "stores": stores,
+        "behavioral": {
+            "purge_times": _purge_tracker.snapshot_state(),
+            "deletion_times": _delete_tracker.snapshot_state(),
+        },
+    }
+
+
+def load_state(data: dict) -> None:
+    """Replace in-memory SQS state from a previously exported snapshot."""
+    data = data or {}
+    version = data.get("schema_version")
+    if version is not None and version != 1:
+        logger.warning(
+            "sqs snapshot schema_version=%s; expected 1. "
+            "Loading with v1 logic; fields may be dropped or misinterpreted.",
+            version,
+        )
+    stores_data = data.get("stores", {})
+    behavioral = data.get("behavioral", {})
+
+    with _store_lock:
+        _stores.clear()
+        for account_id, regions in stores_data.items():
+            for region, store_data in regions.items():
+                _stores[(account_id, region)] = SqsStore.from_snapshot(
+                    store_data,
+                    region=region,
+                    account_id=account_id,
+                )
+
+    _purge_tracker.restore_state(behavioral.get("purge_times"))
+    _delete_tracker.restore_state(behavioral.get("deletion_times"))
+
+
+def _reset_for_tests() -> None:
+    """Reset SQS provider globals without going through persistence code."""
+    global _default_state_handler_registered
+
+    with _store_lock:
+        _stores.clear()
+    _purge_tracker.restore_state({})
+    _delete_tracker.restore_state({})
+    _default_state_handler_registered = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,23 @@
 """Shared test fixtures for robotocore."""
 
+from collections.abc import Callable
+
 import pytest
 from starlette.testclient import TestClient
 
+import robotocore.state.manager as _state_manager
 from robotocore.gateway.app import app
+
+
+def reset_state_manager_singleton() -> None:
+    """Reset global StateManager singleton for test isolation."""
+    _state_manager._manager = None
+
+
+@pytest.fixture
+def reset_state_manager_singleton_fixture() -> Callable[[], None]:
+    """Callable fixture for tests that need fresh global StateManager singleton."""
+    return reset_state_manager_singleton
 
 
 @pytest.fixture

--- a/tests/unit/services/events/test_persistence.py
+++ b/tests/unit/services/events/test_persistence.py
@@ -1,0 +1,418 @@
+"""Unit tests for EventBridge native state persistence."""
+
+import json
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from robotocore.services.events.models import EventsStore
+from robotocore.services.events.provider import (
+    _create_api_destination,
+    _create_connection,
+    _create_endpoint,
+    _describe_api_destination,
+    _describe_connection,
+    _endpoints,
+    _get_store,
+    _reset_for_tests,
+    export_state,
+    load_state,
+    register_state_handler,
+)
+from robotocore.services.events.rule_scheduler import EventBridgeRuleScheduler
+from robotocore.state.manager import StateManager
+
+
+@pytest.fixture(autouse=True)
+def _clear_events_state(reset_state_manager_singleton_fixture):
+    """Reset EventBridge globals and state-manager singleton around each test."""
+    reset_state_manager_singleton_fixture()
+    _reset_for_tests()
+    yield
+    _reset_for_tests()
+    reset_state_manager_singleton_fixture()
+
+
+class TestEventBridgeRoundTrip:
+    def test_round_trip_preserves_buses_rules_targets_archives_replays_and_tags(self):
+        store = _get_store("us-east-1", "111111111111")
+        bus = store.create_event_bus("orders", "us-east-1", "111111111111")
+        rule = store.put_rule(
+            "route-orders",
+            "orders",
+            "us-east-1",
+            "111111111111",
+            event_pattern={"source": ["app.orders"]},
+            description="route order events",
+        )
+        store.put_targets(
+            "route-orders",
+            "orders",
+            [
+                {
+                    "Id": "orders-target",
+                    "Arn": "arn:aws:sqs:us-east-1:111111111111:orders-queue",
+                    "InputTransformer": {
+                        "InputPathsMap": {"orderId": "$.detail.orderId"},
+                        "InputTemplate": '{"orderId": <orderId>}',
+                    },
+                    "DeadLetterConfig": {"Arn": "arn:aws:sqs:us-east-1:111111111111:orders-dlq"},
+                }
+            ],
+        )
+        store.tag_resource(bus.arn, [{"Key": "env", "Value": "test"}])
+        store.tag_resource(rule.arn, [{"Key": "team", "Value": "platform"}])
+
+        archive = store.create_archive(
+            "orders-archive",
+            bus.arn,
+            "us-east-1",
+            "111111111111",
+            description="archive order events",
+            event_pattern={"detail-type": ["OrderCreated"]},
+        )
+        event = {
+            "version": "0",
+            "id": "evt-1",
+            "source": "app.orders",
+            "account": "111111111111",
+            "time": "2026-04-21T00:00:00Z",
+            "region": "us-east-1",
+            "resources": [],
+            "detail-type": "OrderCreated",
+            "detail": {"orderId": "o-1"},
+        }
+        store.archive_event(event, "orders")
+        replay = store.create_replay(
+            "orders-replay",
+            archive.arn,
+            "us-east-1",
+            "111111111111",
+            destination_arn=bus.arn,
+            start_time=0,
+            end_time=9999999999,
+        )
+        replay.state = "COMPLETED"
+        replay.events_replayed = 1
+
+        snapshot = export_state()
+        assert snapshot["schema_version"] == 1
+        assert (
+            snapshot["stores"]["111111111111"]["us-east-1"]["buses"]["orders"]["name"] == "orders"
+        )
+
+        load_state(snapshot)
+
+        restored_store = _get_store("us-east-1", "111111111111")
+        restored_bus = restored_store.get_bus("orders")
+        assert restored_bus is not None
+        assert restored_store.get_bus("default") is not None
+
+        restored_rule = restored_store.get_rule("route-orders", "orders")
+        assert restored_rule is not None
+        assert restored_rule.description == "route order events"
+        assert restored_rule.event_pattern == {"source": ["app.orders"]}
+
+        restored_target = restored_rule.targets["orders-target"]
+        assert restored_target.input_transformer == {
+            "InputPathsMap": {"orderId": "$.detail.orderId"},
+            "InputTemplate": '{"orderId": <orderId>}',
+        }
+        assert restored_target.dead_letter_config == {
+            "Arn": "arn:aws:sqs:us-east-1:111111111111:orders-dlq"
+        }
+
+        restored_archive = restored_store.get_archive("orders-archive")
+        assert restored_archive is not None
+        assert restored_archive.description == "archive order events"
+        assert restored_archive.events == [event]
+        assert restored_archive.event_count == 1
+        assert restored_archive.size_bytes == len(json.dumps(event).encode())
+
+        restored_replay = restored_store.get_replay("orders-replay")
+        assert restored_replay is not None
+        assert restored_replay.archive_arn == archive.arn
+        assert restored_replay.events_replayed == 1
+
+        assert restored_store.list_tags_for_resource(bus.arn) == [{"Key": "env", "Value": "test"}]
+        assert restored_store.list_tags_for_resource(rule.arn) == [
+            {"Key": "team", "Value": "platform"}
+        ]
+
+    def test_round_trip_preserves_multi_account_and_region_isolation(self):
+        east = _get_store("us-east-1", "111111111111")
+        west = _get_store("eu-west-1", "111111111111")
+        other = _get_store("us-east-1", "222222222222")
+
+        east.create_event_bus("shared-name", "us-east-1", "111111111111")
+        west.create_event_bus("shared-name", "eu-west-1", "111111111111")
+        other.create_event_bus("shared-name", "us-east-1", "222222222222")
+
+        load_state(export_state())
+
+        restored_east = _get_store("us-east-1", "111111111111")
+        restored_west = _get_store("eu-west-1", "111111111111")
+        restored_other = _get_store("us-east-1", "222222222222")
+
+        assert restored_east.get_bus("shared-name") is not None
+        assert restored_east.get_bus("shared-name").arn == (
+            "arn:aws:events:us-east-1:111111111111:event-bus/shared-name"
+        )
+        assert restored_west.get_bus("shared-name") is not None
+        assert restored_west.get_bus("shared-name").arn == (
+            "arn:aws:events:eu-west-1:111111111111:event-bus/shared-name"
+        )
+        assert restored_other.get_bus("shared-name") is not None
+        assert restored_other.get_bus("shared-name").arn == (
+            "arn:aws:events:us-east-1:222222222222:event-bus/shared-name"
+        )
+
+    def test_scheduled_rule_still_fires_after_restore(self):
+        store = _get_store("us-east-1", "111111111111")
+        store.put_rule(
+            "scheduled-rule",
+            "default",
+            "us-east-1",
+            "111111111111",
+            schedule_expression="rate(1 minute)",
+        )
+        store.put_targets(
+            "scheduled-rule",
+            "default",
+            [{"Id": "scheduled-target", "Arn": "arn:aws:sqs:us-east-1:111111111111:q"}],
+        )
+
+        load_state(export_state())
+
+        scheduler = EventBridgeRuleScheduler()
+        with patch("robotocore.services.events.provider._dispatch_to_targets") as mock_dispatch:
+            # Scheduler cache is intentionally not persisted; after restore it starts fresh.
+            scheduler._check_all_rules()
+
+        assert mock_dispatch.call_count == 1
+        rule, event, region, account_id, restored_store = mock_dispatch.call_args[0]
+        assert rule.name == "scheduled-rule"
+        assert event["detail-type"] == "Scheduled Event"
+        assert region == "us-east-1"
+        assert account_id == "111111111111"
+        assert restored_store.get_rule("scheduled-rule") is not None
+
+    @pytest.mark.parametrize("snapshot", [None, {}])
+    def test_load_state_with_empty_snapshot_clears_existing_state(self, snapshot):
+        store = _get_store("us-east-1", "111111111111")
+        store.create_event_bus("temporary", "us-east-1", "111111111111")
+
+        load_state(snapshot)
+
+        restored_store = _get_store("us-east-1", "111111111111")
+        assert restored_store.get_bus("temporary") is None
+        assert restored_store.get_bus("default") is not None
+
+    def test_load_state_replaces_existing_state(self):
+        original = _get_store("us-east-1", "111111111111")
+        original.create_event_bus("bus-a", "us-east-1", "111111111111")
+        snapshot = export_state()
+
+        mutated = _get_store("us-east-1", "111111111111")
+        mutated.create_event_bus("bus-b", "us-east-1", "111111111111")
+        _get_store("eu-west-1", "222222222222").create_event_bus(
+            "other-bus",
+            "eu-west-1",
+            "222222222222",
+        )
+
+        load_state(snapshot)
+
+        restored = _get_store("us-east-1", "111111111111")
+        assert restored.get_bus("bus-a") is not None
+        assert restored.get_bus("bus-b") is None
+        assert _get_store("eu-west-1", "222222222222").get_bus("other-bus") is None
+
+    def test_load_state_ignores_unknown_top_level_keys(self):
+        store = _get_store("us-east-1", "111111111111")
+        store.create_event_bus("known-bus", "us-east-1", "111111111111")
+        snapshot = export_state()
+        snapshot["unknown_future_key"] = {"version": 2}
+
+        load_state(snapshot)
+
+        restored = _get_store("us-east-1", "111111111111")
+        assert restored.get_bus("known-bus") is not None
+
+    def test_load_state_warns_on_future_schema_version(self, caplog):
+        store = _get_store("us-east-1", "111111111111")
+        store.create_event_bus("versioned-bus", "us-east-1", "111111111111")
+        snapshot = export_state()
+        snapshot["schema_version"] = 2
+
+        with caplog.at_level(logging.WARNING):
+            load_state(snapshot)
+
+        assert "events snapshot schema_version=2; expected 1" in caplog.text
+        restored = _get_store("us-east-1", "111111111111")
+        assert restored.get_bus("versioned-bus") is not None
+
+    def test_from_snapshot_raises_on_default_bus_identity_mismatch(self):
+        snapshot = {
+            "buses": {
+                "default": {
+                    "name": "default",
+                    "region": "eu-west-1",
+                    "account_id": "111111111111",
+                    "rules": {},
+                }
+            },
+            "archives": {},
+            "replays": {},
+            "tags": {},
+        }
+
+        with pytest.raises(
+            ValueError,
+            match=(
+                "default bus identity 111111111111/eu-west-1 does not match store key "
+                "111111111111/us-east-1"
+            ),
+        ):
+            EventsStore.from_snapshot(snapshot, region="us-east-1", account_id="111111111111")
+
+
+class TestDiskRoundTripViaStateManager:
+    def test_global_connections_destinations_and_endpoints_survive_disk_round_trip(self, tmp_path):
+        store = _get_store("ap-southeast-2", "333333333333")
+
+        connection = _create_connection(
+            store,
+            {
+                "Name": "erp-connection",
+                "AuthorizationType": "API_KEY",
+                "AuthParameters": {
+                    "ApiKeyAuthParameters": {
+                        "ApiKeyName": "x-api-key",
+                        "ApiKeyValue": "secret",
+                    }
+                },
+            },
+            "ap-southeast-2",
+            "333333333333",
+        )
+        api_destination = _create_api_destination(
+            store,
+            {
+                "Name": "erp-destination",
+                "ConnectionArn": connection["ConnectionArn"],
+                "InvocationEndpoint": "https://example.test/orders",
+                "HttpMethod": "POST",
+                "InvocationRateLimitPerSecond": 42,
+            },
+            "ap-southeast-2",
+            "333333333333",
+        )
+        endpoint = _create_endpoint(
+            store,
+            {
+                "Name": "replica-endpoint",
+                "RoutingConfig": {"FailoverConfig": {"Primary": {"HealthCheck": "ok"}}},
+                "ReplicationConfig": {"State": "ENABLED"},
+                "EventBuses": [
+                    {
+                        "EventBusArn": (
+                            "arn:aws:events:ap-southeast-2:333333333333:event-bus/default"
+                        )
+                    }
+                ],
+                "RoleArn": "arn:aws:iam::333333333333:role/events-role",
+                "Description": "replica endpoint",
+            },
+            "ap-southeast-2",
+            "333333333333",
+        )
+
+        manager = StateManager(state_dir=str(tmp_path))
+        register_state_handler(manager)
+        manager.save(name="events-cache", services=["events"])
+
+        _reset_for_tests()
+        manager.load(name="events-cache", services=["events"])
+
+        snapshot = export_state()
+        assert snapshot["schema_version"] == 1
+        assert "connections" in snapshot
+        assert "api_destinations" in snapshot
+        assert "endpoints" in snapshot
+
+        restored_connection = _describe_connection(
+            _get_store("ap-southeast-2", "333333333333"),
+            {"Name": "erp-connection"},
+            "ap-southeast-2",
+            "333333333333",
+        )
+        restored_destination = _describe_api_destination(
+            _get_store("ap-southeast-2", "333333333333"),
+            {"Name": "erp-destination"},
+            "ap-southeast-2",
+            "333333333333",
+        )
+
+        assert restored_connection["ConnectionArn"] == connection["ConnectionArn"]
+        assert restored_connection["AuthorizationType"] == "API_KEY"
+        assert restored_destination["ApiDestinationArn"] == api_destination["ApiDestinationArn"]
+        assert restored_destination["InvocationRateLimitPerSecond"] == 42
+        assert _endpoints["replica-endpoint"]["EndpointArn"] == endpoint["Arn"]
+
+    def test_future_snapshot_fields_on_dataclasses_are_ignored(self):
+        store = _get_store("us-east-1", "111111111111")
+        bus = store.create_event_bus("future-bus", "us-east-1", "111111111111")
+        store.put_rule(
+            "future-rule",
+            "future-bus",
+            "us-east-1",
+            "111111111111",
+            event_pattern={"source": ["future.app"]},
+        )
+        store.put_targets(
+            "future-rule",
+            "future-bus",
+            [{"Id": "future-target", "Arn": "arn:aws:sqs:us-east-1:111111111111:future-q"}],
+        )
+        archive = store.create_archive(
+            "future-archive",
+            bus.arn,
+            "us-east-1",
+            "111111111111",
+        )
+        store.create_replay(
+            "future-replay",
+            archive.arn,
+            "us-east-1",
+            "111111111111",
+            destination_arn=bus.arn,
+            start_time=0,
+            end_time=1,
+        )
+
+        snapshot = export_state()
+        bus_snapshot = snapshot["stores"]["111111111111"]["us-east-1"]["buses"]["future-bus"]
+        rule_snapshot = bus_snapshot["rules"]["future-rule"]
+        target_snapshot = rule_snapshot["targets"]["future-target"]
+        archive_snapshot = snapshot["stores"]["111111111111"]["us-east-1"]["archives"][
+            "future-archive"
+        ]
+        replay_snapshot = snapshot["stores"]["111111111111"]["us-east-1"]["replays"][
+            "future-replay"
+        ]
+
+        bus_snapshot["future_bus_field"] = True
+        rule_snapshot["future_rule_field"] = True
+        target_snapshot["future_target_field"] = True
+        archive_snapshot["future_archive_field"] = True
+        replay_snapshot["future_replay_field"] = True
+
+        load_state(snapshot)
+
+        restored = _get_store("us-east-1", "111111111111")
+        assert restored.get_bus("future-bus") is not None
+        assert restored.get_rule("future-rule", "future-bus") is not None
+        assert restored.get_archive("future-archive") is not None
+        assert restored.get_replay("future-replay") is not None

--- a/tests/unit/services/events/test_rule_scheduler.py
+++ b/tests/unit/services/events/test_rule_scheduler.py
@@ -91,7 +91,7 @@ class TestEventBridgeRuleScheduler:
         # Patch _stores to include our test store
         with patch(
             "robotocore.services.events.provider._stores",
-            {"123456789012:us-east-1": store},
+            {("123456789012", "us-east-1"): store},
         ):
             scheduler._check_all_rules()
 
@@ -114,7 +114,7 @@ class TestEventBridgeRuleScheduler:
         scheduler = EventBridgeRuleScheduler()
         with patch(
             "robotocore.services.events.provider._stores",
-            {"123456789012:us-east-1": store},
+            {("123456789012", "us-east-1"): store},
         ):
             scheduler._check_all_rules()
 
@@ -131,7 +131,7 @@ class TestEventBridgeRuleScheduler:
         scheduler = EventBridgeRuleScheduler()
         with patch(
             "robotocore.services.events.provider._stores",
-            {"123456789012:us-east-1": store},
+            {("123456789012", "us-east-1"): store},
         ):
             scheduler._check_all_rules()
 
@@ -143,7 +143,7 @@ class TestEventBridgeRuleScheduler:
         store = self._make_store_with_scheduled_rule(schedule_expr="rate(1 minute)")
 
         scheduler = EventBridgeRuleScheduler()
-        stores_dict = {"123456789012:us-east-1": store}
+        stores_dict = {("123456789012", "us-east-1"): store}
 
         with patch("robotocore.services.events.provider._stores", stores_dict):
             # First check — should fire
@@ -160,14 +160,14 @@ class TestEventBridgeRuleScheduler:
         store = self._make_store_with_scheduled_rule(schedule_expr="rate(1 minute)")
 
         scheduler = EventBridgeRuleScheduler()
-        stores_dict = {"123456789012:us-east-1": store}
+        stores_dict = {("123456789012", "us-east-1"): store}
 
         with patch("robotocore.services.events.provider._stores", stores_dict):
             scheduler._check_all_rules()
             assert mock_dispatch.call_count == 1
 
             # Manually set last-fired to >60s ago
-            key = ("123456789012:us-east-1", "default", "test-rule")
+            key = (("123456789012", "us-east-1"), "default", "test-rule")
             scheduler._last_fired[key] = time.monotonic() - 61
 
             scheduler._check_all_rules()
@@ -181,7 +181,7 @@ class TestEventBridgeRuleScheduler:
         scheduler = EventBridgeRuleScheduler()
         with patch(
             "robotocore.services.events.provider._stores",
-            {"123456789012:us-east-1": store},
+            {("123456789012", "us-east-1"): store},
         ):
             scheduler._check_all_rules()
 
@@ -206,7 +206,7 @@ class TestEventBridgeRuleScheduler:
         scheduler = EventBridgeRuleScheduler()
         with patch(
             "robotocore.services.events.provider._stores",
-            {"123456789012:us-east-1": store},
+            {("123456789012", "us-east-1"): store},
         ):
             scheduler._check_all_rules()
 

--- a/tests/unit/services/sqs/test_persistence.py
+++ b/tests/unit/services/sqs/test_persistence.py
@@ -1,0 +1,440 @@
+"""Unit tests for SQS native state persistence."""
+
+import hashlib
+import json
+import logging
+import time
+
+import pytest
+
+import robotocore.services.sqs.provider as sqs_provider_module
+from robotocore.services.sqs.behavioral import (
+    PurgeQueueInProgressError,
+    QueueDeletedRecentlyError,
+)
+from robotocore.services.sqs.models import FifoQueue, SqsMessage, StandardQueue
+from robotocore.services.sqs.provider import (
+    _get_store,
+    _reset_for_tests,
+    export_state,
+    load_state,
+    register_state_handler,
+)
+from robotocore.state.manager import StateManager
+
+
+@pytest.fixture(autouse=True)
+def _clear_sqs_state(reset_state_manager_singleton_fixture):
+    """Reset global SQS state and state-manager singleton around each test."""
+    reset_state_manager_singleton_fixture()
+    _reset_for_tests()
+    yield
+    _reset_for_tests()
+    reset_state_manager_singleton_fixture()
+
+
+def _msg(
+    message_id: str,
+    body: str,
+    *,
+    delay_seconds: int = 0,
+    created: float | None = None,
+) -> SqsMessage:
+    message = SqsMessage(
+        message_id=message_id,
+        body=body,
+        md5_of_body=hashlib.md5(body.encode()).hexdigest(),
+        delay_seconds=delay_seconds,
+    )
+    if created is not None:
+        message.created = created
+    return message
+
+
+def _fifo_msg(
+    message_id: str,
+    body: str,
+    *,
+    group_id: str,
+    dedup_id: str,
+    created: float | None = None,
+) -> SqsMessage:
+    message = _msg(message_id, body, created=created)
+    message.message_group_id = group_id
+    message.message_deduplication_id = dedup_id
+    return message
+
+
+class TestStandardQueueRoundTrip:
+    def test_round_trip_preserves_visible_inflight_and_delayed(self):
+        store = _get_store("ap-southeast-2", "111111111111")
+        queue = store.create_queue(
+            "persist-standard",
+            "ap-southeast-2",
+            "111111111111",
+            {"VisibilityTimeout": "45"},
+        )
+        assert queue is not None
+        queue.tags["env"] = "test"
+
+        queue.put(_msg("inflight-1", "inflight-body"))
+        receipt = queue.receive(max_messages=1, visibility_timeout=60)[0][1]
+        queue.put(_msg("visible-1", "visible-body"))
+        queue.put(_msg("delayed-1", "delayed-body", delay_seconds=30))
+
+        load_state(export_state())
+
+        restored = _get_store("ap-southeast-2", "111111111111").get_queue("persist-standard")
+        assert restored is not None
+        assert restored.tags == {"env": "test"}
+
+        attrs = restored.get_attributes()
+        assert attrs["ApproximateNumberOfMessages"] == "1"
+        assert attrs["ApproximateNumberOfMessagesNotVisible"] == "1"
+        assert attrs["ApproximateNumberOfMessagesDelayed"] == "1"
+
+        assert restored.change_visibility(receipt, 0) is True
+        received = restored.receive(max_messages=10, visibility_timeout=0)
+        bodies = {message.body for message, _ in received}
+        assert bodies == {"inflight-body", "visible-body"}
+
+    def test_receipt_handle_still_usable_after_restore(self):
+        store = _get_store("us-east-1", "111111111111")
+        queue = store.create_queue("receipt-queue", "us-east-1", "111111111111")
+        assert queue is not None
+
+        queue.put(_msg("receipt-msg", "body"))
+        receipt = queue.receive(max_messages=1, visibility_timeout=60)[0][1]
+
+        load_state(export_state())
+
+        restored = _get_store("us-east-1", "111111111111").get_queue("receipt-queue")
+        assert restored is not None
+        assert restored.delete_message(receipt) is True
+
+        attrs = restored.get_attributes()
+        assert attrs["ApproximateNumberOfMessages"] == "0"
+        assert attrs["ApproximateNumberOfMessagesNotVisible"] == "0"
+
+    def test_inflight_with_expired_visibility_is_redelivered_after_restore(self):
+        store = _get_store("us-east-1", "111111111111")
+        queue = store.create_queue("expired-inflight", "us-east-1", "111111111111")
+        assert queue is not None
+
+        queue.put(_msg("expired-msg", "body"))
+        queue.receive(max_messages=1, visibility_timeout=30)
+        inflight_message = next(iter(queue._inflight.values()))
+        inflight_message.visibility_deadline = time.time() - 1
+
+        load_state(export_state())
+
+        restored = _get_store("us-east-1", "111111111111").get_queue("expired-inflight")
+        assert restored is not None
+        received = restored.receive(max_messages=1, visibility_timeout=30)
+        assert [message.body for message, _ in received] == ["body"]
+
+    def test_round_trip_is_idempotent(self):
+        store = _get_store("us-east-1", "111111111111")
+        queue = store.create_queue(
+            "idempotent-queue",
+            "us-east-1",
+            "111111111111",
+            {"VisibilityTimeout": "45"},
+        )
+        assert queue is not None
+        queue.tags["env"] = "test"
+        queue.put(_msg("visible-1", "visible-body"))
+        queue.put(_msg("delayed-1", "delayed-body", delay_seconds=15))
+        sqs_provider_module._purge_tracker.check_and_record("idempotent-purged")
+
+        snapshot = export_state()
+        load_state(snapshot)
+
+        assert export_state() == snapshot
+
+    def test_dlq_redrive_policy_survives_restore(self):
+        store = _get_store("us-east-1", "111111111111")
+        dlq = store.create_queue("orders-dlq", "us-east-1", "111111111111")
+        assert dlq is not None
+        queue = store.create_queue(
+            "orders",
+            "us-east-1",
+            "111111111111",
+            {
+                "RedrivePolicy": json.dumps(
+                    {
+                        "maxReceiveCount": "1",
+                        "deadLetterTargetArn": dlq.arn,
+                    }
+                )
+            },
+        )
+        assert queue is not None
+
+        queue.put(_msg("dlq-msg", "body"))
+        load_state(export_state())
+
+        restored_store = _get_store("us-east-1", "111111111111")
+        restored_queue = restored_store.get_queue("orders")
+        restored_dlq = restored_store.get_queue("orders-dlq")
+        assert restored_queue is not None
+        assert restored_dlq is not None
+
+        restored_queue.receive(max_messages=1, visibility_timeout=0)
+        restored_queue.receive(max_messages=1, visibility_timeout=0)
+
+        dlq_received = restored_dlq.receive(max_messages=1, visibility_timeout=30)
+        assert [message.body for message, _ in dlq_received] == ["body"]
+
+
+class TestMultiStoreRoundTrip:
+    def test_round_trip_preserves_multi_account_and_region_isolation(self):
+        east_store = _get_store("us-east-1", "111111111111")
+        west_store = _get_store("eu-west-1", "111111111111")
+        other_store = _get_store("us-east-1", "222222222222")
+
+        east_store.create_queue("east-queue", "us-east-1", "111111111111")
+        west_store.create_queue("west-queue", "eu-west-1", "111111111111")
+        other_store.create_queue("other-queue", "us-east-1", "222222222222")
+
+        load_state(export_state())
+
+        restored_east = _get_store("us-east-1", "111111111111")
+        restored_west = _get_store("eu-west-1", "111111111111")
+        restored_other = _get_store("us-east-1", "222222222222")
+
+        assert restored_east.get_queue("east-queue") is not None
+        assert restored_west.get_queue("west-queue") is not None
+        assert restored_other.get_queue("other-queue") is not None
+        assert restored_east.get_queue("other-queue") is None
+        assert restored_other.get_queue("east-queue") is None
+
+    def test_round_trip_preserves_move_tasks_and_recently_deleted(self):
+        store = _get_store("us-east-1", "111111111111")
+        source = store.create_queue("source-queue", "us-east-1", "111111111111")
+        destination = store.create_queue("destination-queue", "us-east-1", "111111111111")
+        deleted = store.create_queue("deleted-queue", "us-east-1", "111111111111")
+        assert source is not None
+        assert destination is not None
+        assert deleted is not None
+
+        source.put(_msg("move-1", "move-body"))
+        move_task = store.start_message_move_task(source.arn, destination.arn)
+        assert store.delete_queue("deleted-queue") is True
+
+        load_state(export_state())
+
+        restored_store = _get_store("us-east-1", "111111111111")
+        restored_destination = restored_store.get_queue("destination-queue")
+        restored_source = restored_store.get_queue("source-queue")
+        assert restored_destination is not None
+        assert restored_source is not None
+
+        restored_move_task = restored_store.get_message_move_task(move_task.task_handle)
+        assert restored_move_task is not None
+        assert restored_move_task.status == "COMPLETED"
+        assert restored_move_task.approximate_number_of_messages_moved == 1
+        assert restored_destination.get_attributes()["ApproximateNumberOfMessages"] == "1"
+        assert restored_source.get_attributes()["ApproximateNumberOfMessages"] == "0"
+        assert restored_source.get_all_messages() == []
+        assert "deleted-queue" in restored_store._recently_deleted
+
+
+class TestBehavioralTrackerRoundTrip:
+    def test_round_trip_preserves_purge_tracker(self):
+        sqs_provider_module._purge_tracker.check_and_record("purged-queue")
+
+        load_state(export_state())
+
+        with pytest.raises(PurgeQueueInProgressError):
+            sqs_provider_module._purge_tracker.check_and_record("purged-queue")
+
+    def test_round_trip_preserves_recently_deleted_tracker(self):
+        sqs_provider_module._delete_tracker.record_deletion("recently-deleted")
+
+        load_state(export_state())
+
+        with pytest.raises(QueueDeletedRecentlyError):
+            sqs_provider_module._delete_tracker.check_create("recently-deleted")
+
+    def test_load_state_warns_on_future_schema_version(self, caplog):
+        store = _get_store("us-east-1", "111111111111")
+        queue = store.create_queue("versioned-queue", "us-east-1", "111111111111")
+        assert queue is not None
+
+        snapshot = export_state()
+        snapshot["schema_version"] = 2
+
+        with caplog.at_level(logging.WARNING):
+            load_state(snapshot)
+
+        assert "sqs snapshot schema_version=2; expected 1" in caplog.text
+        restored = _get_store("us-east-1", "111111111111")
+        assert restored.get_queue("versioned-queue") is not None
+
+
+class TestFifoQueueRoundTrip:
+    def test_disk_round_trip_preserves_group_order_dedup_tags_and_attributes(self, tmp_path):
+        store = _get_store("us-east-1", "222222222222")
+        queue = store.create_queue(
+            "orders.fifo",
+            "us-east-1",
+            "222222222222",
+            {"FifoQueue": "true", "VisibilityTimeout": "45"},
+        )
+        assert isinstance(queue, FifoQueue)
+        queue.tags["env"] = "test"
+
+        queue.put(
+            _fifo_msg(
+                "fifo-1",
+                "alpha-first",
+                group_id="alpha",
+                dedup_id="dedup-1",
+                created=1.0,
+            )
+        )
+        queue.put(
+            _fifo_msg(
+                "fifo-2",
+                "alpha-second",
+                group_id="alpha",
+                dedup_id="dedup-2",
+                created=2.0,
+            )
+        )
+        queue.put(
+            _fifo_msg(
+                "fifo-3",
+                "beta-first",
+                group_id="beta",
+                dedup_id="dedup-3",
+                created=3.0,
+            )
+        )
+
+        manager = StateManager(state_dir=str(tmp_path))
+        register_state_handler(manager)
+        manager.save(name="sqs-cache", services=["sqs"])
+
+        _reset_for_tests()
+        manager.load(name="sqs-cache", services=["sqs"])
+        restored = _get_store("us-east-1", "222222222222").get_queue("orders.fifo")
+        assert isinstance(restored, FifoQueue)
+        assert restored.tags == {"env": "test"}
+        assert restored.attributes["VisibilityTimeout"] == "45"
+
+        received = restored.receive(max_messages=10, visibility_timeout=30)
+        assert [message.body for message, _ in received] == [
+            "alpha-first",
+            "alpha-second",
+            "beta-first",
+        ]
+
+        duplicate = _fifo_msg(
+            "fifo-dup",
+            "duplicate",
+            group_id="alpha",
+            dedup_id="dedup-2",
+            created=4.0,
+        )
+        accepted_duplicate = restored.put(duplicate)
+        assert accepted_duplicate.message_id == "fifo-2"
+
+        fresh = _fifo_msg(
+            "fifo-4",
+            "alpha-third",
+            group_id="alpha",
+            dedup_id="dedup-4",
+            created=5.0,
+        )
+        accepted_fresh = restored.put(fresh)
+        assert accepted_fresh.sequence_number == "4"
+
+    def test_restore_heapifies_message_groups(self):
+        queue_state = {
+            "queue_type": "fifo",
+            "created": 1.0,
+            "attributes": {"FifoQueue": "true"},
+            "tags": {},
+            "last_purged_at": None,
+            "visible_ids": [],
+            "inflight_ids": [],
+            "delayed_ids": [],
+            "messages": {
+                "alpha-2": _fifo_msg(
+                    "alpha-2",
+                    "alpha-2",
+                    group_id="alpha",
+                    dedup_id="alpha-2",
+                    created=2.0,
+                ).snapshot_state(),
+                "alpha-3": _fifo_msg(
+                    "alpha-3",
+                    "alpha-3",
+                    group_id="alpha",
+                    dedup_id="alpha-3",
+                    created=3.0,
+                ).snapshot_state(),
+                "beta-1": _fifo_msg(
+                    "beta-1",
+                    "beta-1",
+                    group_id="beta",
+                    dedup_id="beta-1",
+                    created=4.0,
+                ).snapshot_state(),
+            },
+            "receipts": {},
+            "dedup_cache": {},
+            "message_groups": {
+                "alpha": ["alpha-3", "alpha-2"],
+                "beta": ["beta-1"],
+            },
+            "inflight_groups": [],
+            "queued_groups": ["alpha", "beta"],
+            "group_queue": ["alpha", "beta"],
+            "sequence_counter": 3,
+        }
+
+        restored = StandardQueue.from_snapshot(
+            queue_state,
+            region="us-east-1",
+            account_id="333333333333",
+            name="damaged.fifo",
+        )
+        assert isinstance(restored, FifoQueue)
+
+        received = restored.receive(max_messages=10, visibility_timeout=30)
+        assert [message.body for message, _ in received] == [
+            "alpha-2",
+            "alpha-3",
+            "beta-1",
+        ]
+
+
+class TestDiskRoundTripViaStateManager:
+    def test_binary_message_attributes_survive_disk_round_trip(self, tmp_path):
+        store = _get_store("us-east-1", "111111111111")
+        queue = store.create_queue("binary-attrs", "us-east-1", "111111111111")
+        assert queue is not None
+
+        message = _msg("binary-msg", "body")
+        message.message_attributes["blob"] = {
+            "DataType": "Binary",
+            "BinaryValue": b"\x00\x01\x02",
+        }
+        queue.put(message)
+
+        manager = StateManager(state_dir=str(tmp_path))
+        register_state_handler(manager)
+        manager.save(name="binary-attrs", services=["sqs"])
+
+        _reset_for_tests()
+        manager.load(name="binary-attrs", services=["sqs"])
+
+        restored = _get_store("us-east-1", "111111111111").get_queue("binary-attrs")
+        assert restored is not None
+        restored_message = restored.get_all_messages()[0]
+        restored_attr = restored_message.message_attributes["blob"]
+        assert restored_attr["DataType"] == "Binary"
+        assert restored_attr["BinaryValue"] == b"\x00\x01\x02"

--- a/tests/unit/services/test_events_provider.py
+++ b/tests/unit/services/test_events_provider.py
@@ -6,11 +6,9 @@ import pytest
 
 from robotocore.services.events.provider import (
     EventsError,
-    _api_destinations,
-    _connections,
     _error,
     _json,
-    _stores,
+    _reset_for_tests,
     clear_invocation_log,
     get_invocation_log,
     handle_events_request,
@@ -44,15 +42,9 @@ def _make_request(operation: str, body: dict):
 @pytest.fixture(autouse=True)
 def _clear_stores():
     """Reset global stores between tests."""
-    _stores.clear()
-    _connections.clear()
-    _api_destinations.clear()
-    clear_invocation_log()
+    _reset_for_tests()
     yield
-    _stores.clear()
-    _connections.clear()
-    _api_destinations.clear()
-    clear_invocation_log()
+    _reset_for_tests()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
In a workflow that constantly starts/stops docker containers, it's often annoying to lose resources you were previously working on, so I've added persistence to those I work with most in this setup.

## Summary

This PR extends robotocore native state persistence to cover both SQS and EventBridge using the existing snapshot/save/load framework.

  Before this change, native SQS and EventBridge provider state lived only in memory and was lost on process or container restart unless recreated by bootstrap logic. This PR wires both services into the existing
  `StateManager` native handler flow so their in-memory state can be saved, restored on startup, and survive container recreation when `ROBOTOCORE_STATE_DIR` is configured.

  ## What Changed

  ### Native SQS persistence
  - Registered SQS with `StateManager.register_native_handler(...)`
  - Persisted and restored:
    - account/region stores
    - queue definitions, attributes, tags, timestamps
    - visible, inflight, and delayed messages
    - receipt handle mappings
    - FIFO ordering state, dedup cache, group state, sequence continuity
    - purge/delete behavioral trackers
    - message move task state
  - Restored queues and messages back into working in-memory queue/store objects
  - Added `schema_version: 1` to SQS snapshots
  - Added load-time warning for explicit future SQS snapshot versions

  ### Native EventBridge persistence
  - Added native persistence for EventBridge using same existing state manager flow
  - Persisted and restored:
    - event buses
    - rules
    - targets
    - archives
    - replays
    - provider-scoped connections, API destinations, and endpoints
  - Normalized snapshot shape to nested account/region stores
  - Switched in-memory EventBridge store keys to `(account_id, region)` tuples for consistency with other native providers
  - Added `schema_version: 1` to EventBridge snapshots
  - Added load-time warning for explicit future EventBridge snapshot versions
  - Added restore-time validation for default bus identity to prevent silently loading inconsistent state

  ### Refactor and hardening
  - Moved snapshot/restore behavior closer to owning models instead of keeping it in provider glue
  - Removed unnecessary serializer/deserializer indirection:
    - initial implementation passed serializer/deserializer callables down through queue/store snapshot APIs so providers could control how nested objects were encoded and rebuilt
    - in practice, every caller used same direct pattern: `obj.snapshot_state()` on save and `Class.from_snapshot(data)` on load
    - there were no alternate formats, no provider-specific transforms, and no real extension point being exercised
    - keeping that indirection added wrapper functions in providers, extra callable plumbing in models, and more surface area to read and maintain without adding flexibility
    - collapsing to owner-driven `snapshot_state()` / `from_snapshot()` made boundaries clearer: each model now owns its own persistence shape, while providers only coordinate top-level export/load
  - Fixed FIFO snapshot locking so standard and FIFO-specific state are captured under one lock
  - Shortened global store lock scope during export
  - Hardened snapshot loading to ignore unknown future dataclass fields where appropriate
  - Moved state-manager singleton reset helper out of production code and into test-only setup

  ### Docs
  - Updated docs to reflect that native SQS and EventBridge now participate in save/load persistence flows
  - Updated prompt/PR summary docs to reflect actual branch scope

  ## Testing

  Added and expanded focused tests for both services, including:

  - native export/import round trips
  - state-manager disk save/load round trips
  - multi-account and multi-region isolation
  - receipt handle continuity after restore
  - FIFO ordering and dedup behavior after restore
  - purge/delete tracker round trips
  - move-task and recently-deleted state round trips
  - DLQ behavior after restore
  - EventBridge bus/rule/target/archive/replay round trips
  - EventBridge load-state replacement behavior
  - unknown future fields and top-level keys ignored on load
  - schema version warning behavior
  - default-bus identity validation

  Targeted verification run for changed areas:

  - `uv run pytest tests/unit/services/events/test_persistence.py -q --tb=short`
  - `uv run pytest tests/unit/services/sqs/test_persistence.py -q --tb=short`
  - `uv run pytest tests/unit/services/events/test_rule_scheduler.py tests/unit/services/test_events_provider.py tests/unit/test_state_manager.py -q --tb=short`
  - `uv run ruff check ...`
  - `uv run ruff format --check ...`
  - `uv run mypy ...`
  - `make test-quality`

  ## Notes

  - This PR intentionally uses existing native snapshot/save/load framework rather than introducing a new persistence subsystem.
  - `_invocation_log` and scheduler monotonic timing state are still intentionally not persisted.
  - I also used a local Docker smoke script (`scripts/test-native-persistence-docker.sh`) to externally validate SQS and EventBridge behavior across container recreation, but that script is not part of this PR.
  - The script starts robotocore with persistence enabled, uses
  AWS CLI to exercise basic SQS and EventBridge flows, leaves queued messages in both systems, recreates the container against the same persisted state directory, and then verifies that both resource definitions and pending
  messages survive restart and remain functional.
