### PR TITLE
fix(tests): starlette 1.x and boto3 >=1.42 compatibility

### DIFF
--- a/prompts/20260423-test-compat-starlette-boto3.md
+++ b/prompts/20260423-test-compat-starlette-boto3.md
@@ -1,0 +1,19 @@
+---
+session: 20260423
+slug: test-compat-starlette-boto3
+type: ci-fix
+---
+
+## Context
+
+Two dependabot PRs (#248 starlette >=1.0.0, #246 boto3 >=1.42.88) had failing CI.
+
+## Changes
+
+### Starlette 1.0 fix (`tests/unit/config/test_runtime_integration.py`)
+
+Starlette 1.0 removed `Router.on_startup` and `Router.on_shutdown` lists. Tests used `.clear()` on these to prevent SMTP binding during tests. Replaced with `AsyncMock` patches on `_start_background_engines` and `_shutdown` — works with all starlette versions and is clearer about intent.
+
+### Boto3 >=1.42 fix (`tests/compatibility/test_bedrock_compat.py`)
+
+Boto3 >=1.42 dropped `inputTags` from the `guardrailInferenceConfig` shape for `PutEnforcedGuardrailConfiguration`. Removed the parameter from the test.

--- a/tests/compatibility/test_bedrock_compat.py
+++ b/tests/compatibility/test_bedrock_compat.py
@@ -1077,7 +1077,6 @@ class TestBedrockEnforcedGuardrailConfigOps:
             guardrailInferenceConfig={
                 "guardrailIdentifier": "test-guardrail-id",
                 "guardrailVersion": "1",
-                "inputTags": '{"source": "user"}',
             },
         )
         assert "configId" in r

--- a/tests/compatibility/test_bedrock_compat.py
+++ b/tests/compatibility/test_bedrock_compat.py
@@ -1073,12 +1073,19 @@ class TestBedrockEnforcedGuardrailConfigOps:
 
     def test_put_enforced_guardrail_configuration(self, bedrock):
         """PutEnforcedGuardrailConfiguration returns configId."""
-        r = bedrock.put_enforced_guardrail_configuration(
-            guardrailInferenceConfig={
-                "guardrailIdentifier": "test-guardrail-id",
-                "guardrailVersion": "1",
-            },
-        )
+        import botocore.session
+
+        svc = botocore.session.get_session().get_service_model("bedrock")
+        op = svc.operation_model("PutEnforcedGuardrailConfiguration")
+        gic_shape = op.input_shape.members["guardrailInferenceConfig"]
+        required = getattr(gic_shape, "required_members", [])
+        config: dict = {
+            "guardrailIdentifier": "test-guardrail-id",
+            "guardrailVersion": "1",
+        }
+        if "inputTags" in required:
+            config["inputTags"] = '{"source": "user"}'
+        r = bedrock.put_enforced_guardrail_configuration(guardrailInferenceConfig=config)
         assert "configId" in r
         assert r["ResponseMetadata"]["HTTPStatusCode"] == 200
 

--- a/tests/unit/config/test_runtime_integration.py
+++ b/tests/unit/config/test_runtime_integration.py
@@ -5,7 +5,7 @@ the full request/response cycle for config management.
 """
 
 import os
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from starlette.testclient import TestClient
@@ -15,7 +15,6 @@ from starlette.testclient import TestClient
 def client_enabled():
     """Create a test client with config updates enabled."""
     with patch.dict(os.environ, {"ENABLE_CONFIG_UPDATES": "1"}):
-        # Reset the singleton so it picks up the env var
         import robotocore.config.runtime as rt_mod
 
         old = rt_mod._runtime_config
@@ -23,11 +22,12 @@ def client_enabled():
         try:
             from robotocore.gateway.app import app
 
-            # Clear startup/shutdown hooks to prevent SMTP port binding in tests
-            app.router.on_startup.clear()
-            app.router.on_shutdown.clear()
-            with TestClient(app, raise_server_exceptions=False) as client:
-                yield client
+            with (
+                patch("robotocore.gateway.app._start_background_engines", AsyncMock()),
+                patch("robotocore.gateway.app._shutdown", AsyncMock()),
+            ):
+                with TestClient(app, raise_server_exceptions=False) as client:
+                    yield client
         finally:
             rt_mod._runtime_config = old
 
@@ -44,11 +44,12 @@ def client_disabled():
         try:
             from robotocore.gateway.app import app
 
-            # Clear startup/shutdown hooks to prevent SMTP port binding in tests
-            app.router.on_startup.clear()
-            app.router.on_shutdown.clear()
-            with TestClient(app, raise_server_exceptions=False) as client:
-                yield client
+            with (
+                patch("robotocore.gateway.app._start_background_engines", AsyncMock()),
+                patch("robotocore.gateway.app._shutdown", AsyncMock()),
+            ):
+                with TestClient(app, raise_server_exceptions=False) as client:
+                    yield client
         finally:
             rt_mod._runtime_config = old
 


### PR DESCRIPTION
Unblocks two dependabot PRs (#248 starlette >=1.0.0, #246 boto3 >=1.42.88).

- **Starlette 1.0** removed `Router.on_startup`/`on_shutdown` lists. Replace `.clear()` calls in `test_runtime_integration.py` with `AsyncMock` patches on `_start_background_engines` and `_shutdown`.
- **boto3 >=1.42** dropped `inputTags` from `guardrailInferenceConfig` shape. Remove it from `test_put_enforced_guardrail_configuration`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)