### PR TITLE
docs: fix Docker image name from Docker Hub to GHCR

### DIFF
--- a/.claude/skills/use-in-tests.md
+++ b/.claude/skills/use-in-tests.md
@@ -11,7 +11,7 @@ robotocore runs as a Docker container on port 4566 and responds to real AWS SDK 
 ### Option A: start it per-session (local dev)
 
 ```bash
-docker run -d -p 4566:4566 --name robotocore robotocore/robotocore:latest
+docker run -d -p 4566:4566 --name robotocore ghcr.io/robotocore/robotocore:latest
 ```
 
 ### Option B: docker-compose (team standard)
@@ -21,7 +21,7 @@ Add to `docker-compose.yml`:
 ```yaml
 services:
   aws:
-    image: robotocore/robotocore:latest
+    image: ghcr.io/robotocore/robotocore:latest
     ports:
       - "4566:4566"
     healthcheck:
@@ -35,7 +35,7 @@ services:
 ```yaml
 services:
   robotocore:
-    image: robotocore/robotocore:latest
+    image: ghcr.io/robotocore/robotocore:latest
     ports:
       - 4566:4566
     options: >-
@@ -195,7 +195,7 @@ AWS_ENDPOINT_URL="" pytest tests/
 ```toml
 # pyproject.toml — no Python package needed, just document the Docker image
 [tool.robotocore]
-image = "robotocore/robotocore:latest"
+image = "ghcr.io/robotocore/robotocore:latest"
 port  = 4566
 ```
 
@@ -206,6 +206,6 @@ Or just document it in `README.md` or `CONTRIBUTING.md`:
 
 Start robotocore before running tests:
 
-    docker run -d -p 4566:4566 robotocore/robotocore:latest
+    docker run -d -p 4566:4566 ghcr.io/robotocore/robotocore:latest
     pytest tests/
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ curl -sf http://localhost:4566/_robotocore/health > /dev/null && echo "already r
 
 ```bash
 docker rm -f robotocore 2>/dev/null || true
-docker run -d -p 4566:4566 --name robotocore robotocore/robotocore:latest
+docker run -d -p 4566:4566 --name robotocore ghcr.io/robotocore/robotocore:latest
 ```
 
 Also available from GHCR:
@@ -382,7 +382,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       robotocore:
-        image: robotocore/robotocore:latest
+        image: ghcr.io/robotocore/robotocore:latest
         ports:
           - 4566:4566
         options: >-
@@ -404,7 +404,7 @@ jobs:
 # docker-compose
 services:
   aws:
-    image: robotocore/robotocore:latest
+    image: ghcr.io/robotocore/robotocore:latest
     ports:
       - "4566:4566"
     healthcheck:

--- a/LOCALSTACK.md
+++ b/LOCALSTACK.md
@@ -55,7 +55,7 @@ Be honest with yourself about what LocalStack does well that Robotocore doesn't 
 docker run -p 4566:4566 localstack/localstack
 
 # After
-docker run -p 4566:4566 robotocore/robotocore
+docker run -p 4566:4566 ghcr.io/robotocore/robotocore:latest
 ```
 
 That's it. Same port, same endpoint, same credentials.
@@ -86,7 +86,7 @@ services:
 
   # After
   aws:
-    image: robotocore/robotocore
+    image: ghcr.io/robotocore/robotocore:latest
     ports:
       - "4566:4566"
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ aws dynamodb list-tables
 ```yaml
 services:
   aws:
-    image: robotocore/robotocore:latest
+    image: ghcr.io/robotocore/robotocore:latest
     ports:
       - "4566:4566"
 
@@ -101,7 +101,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       robotocore:
-        image: robotocore/robotocore:latest
+        image: ghcr.io/robotocore/robotocore:latest
         ports:
           - 4566:4566
         options: >-

--- a/prompts/20260511-000000-fix-docker-image-names-and-ses-api-capture.md
+++ b/prompts/20260511-000000-fix-docker-image-names-and-ses-api-capture.md
@@ -1,0 +1,47 @@
+---
+session: "20260511-open-issues"
+timestamp: "2026-05-11T00:00:00Z"
+model: claude-sonnet-4-6
+sequence: 1
+---
+
+## Human
+
+One by one, solve each open GitHub issue with a PR. Spend time thinking about various tradeoffs before selecting a solution. Solve problems categorically, don't just address individual symptoms.
+
+## Assistant
+
+## Key decisions
+
+Three open issues to address:
+
+**Issue #220: Error starting container in GitHub Actions**
+
+Two symptoms reported: (1) wrong image name in README examples, (2) Starlette `on_startup` error.
+
+The `on_startup` bug was already fixed in commit `b1efff7a` (migrated to `lifespan=` context manager). The remaining problem is that docs still reference `robotocore/robotocore:latest` (Docker Hub format) after Docker Hub publishing was removed in `a5b21e5a`.
+
+**Categorical fix chosen**: Update ALL documentation files (README.md, LOCALSTACK.md, AGENTS.md, .claude/skills/use-in-tests.md, all service READMEs) to use `ghcr.io/robotocore/robotocore:latest`. 50+ occurrences across 10 files.
+
+Did NOT add Docker Hub publishing back — that would require Docker Hub credentials not in the repo secrets, and GHCR is the canonical registry going forward. The correct fix is accurate docs, not adding infrastructure complexity.
+
+Used `perl -pi -e` with negative lookbehind to replace image references while preserving GitHub repo URLs (`github.com/robotocore/robotocore`) and GitHub Actions references (`uses: robotocore/robotocore/`).
+
+**Issue #222: SES SendEmail API emails not appearing in /_robotocore/ses/messages**
+
+Root cause: `EmailStore` is only fed by the SMTP server path. SES API calls (`SendEmail`, `SendRawEmail`, `SendTemplatedEmail`, `SendBulkTemplatedEmail`) fall through to Moto's backend, which stores emails in `backend.sent_messages`, a completely separate data structure.
+
+Three approaches considered:
+1. **Bridge Moto's store**: Query `backend.sent_messages` at the management endpoint. Con: Moto has 4+ message types (Message, RawMessage, TemplateMessage, BulkTemplateMessage) with different field names; translation is fragile against Moto version changes.
+2. **Intercept before Moto**: Extract email data from request params and add to EmailStore before forwarding. Con: If Moto rejects the email (unverified sender), we'd capture failed sends.
+3. **Intercept after Moto** (chosen): Let Moto process the email normally, capture it into EmailStore only on HTTP 200 response. Covers all send operations. Correct (only captures successful sends). Doesn't require touching Moto internals.
+
+Applied the same pattern to SES v2 (`SendEmail` at POST `/v2/email/outbound-emails`).
+
+Also added `source` field to `StoredEmail` ("smtp" vs "api") so callers can distinguish how the email was sent.
+
+**Issue #212: Node.js lambda support**
+
+This is a larger feature. Node.js runtimes (nodejs18.x, nodejs20.x, nodejs22.x) require executing JavaScript in a Node.js subprocess rather than in Python. The existing Lambda executor already handles Python by executing code in a subprocess with the right runtime environment. Node.js support requires: (1) ensuring Node.js is installed in the Docker image, (2) adding a Node.js function executor path alongside the Python one, (3) handling the Lambda runtime API in a way compatible with Node.js Lambda bootstrap.
+
+Key decision: Node.js Lambdas use the Lambda Runtime API (`/2018-06-01/runtime/...` endpoints) for a pull-based invocation model. The existing Python executor simulates this. The same approach works for Node.js by launching `node` with a compatible bootstrap.

--- a/src/robotocore/services/README.md
+++ b/src/robotocore/services/README.md
@@ -38,7 +38,7 @@ Robotocore is MIT-licensed, requires no registration or auth tokens, and will re
 docker run -p 4566:4566 localstack/localstack
 
 # After (Robotocore) -- same port, drop-in replacement
-docker run -p 4566:4566 robotocore/robotocore
+docker run -p 4566:4566 ghcr.io/robotocore/robotocore:latest
 ```
 
 No client-side changes needed. Your `--endpoint-url http://localhost:4566` configuration works as-is.
@@ -50,10 +50,10 @@ No client-side changes needed. Your `--endpoint-url http://localhost:4566` confi
 docker run -p 5000:5000 motoserver/moto
 
 # After (Robotocore on port 4566, or map to 5000 if you prefer)
-docker run -p 4566:4566 robotocore/robotocore
+docker run -p 4566:4566 ghcr.io/robotocore/robotocore:latest
 
 # Or, to keep your existing port:
-docker run -p 5000:4566 robotocore/robotocore
+docker run -p 5000:4566 ghcr.io/robotocore/robotocore:latest
 ```
 
 Update your `--endpoint-url` from `http://localhost:5000` to `http://localhost:4566` (or use the port mapping above to avoid changing clients).
@@ -136,7 +136,7 @@ Beyond the 46 native providers listed above, Robotocore registers 101 additional
 
 | moto server | Robotocore | Notes |
 |---|---|---|
-| `moto_server -p 5000` | `docker run -p 4566:4566 robotocore/robotocore` | Port is configurable via Docker mapping |
+| `moto_server -p 5000` | `docker run -p 4566:4566 ghcr.io/robotocore/robotocore:latest` | Port is configurable via Docker mapping |
 | `moto_server -H 0.0.0.0` | Default binds to `0.0.0.0` inside container | |
 | `POST /moto-api/reset` | `POST /_robotocore/state/reset` | State reset endpoint |
 | `POST /moto-api/state-manager` | `POST /_robotocore/state/save` | Snapshot save |
@@ -252,7 +252,7 @@ curl -X POST http://localhost:4566/_robotocore/state/reset
 # docker-compose.yml
 services:
   robotocore:
-    image: robotocore/robotocore
+    image: ghcr.io/robotocore/robotocore:latest
     ports:
       - "4566:4566"
     environment:
@@ -264,7 +264,7 @@ services:
 ```yaml
 services:
   robotocore:
-    image: robotocore/robotocore
+    image: ghcr.io/robotocore/robotocore:latest
     ports:
       - "4566:4566"
     environment:
@@ -278,7 +278,7 @@ services:
 ```yaml
 services:
   robotocore:
-    image: robotocore/robotocore
+    image: ghcr.io/robotocore/robotocore:latest
     ports:
       - "5000:4566"
 ```

--- a/src/robotocore/services/dynamodb/README.md
+++ b/src/robotocore/services/dynamodb/README.md
@@ -13,7 +13,7 @@ Migration guide for teams moving from **dynalite** or **DynamoDB Local** to Robo
 docker run -p 4567:4567 kpavlov/dynalite
 
 # After (Robotocore)
-docker run -p 4566:4566 robotocore/robotocore
+docker run -p 4566:4566 ghcr.io/robotocore/robotocore:latest
 ```
 
 Change your endpoint from `http://localhost:4567` to `http://localhost:4566`.
@@ -25,7 +25,7 @@ Change your endpoint from `http://localhost:4567` to `http://localhost:4566`.
 docker run -p 8000:8000 amazon/dynamodb-local
 
 # After (Robotocore)
-docker run -p 4566:4566 robotocore/robotocore
+docker run -p 4566:4566 ghcr.io/robotocore/robotocore:latest
 ```
 
 Change your endpoint from `http://localhost:8000` to `http://localhost:4566`.
@@ -33,7 +33,7 @@ Change your endpoint from `http://localhost:8000` to `http://localhost:4566`.
 If you want to keep using port 8000 during migration:
 
 ```bash
-docker run -p 8000:4566 robotocore/robotocore
+docker run -p 8000:4566 ghcr.io/robotocore/robotocore:latest
 ```
 
 ---
@@ -304,19 +304,19 @@ export AWS_DEFAULT_REGION=us-east-1
 ### Basic (drop-in replacement)
 
 ```bash
-docker run -d --name robotocore -p 4566:4566 robotocore/robotocore
+docker run -d --name robotocore -p 4566:4566 ghcr.io/robotocore/robotocore:latest
 ```
 
 ### Keep existing dynalite port
 
 ```bash
-docker run -d --name robotocore -p 4567:4566 robotocore/robotocore
+docker run -d --name robotocore -p 4567:4566 ghcr.io/robotocore/robotocore:latest
 ```
 
 ### Keep existing DynamoDB Local port
 
 ```bash
-docker run -d --name robotocore -p 8000:4566 robotocore/robotocore
+docker run -d --name robotocore -p 8000:4566 ghcr.io/robotocore/robotocore:latest
 ```
 
 ### With docker-compose
@@ -324,7 +324,7 @@ docker run -d --name robotocore -p 8000:4566 robotocore/robotocore
 ```yaml
 services:
   robotocore:
-    image: robotocore/robotocore
+    image: ghcr.io/robotocore/robotocore:latest
     ports:
       - "4566:4566"
     environment:

--- a/src/robotocore/services/kinesis/README.md
+++ b/src/robotocore/services/kinesis/README.md
@@ -9,7 +9,7 @@ Robotocore's Kinesis provider is a native implementation with 28 natively-handle
 docker run -p 4567:4567 dlsteuer/kinesalite
 
 # After (Robotocore)
-docker run -p 4566:4566 robotocore/robotocore
+docker run -p 4566:4566 ghcr.io/robotocore/robotocore:latest
 ```
 
 Update your SDK/CLI endpoint from `http://localhost:4567` to `http://localhost:4566`. That's it.
@@ -176,14 +176,14 @@ Additionally, Robotocore runs 146 other AWS services on the same endpoint. If yo
 
 ```bash
 # Basic (matches kinesalite's default behavior)
-docker run -p 4566:4566 robotocore/robotocore
+docker run -p 4566:4566 ghcr.io/robotocore/robotocore:latest
 
 # Custom host port (if you need 4567 for backward compatibility)
-docker run -p 4567:4566 robotocore/robotocore
+docker run -p 4567:4566 ghcr.io/robotocore/robotocore:latest
 
 # With debug logging
-docker run -p 4566:4566 -e ROBOTOCORE_LOG_LEVEL=DEBUG robotocore/robotocore
+docker run -p 4566:4566 -e ROBOTOCORE_LOG_LEVEL=DEBUG ghcr.io/robotocore/robotocore:latest
 
 # With audit logging (track all API calls)
-docker run -p 4566:4566 -e AUDIT_LOG_SIZE=1000 robotocore/robotocore
+docker run -p 4566:4566 -e AUDIT_LOG_SIZE=1000 ghcr.io/robotocore/robotocore:latest
 ```

--- a/src/robotocore/services/s3/README.md
+++ b/src/robotocore/services/s3/README.md
@@ -13,7 +13,7 @@ Drop-in S3 emulator replacement for **s3rver** and **Adobe S3Mock**. One port, f
 docker run -p 4569:4569 jbergknoff/s3rver --directory /tmp/s3
 
 # After (Robotocore)
-docker run -p 4566:4566 robotocore/robotocore
+docker run -p 4566:4566 ghcr.io/robotocore/robotocore:latest
 ```
 
 Update your endpoint:
@@ -33,7 +33,7 @@ aws --endpoint-url http://localhost:4566 s3 ls
 docker run -p 9090:9090 -e initialBuckets=my-bucket adobe/s3mock
 
 # After (Robotocore)
-docker run -p 4566:4566 robotocore/robotocore
+docker run -p 4566:4566 ghcr.io/robotocore/robotocore:latest
 ```
 
 Update your endpoint:
@@ -147,7 +147,7 @@ aws --endpoint-url http://localhost:4566 s3 ls
 | `retainFilesOnExit=true` | Snapshot save/load | `POST /_robotocore/state/save` before shutdown |
 | Port 9090 (HTTP) | Port 4566 | |
 | Port 9191 (HTTPS) | Not applicable | HTTP only (use a TLS proxy if needed) |
-| Testcontainers | `robotocore/robotocore` image | Works with any Testcontainers setup |
+| Testcontainers | `ghcr.io/robotocore/robotocore:latest` image | Works with any Testcontainers setup |
 
 ---
 
@@ -261,18 +261,18 @@ s3Client := s3.NewFromConfig(cfg, func(o *s3.Options) {
 
 ```bash
 # Basic
-docker run -p 4566:4566 robotocore/robotocore
+docker run -p 4566:4566 ghcr.io/robotocore/robotocore:latest
 
 # With a custom host port (drop-in for s3rver)
-docker run -p 4569:4566 robotocore/robotocore
+docker run -p 4569:4566 ghcr.io/robotocore/robotocore:latest
 
 # With a custom host port (drop-in for S3Mock)
-docker run -p 9090:4566 robotocore/robotocore
+docker run -p 9090:4566 ghcr.io/robotocore/robotocore:latest
 
 # Docker Compose
 # services:
 #   robotocore:
-#     image: robotocore/robotocore
+#     image: ghcr.io/robotocore/robotocore:latest
 #     ports:
 #       - "4566:4566"
 ```

--- a/src/robotocore/services/sns/README.md
+++ b/src/robotocore/services/sns/README.md
@@ -9,7 +9,7 @@ Drop-in migration guide for teams moving from [goaws](https://github.com/Admiral
 docker run -p 4100:4100 admiralpiett/goaws
 
 # With this:
-docker run -p 4566:4566 robotocore/robotocore
+docker run -p 4566:4566 ghcr.io/robotocore/robotocore:latest
 ```
 
 Then update your endpoint:
@@ -100,7 +100,7 @@ Or use a docker-compose setup:
 ```yaml
 services:
   robotocore:
-    image: robotocore/robotocore
+    image: ghcr.io/robotocore/robotocore:latest
     ports:
       - "4566:4566"
   init:
@@ -221,13 +221,13 @@ Features not available in goaws:
 
 ```bash
 # Basic
-docker run -p 4566:4566 robotocore/robotocore
+docker run -p 4566:4566 ghcr.io/robotocore/robotocore:latest
 
 # With debug logging
-docker run -p 4566:4566 -e DEBUG=1 robotocore/robotocore
+docker run -p 4566:4566 -e DEBUG=1 ghcr.io/robotocore/robotocore:latest
 
 # With persistent state directory
-docker run -p 4566:4566 -v robotocore-data:/data robotocore/robotocore
+docker run -p 4566:4566 -v robotocore-data:/data ghcr.io/robotocore/robotocore:latest
 
 # Replacing goaws in docker-compose
 # Change image and port, remove goaws.yaml volume, add init script

--- a/src/robotocore/services/sqs/README.md
+++ b/src/robotocore/services/sqs/README.md
@@ -11,7 +11,7 @@ Replace your existing emulator container with Robotocore. No SDK code changes be
 docker run -p 9324:9324 softwaremill/elasticmq-native
 
 # After (Robotocore)
-docker run -p 4566:4566 robotocore/robotocore
+docker run -p 4566:4566 ghcr.io/robotocore/robotocore:latest
 ```
 
 Update your endpoint:
@@ -27,7 +27,7 @@ http://localhost:4566
 If you cannot change the port in your application, map it:
 
 ```bash
-docker run -p 9324:4566 robotocore/robotocore
+docker run -p 9324:4566 ghcr.io/robotocore/robotocore:latest
 ```
 
 ### From goaws
@@ -37,7 +37,7 @@ docker run -p 9324:4566 robotocore/robotocore
 docker run -p 4100:4100 admiralpiett/goaws
 
 # After (Robotocore)
-docker run -p 4566:4566 robotocore/robotocore
+docker run -p 4566:4566 ghcr.io/robotocore/robotocore:latest
 ```
 
 Update your endpoint:
@@ -50,7 +50,7 @@ http://localhost:4100
 http://localhost:4566
 ```
 
-Or map the port: `docker run -p 4100:4566 robotocore/robotocore`
+Or map the port: `docker run -p 4100:4566 ghcr.io/robotocore/robotocore:latest`
 
 ---
 
@@ -275,7 +275,7 @@ aws sqs create-queue --queue-name events.fifo \
 ```yaml
 services:
   robotocore:
-    image: robotocore/robotocore
+    image: ghcr.io/robotocore/robotocore:latest
     ports:
       - "4566:4566"
     healthcheck:
@@ -390,7 +390,7 @@ You can also configure persistent startup/shutdown save behavior with `ROBOTOCOR
 ### Minimal
 
 ```bash
-docker run -p 4566:4566 robotocore/robotocore
+docker run -p 4566:4566 ghcr.io/robotocore/robotocore:latest
 ```
 
 ### With environment variables
@@ -399,19 +399,19 @@ docker run -p 4566:4566 robotocore/robotocore
 docker run -p 4566:4566 \
   -e ROBOTOCORE_PORT=4566 \
   -e AUDIT_LOG_SIZE=1000 \
-  robotocore/robotocore
+  ghcr.io/robotocore/robotocore:latest
 ```
 
 ### Port-compatible with ElasticMQ
 
 ```bash
-docker run -p 9324:4566 robotocore/robotocore
+docker run -p 9324:4566 ghcr.io/robotocore/robotocore:latest
 ```
 
 ### Port-compatible with goaws
 
 ```bash
-docker run -p 4100:4566 robotocore/robotocore
+docker run -p 4100:4566 ghcr.io/robotocore/robotocore:latest
 ```
 
 ### Docker Compose (replacing ElasticMQ)
@@ -426,7 +426,7 @@ services:
 
   # With this:
   aws:
-    image: robotocore/robotocore
+    image: ghcr.io/robotocore/robotocore:latest
     ports:
       - "9324:4566"
     healthcheck:
@@ -447,7 +447,7 @@ services:
 
   # With this:
   aws:
-    image: robotocore/robotocore
+    image: ghcr.io/robotocore/robotocore:latest
     ports:
       - "4100:4566"
     healthcheck:


### PR DESCRIPTION
## Summary

- Fixes all documentation examples that referenced `robotocore/robotocore:latest` (Docker Hub) instead of `ghcr.io/robotocore/robotocore:latest` (GHCR, where images are actually published)
- Updated 50+ references across README.md, LOCALSTACK.md, AGENTS.md, service READMEs, and the `use-in-tests` skill
- The Starlette `on_startup` error mentioned in the issue was already fixed in commit `b1efff7a`; this PR addresses the remaining doc inconsistency

**Root cause**: Docker Hub publishing was removed in commit `a5b21e5a` but the documentation examples weren't updated at the same time, leaving users confused about which image name to use.

Closes #220

## Test plan

- [ ] README.md docker-compose example uses `ghcr.io/robotocore/robotocore:latest`
- [ ] README.md GitHub Actions example uses `ghcr.io/robotocore/robotocore:latest`
- [ ] Service READMEs (sqs, sns, s3, kinesis, dynamodb) all use correct image name
- [ ] No broken references to Docker Hub remain in docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)