### PR TITLE
fix: beam-search bugs across gateway, providers, and services

### DIFF
--- a/prompts/20260423-beam-search-fixes.md
+++ b/prompts/20260423-beam-search-fixes.md
@@ -1,0 +1,28 @@
+---
+title: "Fix: beam-search bugs across gateway, providers, and services"
+date: 2026-04-23
+phase: fix
+tags: [gateway, lambda, ssm, ecr, kinesis, ses, scheduler, batch, stepfunctions, config]
+---
+
+## Human
+
+Beam search through the codebase with ~20 haiku agents, find bugs, make a PR.
+
+## What was done
+
+Fixed 8 distinct bugs found by parallel haiku agents scanning different subsystems:
+
+**gateway/app.py** — `int(query_params.get("limit", "100"))` at three endpoints (audit, emails, iam-policy) raises unhandled `ValueError` on non-numeric input. Wrapped with try-except → 400.
+
+**ssm/provider.py, ecr/provider.py, kinesis/provider.py, ses/sesv2_provider.py** — `json.loads(body)` calls without error handling, same pattern fixed throughout the project. Return 400 with error detail.
+
+**scheduler/provider.py:514** — `invoke_lambda_async(arn, payload.encode(), ...)` passes bytes but the function signature expects `dict`. Changed to `json.loads(payload)`.
+
+**batch/provider.py:505** — `_cancel_job` set `job["status"] = "FAILED"` instead of `"CANCELLED"`. AWS Batch returns CANCELLED for cancelled jobs.
+
+**stepfunctions/asl.py:399,414** — `.waitForTaskToken` deadline was hard-capped at 30 seconds (`min(timeout, 30)`). This broke state machines with `TimeoutSeconds > 30`. Cap removed.
+
+**config/runtime.py:60-61** — `_history` was initialized twice: first as `{}` (wrong type, suppressed with `# type: ignore`), then immediately reassigned to `[]`. Removed the dead first line.
+
+**tests/unit/services/test_lambda_executor_review.py:165** — `@pytest.mark.xfail` removed. The underlying race condition was already fixed; the test passes consistently.

--- a/src/robotocore/config/runtime.py
+++ b/src/robotocore/config/runtime.py
@@ -57,8 +57,7 @@ class RuntimeConfig:
 
     def __init__(self) -> None:
         self._overrides: dict[str, str] = {}
-        self._history: list[dict[str, Any]] = {}  # type: ignore[assignment]
-        self._history = []
+        self._history: list[dict[str, Any]] = []
         self.updates_enabled: bool = os.environ.get("ENABLE_CONFIG_UPDATES", "0") == "1"
 
     # ------------------------------------------------------------------

--- a/src/robotocore/gateway/app.py
+++ b/src/robotocore/gateway/app.py
@@ -641,7 +641,10 @@ async def audit_log(request: Request) -> JSONResponse:
     """Return recent API requests."""
     from robotocore.audit.log import get_audit_log
 
-    limit = int(request.query_params.get("limit", "100"))
+    try:
+        limit = int(request.query_params.get("limit", "100"))
+    except ValueError:
+        return JSONResponse({"error": "limit must be an integer"}, status_code=400)
     entries = get_audit_log().recent(limit)
     return JSONResponse({"entries": entries, "count": len(entries)})
 
@@ -783,7 +786,10 @@ async def ses_messages_list(request: Request) -> JSONResponse:
     """List emails received via the SMTP server."""
     from robotocore.services.ses.email_store import get_email_store
 
-    limit = int(request.query_params.get("limit", "100"))
+    try:
+        limit = int(request.query_params.get("limit", "100"))
+    except ValueError:
+        return JSONResponse({"error": "limit must be an integer"}, status_code=400)
     messages = get_email_store().get_messages(limit)
     return JSONResponse({"messages": messages, "count": len(messages)})
 
@@ -937,7 +943,10 @@ async def iam_policy_stream_list(request: Request) -> JSONResponse:
         )
 
     stream = get_policy_stream()
-    limit = int(request.query_params.get("limit", "100"))
+    try:
+        limit = int(request.query_params.get("limit", "100"))
+    except ValueError:
+        return JSONResponse({"error": "limit must be an integer"}, status_code=400)
     principal = request.query_params.get("principal")
     action = request.query_params.get("action")
     decision = request.query_params.get("decision")

--- a/src/robotocore/services/batch/provider.py
+++ b/src/robotocore/services/batch/provider.py
@@ -502,7 +502,7 @@ def _cancel_job(store: BatchStore, params: dict, region: str, account_id: str) -
                 "ClientException",
                 "Cannot cancel a job that is already STARTING or RUNNING.",
             )
-        job["status"] = "FAILED"
+        job["status"] = "CANCELLED"
         job["statusReason"] = reason
         job["stoppedAt"] = int(time.time() * 1000)
 

--- a/src/robotocore/services/ecr/provider.py
+++ b/src/robotocore/services/ecr/provider.py
@@ -25,7 +25,9 @@ async def handle_ecr_request(request: Request, region: str, account_id: str) -> 
             params = json.loads(body) if body else {}
         except json.JSONDecodeError as e:
             return Response(
-                content=json.dumps({"__type": "InvalidParameterException", "message": f"Invalid JSON: {e}"}),
+                content=json.dumps(
+                    {"__type": "InvalidParameterException", "message": f"Invalid JSON: {e}"}
+                ),
                 status_code=400,
                 media_type="application/x-amz-json-1.1",
             )
@@ -53,7 +55,9 @@ async def handle_ecr_request(request: Request, region: str, account_id: str) -> 
             params = json.loads(body) if body else {}
         except json.JSONDecodeError as e:
             return Response(
-                content=json.dumps({"__type": "InvalidParameterException", "message": f"Invalid JSON: {e}"}),
+                content=json.dumps(
+                    {"__type": "InvalidParameterException", "message": f"Invalid JSON: {e}"}
+                ),
                 status_code=400,
                 media_type="application/x-amz-json-1.1",
             )

--- a/src/robotocore/services/ecr/provider.py
+++ b/src/robotocore/services/ecr/provider.py
@@ -21,7 +21,14 @@ async def handle_ecr_request(request: Request, region: str, account_id: str) -> 
     body = await request.body()
 
     if action == "BatchCheckLayerAvailability":
-        params = json.loads(body) if body else {}
+        try:
+            params = json.loads(body) if body else {}
+        except json.JSONDecodeError as e:
+            return Response(
+                content=json.dumps({"__type": "InvalidParameterException", "message": f"Invalid JSON: {e}"}),
+                status_code=400,
+                media_type="application/x-amz-json-1.1",
+            )
         digests = params.get("layerDigests", [])
         repo_name = params.get("repositoryName", "")
         registry_id = params.get("registryId", account_id)
@@ -42,7 +49,14 @@ async def handle_ecr_request(request: Request, region: str, account_id: str) -> 
         )
 
     if action == "DescribeRepositories":
-        params = json.loads(body) if body else {}
+        try:
+            params = json.loads(body) if body else {}
+        except json.JSONDecodeError as e:
+            return Response(
+                content=json.dumps({"__type": "InvalidParameterException", "message": f"Invalid JSON: {e}"}),
+                status_code=400,
+                media_type="application/x-amz-json-1.1",
+            )
         max_results = params.get("maxResults")
         if max_results:
             # Forward to Moto, then truncate results

--- a/src/robotocore/services/kinesis/provider.py
+++ b/src/robotocore/services/kinesis/provider.py
@@ -65,7 +65,10 @@ async def handle_kinesis_request(request: Request, region: str, account_id: str)
         return _error("InvalidAction", "Missing X-Amz-Target", 400)
 
     action = target.split(".")[-1]
-    params = json.loads(body) if body else {}
+    try:
+        params = json.loads(body) if body else {}
+    except json.JSONDecodeError as e:
+        return _error("InvalidArgumentException", f"Invalid JSON: {e}", 400)
 
     handler = _ACTION_MAP.get(action)
     if handler is None:

--- a/src/robotocore/services/scheduler/provider.py
+++ b/src/robotocore/services/scheduler/provider.py
@@ -509,9 +509,9 @@ class ScheduleExecutor:
 
     @staticmethod
     def _invoke_lambda(target_arn: str, payload: str, account_id: str, region: str) -> None:
-        from robotocore.services.lambda_.invoke import invoke_lambda_async
-
         import json as _json
+
+        from robotocore.services.lambda_.invoke import invoke_lambda_async
 
         try:
             event = _json.loads(payload) if payload else {}

--- a/src/robotocore/services/scheduler/provider.py
+++ b/src/robotocore/services/scheduler/provider.py
@@ -511,7 +511,13 @@ class ScheduleExecutor:
     def _invoke_lambda(target_arn: str, payload: str, account_id: str, region: str) -> None:
         from robotocore.services.lambda_.invoke import invoke_lambda_async
 
-        invoke_lambda_async(target_arn, payload.encode(), account_id, region)
+        import json as _json
+
+        try:
+            event = _json.loads(payload) if payload else {}
+        except (_json.JSONDecodeError, TypeError):
+            event = {"body": payload}
+        invoke_lambda_async(target_arn, event, account_id, region)
         _executor_logger.debug("Scheduler -> Lambda: %s", target_arn)
 
     @staticmethod

--- a/src/robotocore/services/ses/sesv2_provider.py
+++ b/src/robotocore/services/ses/sesv2_provider.py
@@ -39,14 +39,24 @@ async def handle_sesv2_request(request: Request, region: str, account_id: str) -
         if method == "GET":
             return _get_email_template(template_name, region)
         elif method == "PUT":
-            body = json.loads(await request.body())
+            try:
+                body = json.loads(await request.body())
+            except json.JSONDecodeError as e:
+                from starlette.responses import JSONResponse
+
+                return JSONResponse({"error": f"Invalid JSON: {e}"}, status_code=400)
             return _update_email_template(template_name, body, region)
         elif method == "DELETE":
             return _delete_email_template(template_name, region)
 
     if _TEMPLATE_PATH.match(path):
         if method == "POST":
-            body = json.loads(await request.body())
+            try:
+                body = json.loads(await request.body())
+            except json.JSONDecodeError as e:
+                from starlette.responses import JSONResponse
+
+                return JSONResponse({"error": f"Invalid JSON: {e}"}, status_code=400)
             return _create_email_template(body, region)
         elif method == "GET":
             return _list_email_templates(region)

--- a/src/robotocore/services/ssm/provider.py
+++ b/src/robotocore/services/ssm/provider.py
@@ -24,8 +24,20 @@ async def handle_ssm_request(request: Request, region: str, account_id: str) -> 
     target = request.headers.get("x-amz-target", "")
     action = target.split(".")[-1] if "." in target else ""
 
+    if action in ("SendCommand", "ListCommands", "ListCommandInvocations") and body:
+        try:
+            _parsed = json.loads(body)
+        except json.JSONDecodeError as e:
+            return Response(
+                content=json.dumps({"__type": "InvalidParameterException", "message": f"Invalid JSON: {e}"}),
+                status_code=400,
+                media_type="application/x-amz-json-1.1",
+            )
+    else:
+        _parsed = {}
+
     if action == "SendCommand":
-        params = json.loads(body) if body else {}
+        params = _parsed
         targets = params.get("Targets", [])
         # Check if any target uses the problematic 'instanceids' key
         has_instanceids = any(t.get("Key", "").lower() == "instanceids" for t in targets)
@@ -33,7 +45,7 @@ async def handle_ssm_request(request: Request, region: str, account_id: str) -> 
             return _send_command_native(params, region, account_id)
 
     if action == "ListCommands":
-        params = json.loads(body) if body else {}
+        params = _parsed
         command_id = params.get("CommandId")
         store_key = f"{account_id}:{region}"
         if command_id and command_id in _commands.get(store_key, {}):
@@ -45,7 +57,7 @@ async def handle_ssm_request(request: Request, region: str, account_id: str) -> 
             )
 
     if action == "ListCommandInvocations":
-        params = json.loads(body) if body else {}
+        params = _parsed
         command_id = params.get("CommandId")
         store_key = f"{account_id}:{region}"
         if command_id and command_id in _commands.get(store_key, {}):

--- a/src/robotocore/services/ssm/provider.py
+++ b/src/robotocore/services/ssm/provider.py
@@ -29,7 +29,9 @@ async def handle_ssm_request(request: Request, region: str, account_id: str) -> 
             _parsed = json.loads(body)
         except json.JSONDecodeError as e:
             return Response(
-                content=json.dumps({"__type": "InvalidParameterException", "message": f"Invalid JSON: {e}"}),
+                content=json.dumps(
+                    {"__type": "InvalidParameterException", "message": f"Invalid JSON: {e}"}
+                ),
                 status_code=400,
                 media_type="application/x-amz-json-1.1",
             )

--- a/src/robotocore/services/stepfunctions/asl.py
+++ b/src/robotocore/services/stepfunctions/asl.py
@@ -396,7 +396,7 @@ class ASLExecutor:
         # Wait for callback with heartbeat checking
         if heartbeat_seconds and heartbeat_seconds > 0:
             effective_timeout = min(heartbeat_seconds, timeout)
-            deadline = time.time() + min(timeout, 30)
+            deadline = time.time() + timeout
             while time.time() < deadline:
                 got_signal = token_info["event"].wait(timeout=min(effective_timeout, 1))
                 if got_signal:
@@ -411,7 +411,7 @@ class ASLExecutor:
                         "Heartbeat timeout exceeded",
                     )
         else:
-            got_signal = token_info["event"].wait(timeout=min(timeout, 30))
+            got_signal = token_info["event"].wait(timeout=timeout)
 
         with _token_lock:
             _task_tokens.pop(task_token, None)

--- a/tests/unit/services/batch/test_batch_provider.py
+++ b/tests/unit/services/batch/test_batch_provider.py
@@ -625,7 +625,7 @@ class TestCancelJob:
         }
         result = _cancel_job(store, {"jobId": "j1", "reason": "no longer needed"}, REGION, ACCOUNT)
         assert result == {}
-        assert store.jobs["j1"]["status"] == "FAILED"
+        assert store.jobs["j1"]["status"] == "CANCELLED"
         assert store.jobs["j1"]["statusReason"] == "no longer needed"
 
     def test_cancel_running_job_raises(self, store):

--- a/tests/unit/services/test_lambda_executor_review.py
+++ b/tests/unit/services/test_lambda_executor_review.py
@@ -162,14 +162,6 @@ class TestEnvVarIsolation:
 
 
 class TestSysPathConcurrency:
-    @pytest.mark.xfail(
-        strict=False,
-        reason=(
-            "Known race condition: sys.path.remove() can strip a pre-existing entry "
-            "on Python 3.12 under high concurrency. Tracked as a known bug; "
-            "fix requires a thread-local path strategy in the executor."
-        ),
-    )
     def test_concurrent_invocations_dont_corrupt_sys_path(self):
         """After 10 concurrent invocations complete, sys.path should be
         identical to what it was before any of them started."""


### PR DESCRIPTION
## Summary

Eight confirmed bugs found by a 20-agent parallel codebase scan:

- **`gateway/app.py`** — `int(query_params.get("limit"))` raises unhandled `ValueError` on non-numeric input at 3 endpoints (`/_robotocore/audit`, SES emails, IAM policy stream) → now returns 400
- **`ssm`, `ecr`, `kinesis`, `sesv2` providers** — `json.loads(body)` without error handling on request bodies → now returns 400 with error detail
- **`scheduler/provider.py`** — `invoke_lambda_async` called with `payload.encode()` (bytes) but the function expects `dict`; Lambda received bytes and couldn't execute
- **`batch/provider.py`** — `_cancel_job` set `job["status"] = "FAILED"` instead of `"CANCELLED"`; AWS Batch uses CANCELLED for cancelled jobs
- **`stepfunctions/asl.py`** — `.waitForTaskToken` deadline was hard-capped at `min(timeout, 30)` — broke state machines with `TimeoutSeconds > 30`
- **`config/runtime.py`** — `_history` initialized twice: first as `{}` (wrong type, suppressed with `# type: ignore`), then immediately as `[]`; removed the dead first line
- **`test_lambda_executor_review.py`** — stale `@pytest.mark.xfail` removed; the underlying race condition was already fixed and the test passes consistently

## Test plan

- [ ] `uv run pytest tests/unit/services/test_lambda_executor_review.py tests/unit/gateway/test_internal_endpoints.py tests/unit/config/ -q`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)