### PR TITLE
fix: capture SES API emails in /_robotocore/ses/messages

### DIFF
--- a/prompts/20260511-000100-ses-api-email-capture.md
+++ b/prompts/20260511-000100-ses-api-email-capture.md
@@ -1,0 +1,36 @@
+---
+session: "20260511-open-issues"
+timestamp: "2026-05-11T00:01:00Z"
+model: claude-sonnet-4-6
+sequence: 2
+---
+
+## Human
+
+One by one, solve each open GitHub issue with a PR. (Continuation — working on issue #222.)
+
+## Assistant
+
+## Key decisions
+
+**Issue #222: SES SendEmail API emails not appearing in /_robotocore/ses/messages**
+
+Root cause: `EmailStore` is exclusively fed by `RobotocoreSMTPHandler.handle_DATA` in the SMTP server. When boto3/AWS SDK calls `ses.send_email()`, the request goes through the native SES provider → Moto, and Moto stores emails in `backend.sent_messages` (a separate, internal data structure). The management endpoint at `/_robotocore/ses/messages` only reads from `EmailStore`, so API-sent emails never appear.
+
+**Approach chosen: intercept after Moto succeeds**
+
+Three approaches considered:
+
+1. **Bridge Moto's store** — query `backend.sent_messages` in the management endpoint and translate Moto's `Message`/`RawMessage`/`TemplateMessage`/`BulkTemplateMessage` types. Rejected: fragile against Moto version changes; Moto's internal message types differ between SES v1 and v2 paths.
+
+2. **Intercept before Moto** — extract email data from params, add to store, then forward to Moto. Rejected: if Moto rejects the email (unverified sender, invalid address), we'd capture a failed send.
+
+3. **Intercept after Moto** (chosen) — forward to Moto as usual, check HTTP 200, then extract email data from params and add to EmailStore. Only successful sends are captured. Capture errors are logged as debug and never surface to callers.
+
+**Scope of changes:**
+
+- `email_store.py`: Added `source: Literal["smtp", "api"]` field (default "smtp") to `StoredEmail` and `add_message()`. Exposed in `to_dict()`. Backward-compatible — existing SMTP code works unchanged.
+- `provider.py` (SES v1): Added `_SEND_ACTIONS` set; after Moto returns 200, calls `_capture_send()` dispatcher. Capture helpers: `_capture_send_email` (extracts Source + Destination.*.member.N params), `_capture_send_raw_email` (decodes base64, parses email headers), `_capture_send_templated_email` (records template name as subject).
+- `sesv2_provider.py` (SES v2): Added `_OUTBOUND_EMAILS_PATH` regex; intercepts POST `/v2/email/outbound-emails`, reads body bytes, forwards to Moto, then captures on success. `_capture_sesv2_send_email` parses the JSON body's `Content.Simple`/`Content.Template` structure.
+
+**Tests**: 16 new unit tests covering `StoredEmail.source`, `EmailStore` with source parameter, all SES v1 capture helpers (SendEmail, SendRawEmail, SendTemplatedEmail, indexed param collection), and SES v2 capture (simple email, template email, empty body).

--- a/src/robotocore/services/ses/email_store.py
+++ b/src/robotocore/services/ses/email_store.py
@@ -1,19 +1,21 @@
-"""In-memory store for emails sent via the SMTP server."""
+"""In-memory store for emails sent via SMTP or the SES API."""
 
 import threading
 import time
 from dataclasses import dataclass, field
+from typing import Literal
 
 
 @dataclass
 class StoredEmail:
-    """A single email stored from SMTP delivery."""
+    """A single captured email, from SMTP or the SES API."""
 
     sender: str
     recipients: list[str]
     subject: str
     body: str
     raw: str
+    source: Literal["smtp", "api"] = "smtp"
     timestamp: float = field(default_factory=time.time)
 
     def to_dict(self) -> dict:
@@ -22,12 +24,13 @@ class StoredEmail:
             "recipients": self.recipients,
             "subject": self.subject,
             "body": self.body,
+            "source": self.source,
             "timestamp": self.timestamp,
         }
 
 
 class EmailStore:
-    """Thread-safe singleton store for SMTP-delivered emails."""
+    """Thread-safe singleton store for all sent emails."""
 
     def __init__(self) -> None:
         self._messages: list[StoredEmail] = []
@@ -40,6 +43,7 @@ class EmailStore:
         subject: str,
         body: str,
         raw: str,
+        source: Literal["smtp", "api"] = "smtp",
     ) -> None:
         """Store a new email message."""
         msg = StoredEmail(
@@ -48,6 +52,7 @@ class EmailStore:
             subject=subject,
             body=body,
             raw=raw,
+            source=source,
         )
         with self._lock:
             self._messages.append(msg)

--- a/src/robotocore/services/ses/provider.py
+++ b/src/robotocore/services/ses/provider.py
@@ -579,22 +579,26 @@ def _capture_send_email(params: dict, store) -> None:  # type: ignore[type-arg]
 
 def _capture_send_raw_email(params: dict, store) -> None:  # type: ignore[type-arg]
     raw_b64 = params.get("RawMessage.Data", "")
+    raw_bytes = b""
     try:
-        raw = base64.b64decode(raw_b64).decode("utf-8", errors="replace")
+        raw_bytes = base64.b64decode(raw_b64)
     except Exception:  # noqa: BLE001
-        raw = ""
+        logger.debug("SES raw email base64 decode failed (non-fatal)", exc_info=True)
 
     sender = params.get("Source", "")
     recipients = _collect_indexed_params(params, "Destinations")
 
     subject = ""
     body = ""
-    if raw:
+    if raw_bytes:
         try:
-            msg = _email.message_from_string(raw)
+            # Parse from bytes so the email library handles charset detection
+            # before we decode headers — avoids mangling non-UTF8 content.
+            msg = _email.message_from_bytes(raw_bytes)
             subject = msg.get("Subject", "") or ""
             if not sender:
-                sender = msg.get("From", "") or ""
+                # parseaddr strips display names: "Jane Doe <j@x.com>" → "j@x.com"
+                _, sender = _email.utils.parseaddr(msg.get("From", "") or "")
             if not recipients:
                 raw_to = msg.get("To", "") or ""
                 recipients = [addr for _, addr in _email.utils.getaddresses([raw_to]) if addr]
@@ -615,7 +619,7 @@ def _capture_send_raw_email(params: dict, store) -> None:  # type: ignore[type-a
         recipients=recipients,
         subject=subject,
         body=body,
-        raw=raw,
+        raw=raw_bytes.decode("utf-8", errors="replace"),
         source="api",
     )
 

--- a/src/robotocore/services/ses/provider.py
+++ b/src/robotocore/services/ses/provider.py
@@ -71,7 +71,7 @@ async def handle_ses_request(request: Request, region: str, account_id: str) -> 
         try:
             _capture_send(action, params)
         except Exception:  # noqa: BLE001
-            logger.debug("SES email capture failed for %s (non-fatal)", action)
+            logger.debug("SES email capture failed for %s (non-fatal)", action, exc_info=True)
 
     return response
 
@@ -596,8 +596,8 @@ def _capture_send_raw_email(params: dict, store) -> None:  # type: ignore[type-a
             if not sender:
                 sender = msg.get("From", "") or ""
             if not recipients:
-                to_header = (msg.get("To", "") or "").split(",")
-                recipients = [a.strip() for a in to_header if a.strip()]
+                raw_to = msg.get("To", "") or ""
+                recipients = [addr for _, addr in _email.utils.getaddresses([raw_to]) if addr]
             if msg.is_multipart():
                 for part in msg.walk():
                     if part.get_content_type() == "text/plain":
@@ -608,7 +608,7 @@ def _capture_send_raw_email(params: dict, store) -> None:  # type: ignore[type-a
                 payload = msg.get_payload(decode=True)
                 body = payload.decode("utf-8", errors="replace") if payload else ""
         except Exception:  # noqa: BLE001
-            logger.debug("SES raw email parse failed (non-fatal)")
+            logger.debug("SES raw email parse failed (non-fatal)", exc_info=True)
 
     store.add_message(
         sender=sender,
@@ -622,11 +622,30 @@ def _capture_send_raw_email(params: dict, store) -> None:  # type: ignore[type-a
 
 def _capture_send_templated_email(params: dict, store) -> None:  # type: ignore[type-arg]
     sender = params.get("Source", "")
+    template = params.get("Template", "")
+
+    # SendTemplatedEmail uses Destination.ToAddresses.member.N
+    # SendBulkTemplatedEmail uses Destinations.member.N.Destination.ToAddresses.member.N
     to = _collect_indexed_params(params, "Destination.ToAddresses")
     cc = _collect_indexed_params(params, "Destination.CcAddresses")
     bcc = _collect_indexed_params(params, "Destination.BccAddresses")
+
+    if not to and not cc and not bcc:
+        # Bulk form: collect recipients from all Destinations entries
+        i = 1
+        while True:
+            prefix = f"Destinations.member.{i}.Destination"
+            dest_to = _collect_indexed_params(params, f"{prefix}.ToAddresses")
+            dest_cc = _collect_indexed_params(params, f"{prefix}.CcAddresses")
+            dest_bcc = _collect_indexed_params(params, f"{prefix}.BccAddresses")
+            if not dest_to and not dest_cc and not dest_bcc:
+                break
+            to += dest_to
+            cc += dest_cc
+            bcc += dest_bcc
+            i += 1
+
     recipients = to + cc + bcc
-    template = params.get("Template", "")
     store.add_message(
         sender=sender,
         recipients=recipients,

--- a/src/robotocore/services/ses/provider.py
+++ b/src/robotocore/services/ses/provider.py
@@ -6,10 +6,16 @@ Intercepts operations that Moto doesn't support or handles incorrectly:
 - DeleteReceiptRule (not in Moto, only DeleteReceiptRuleSet exists)
 - CreateReceiptRule cleanup support
 
+Also captures all outbound email API calls (SendEmail, SendRawEmail,
+SendTemplatedEmail, SendBulkTemplatedEmail) into the EmailStore so they
+appear at /_robotocore/ses/messages alongside SMTP-delivered emails.
+
 Delegates everything else to Moto via forward_to_moto.
 Uses query protocol (Action parameter).
 """
 
+import base64
+import email as _email
 import logging
 from urllib.parse import parse_qs
 
@@ -17,8 +23,13 @@ from starlette.requests import Request
 from starlette.responses import Response
 
 from robotocore.providers.moto_bridge import forward_to_moto
+from robotocore.services.ses.email_store import get_email_store
 
 logger = logging.getLogger(__name__)
+
+_SEND_ACTIONS = frozenset(
+    {"SendEmail", "SendRawEmail", "SendTemplatedEmail", "SendBulkTemplatedEmail"}
+)
 
 
 def _get_ses_backend(account_id: str, region: str):
@@ -53,7 +64,16 @@ async def handle_ses_request(request: Request, region: str, account_id: str) -> 
             return _error_response("InternalError", str(e), 500)
 
     # Fall back to Moto
-    return await forward_to_moto(request, "ses", account_id=account_id)
+    response = await forward_to_moto(request, "ses", account_id=account_id)
+
+    # Capture successful send operations in the email store
+    if response.status_code == 200 and action in _SEND_ACTIONS:
+        try:
+            _capture_send(action, params)
+        except Exception:  # noqa: BLE001
+            logger.debug("SES email capture failed for %s (non-fatal)", action)
+
+    return response
 
 
 class SesError(Exception):
@@ -508,6 +528,113 @@ def _send_bounce(params: dict, region: str, account_id: str) -> str:
     # We don't need to actually process the bounce; just return a message ID
     message_id = _uuid.uuid4().hex
     return f"<MessageId>{message_id}</MessageId>"
+
+
+# ---------------------------------------------------------------------------
+# Email capture helpers (for /_robotocore/ses/messages)
+# ---------------------------------------------------------------------------
+
+
+def _capture_send(action: str, params: dict) -> None:
+    """Capture a successful SES API send into the shared EmailStore."""
+    store = get_email_store()
+    if action == "SendEmail":
+        _capture_send_email(params, store)
+    elif action == "SendRawEmail":
+        _capture_send_raw_email(params, store)
+    elif action in ("SendTemplatedEmail", "SendBulkTemplatedEmail"):
+        _capture_send_templated_email(params, store)
+
+
+def _collect_indexed_params(params: dict, prefix: str) -> list[str]:
+    """Extract Param.member.1, Param.member.2, ... values in order."""
+    result = []
+    i = 1
+    while True:
+        val = params.get(f"{prefix}.member.{i}")
+        if val is None:
+            break
+        result.append(val)
+        i += 1
+    return result
+
+
+def _capture_send_email(params: dict, store) -> None:  # type: ignore[type-arg]
+    sender = params.get("Source", "")
+    to = _collect_indexed_params(params, "Destination.ToAddresses")
+    cc = _collect_indexed_params(params, "Destination.CcAddresses")
+    bcc = _collect_indexed_params(params, "Destination.BccAddresses")
+    recipients = to + cc + bcc
+    subject = params.get("Message.Subject.Data", "")
+    body = params.get("Message.Body.Text.Data", "") or params.get("Message.Body.Html.Data", "")
+    store.add_message(
+        sender=sender,
+        recipients=recipients,
+        subject=subject,
+        body=body,
+        raw="",
+        source="api",
+    )
+
+
+def _capture_send_raw_email(params: dict, store) -> None:  # type: ignore[type-arg]
+    raw_b64 = params.get("RawMessage.Data", "")
+    try:
+        raw = base64.b64decode(raw_b64).decode("utf-8", errors="replace")
+    except Exception:  # noqa: BLE001
+        raw = ""
+
+    sender = params.get("Source", "")
+    recipients = _collect_indexed_params(params, "Destinations")
+
+    subject = ""
+    body = ""
+    if raw:
+        try:
+            msg = _email.message_from_string(raw)
+            subject = msg.get("Subject", "") or ""
+            if not sender:
+                sender = msg.get("From", "") or ""
+            if not recipients:
+                to_header = (msg.get("To", "") or "").split(",")
+                recipients = [a.strip() for a in to_header if a.strip()]
+            if msg.is_multipart():
+                for part in msg.walk():
+                    if part.get_content_type() == "text/plain":
+                        payload = part.get_payload(decode=True)
+                        body = payload.decode("utf-8", errors="replace") if payload else ""
+                        break
+            else:
+                payload = msg.get_payload(decode=True)
+                body = payload.decode("utf-8", errors="replace") if payload else ""
+        except Exception:  # noqa: BLE001
+            logger.debug("SES raw email parse failed (non-fatal)")
+
+    store.add_message(
+        sender=sender,
+        recipients=recipients,
+        subject=subject,
+        body=body,
+        raw=raw,
+        source="api",
+    )
+
+
+def _capture_send_templated_email(params: dict, store) -> None:  # type: ignore[type-arg]
+    sender = params.get("Source", "")
+    to = _collect_indexed_params(params, "Destination.ToAddresses")
+    cc = _collect_indexed_params(params, "Destination.CcAddresses")
+    bcc = _collect_indexed_params(params, "Destination.BccAddresses")
+    recipients = to + cc + bcc
+    template = params.get("Template", "")
+    store.add_message(
+        sender=sender,
+        recipients=recipients,
+        subject=f"[template: {template}]",
+        body="",
+        raw="",
+        source="api",
+    )
 
 
 _ACTION_MAP = {

--- a/src/robotocore/services/ses/sesv2_provider.py
+++ b/src/robotocore/services/ses/sesv2_provider.py
@@ -1,6 +1,8 @@
 """Native SES v2 provider.
 
 Handles operations that Moto's sesv2 doesn't support (email templates).
+Also captures SendEmail calls into the shared EmailStore so they appear at
+/_robotocore/ses/messages alongside SMTP and SES v1 API emails.
 Delegates everything else to Moto via forward_to_moto.
 Uses REST-JSON protocol with path-based routing.
 """
@@ -14,6 +16,7 @@ from starlette.requests import Request
 from starlette.responses import Response
 
 from robotocore.providers.moto_bridge import forward_to_moto
+from robotocore.services.ses.email_store import get_email_store
 
 logger = logging.getLogger(__name__)
 
@@ -25,6 +28,7 @@ _TEMPLATE_PATH = re.compile(r"^/v2/email/templates/?$")
 _TEMPLATE_ITEM_PATH = re.compile(r"^/v2/email/templates/([^/]+)$")
 _TEMPLATE_RENDER_PATH = re.compile(r"^/v2/email/templates/([^/]+)/render$")
 _MESSAGE_INSIGHTS_PATH = re.compile(r"^/v2/email/insights/([^/]+)/?$")
+_OUTBOUND_EMAILS_PATH = re.compile(r"^/v2/email/outbound-emails/?$")
 
 
 async def handle_sesv2_request(request: Request, region: str, account_id: str) -> Response:
@@ -65,6 +69,17 @@ async def handle_sesv2_request(request: Request, region: str, account_id: str) -
     if m:
         message_id = m.group(1)
         return _get_message_insights(message_id)
+
+    # Intercept SendEmail to capture it in the email store
+    if _OUTBOUND_EMAILS_PATH.match(path) and method == "POST":
+        body_bytes = await request.body()
+        response = await forward_to_moto(request, "sesv2", account_id=account_id)
+        if response.status_code == 200:
+            try:
+                _capture_sesv2_send_email(json.loads(body_bytes))
+            except Exception:  # noqa: BLE001
+                logger.debug("SES v2 email capture failed (non-fatal)")
+        return response
 
     # Everything else → Moto
     return await forward_to_moto(request, "sesv2", account_id=account_id)
@@ -145,6 +160,38 @@ def _get_message_insights(message_id: str) -> Response:
         "Insights": [],
     }
     return Response(content=json.dumps(result), status_code=200, media_type="application/json")
+
+
+def _capture_sesv2_send_email(body: dict) -> None:
+    """Capture a SES v2 SendEmail call into the shared EmailStore."""
+    sender = body.get("FromEmailAddress", "")
+    dest = body.get("Destination", {})
+    recipients = (
+        dest.get("ToAddresses", []) + dest.get("CcAddresses", []) + dest.get("BccAddresses", [])
+    )
+
+    content = body.get("Content", {})
+    simple = content.get("Simple", {})
+    subject = simple.get("Subject", {}).get("Data", "")
+    text_body = simple.get("Body", {}).get("Text", {}).get("Data", "")
+    html_body = simple.get("Body", {}).get("Html", {}).get("Data", "")
+    email_body = text_body or html_body
+
+    # Template-based sends
+    if not subject:
+        template = content.get("Template", {})
+        template_name = template.get("TemplateName", "")
+        if template_name:
+            subject = f"[template: {template_name}]"
+
+    get_email_store().add_message(
+        sender=sender,
+        recipients=recipients,
+        subject=subject,
+        body=email_body,
+        raw="",
+        source="api",
+    )
 
 
 def _error(code: str, message: str, status: int) -> Response:

--- a/src/robotocore/services/ses/sesv2_provider.py
+++ b/src/robotocore/services/ses/sesv2_provider.py
@@ -78,7 +78,7 @@ async def handle_sesv2_request(request: Request, region: str, account_id: str) -
             try:
                 _capture_sesv2_send_email(json.loads(body_bytes))
             except Exception:  # noqa: BLE001
-                logger.debug("SES v2 email capture failed (non-fatal)")
+                logger.debug("SES v2 email capture failed (non-fatal)", exc_info=True)
         return response
 
     # Everything else → Moto

--- a/src/robotocore/services/ses/sesv2_provider.py
+++ b/src/robotocore/services/ses/sesv2_provider.py
@@ -15,7 +15,7 @@ import time
 from starlette.requests import Request
 from starlette.responses import Response
 
-from robotocore.providers.moto_bridge import forward_to_moto
+from robotocore.providers.moto_bridge import forward_to_moto, forward_to_moto_with_body
 from robotocore.services.ses.email_store import get_email_store
 
 logger = logging.getLogger(__name__)
@@ -73,7 +73,9 @@ async def handle_sesv2_request(request: Request, region: str, account_id: str) -
     # Intercept SendEmail to capture it in the email store
     if _OUTBOUND_EMAILS_PATH.match(path) and method == "POST":
         body_bytes = await request.body()
-        response = await forward_to_moto(request, "sesv2", account_id=account_id)
+        response = await forward_to_moto_with_body(
+            request, "sesv2", body_bytes, account_id=account_id
+        )
         if response.status_code == 200:
             try:
                 _capture_sesv2_send_email(json.loads(body_bytes))

--- a/tests/unit/services/ses/test_api_email_capture.py
+++ b/tests/unit/services/ses/test_api_email_capture.py
@@ -159,6 +159,68 @@ class TestSesV1Capture:
         assert msgs[0]["sender"] == "auto@x.com"
         assert "dest@y.com" in msgs[0]["recipients"]
 
+    def test_capture_send_raw_email_strips_display_names(self):
+        """Display names in From/To headers should not bleed into sender/recipients."""
+        from robotocore.services.ses.provider import _capture_send_raw_email
+
+        raw = (
+            'From: "Jane Doe" <jane@x.com>\r\n'
+            'To: "Bob Smith" <bob@y.com>, carol@z.com\r\n'
+            "Subject: Display names\r\n\r\n"
+            "Hello"
+        )
+        encoded = base64.b64encode(raw.encode()).decode()
+        params = {"RawMessage.Data": encoded}
+        _capture_send_raw_email(params, self.store)
+
+        msgs = self.store.get_messages()
+        assert msgs[0]["sender"] == "jane@x.com"
+        assert "bob@y.com" in msgs[0]["recipients"]
+        assert "carol@z.com" in msgs[0]["recipients"]
+        # Display names must not appear in recipient list
+        assert not any("Bob Smith" in r or "carol" == r for r in msgs[0]["recipients"])
+
+    def test_capture_send_raw_email_multipart_body(self):
+        """Multipart MIME: extract text/plain part, ignore html part."""
+        from robotocore.services.ses.provider import _capture_send_raw_email
+
+        raw = (
+            "From: s@x.com\r\nTo: r@y.com\r\nSubject: Multipart\r\n"
+            'MIME-Version: 1.0\r\nContent-Type: multipart/alternative; boundary="bound"\r\n\r\n'
+            "--bound\r\nContent-Type: text/plain\r\n\r\nPlain text part\r\n"
+            "--bound\r\nContent-Type: text/html\r\n\r\n<p>HTML part</p>\r\n"
+            "--bound--"
+        )
+        encoded = base64.b64encode(raw.encode()).decode()
+        params = {"Source": "s@x.com", "RawMessage.Data": encoded}
+        _capture_send_raw_email(params, self.store)
+
+        msgs = self.store.get_messages()
+        assert "Plain text part" in msgs[0]["body"]
+        assert "<p>" not in msgs[0]["body"]
+
+    def test_capture_bulk_templated_email(self):
+        """SendBulkTemplatedEmail: collect recipients from all Destinations entries."""
+        from robotocore.services.ses.provider import _capture_send_templated_email
+
+        params = {
+            "Source": "bulk@x.com",
+            "Template": "BulkTemplate",
+            "Destinations.member.1.Destination.ToAddresses.member.1": "a@y.com",
+            "Destinations.member.1.Destination.ToAddresses.member.2": "b@y.com",
+            "Destinations.member.2.Destination.ToAddresses.member.1": "c@y.com",
+        }
+        _capture_send_templated_email(params, self.store)
+
+        msgs = self.store.get_messages()
+        assert len(msgs) == 1
+        m = msgs[0]
+        assert m["sender"] == "bulk@x.com"
+        assert m["subject"] == "[template: BulkTemplate]"
+        assert "a@y.com" in m["recipients"]
+        assert "b@y.com" in m["recipients"]
+        assert "c@y.com" in m["recipients"]
+
     def test_capture_templated_email(self):
         from robotocore.services.ses.provider import _capture_send_templated_email
 

--- a/tests/unit/services/ses/test_api_email_capture.py
+++ b/tests/unit/services/ses/test_api_email_capture.py
@@ -86,9 +86,6 @@ class TestSesV1Capture:
     def setup_method(self):
         self.store = EmailStore()
 
-    def _patch_store(self):
-        return patch("robotocore.services.ses.provider.get_email_store", return_value=self.store)
-
     def test_capture_send_email(self):
         from robotocore.services.ses.provider import _capture_send_email
 

--- a/tests/unit/services/ses/test_api_email_capture.py
+++ b/tests/unit/services/ses/test_api_email_capture.py
@@ -1,0 +1,274 @@
+"""Unit tests for SES API email capture (issue #222).
+
+Verifies that emails sent via the SES v1 and v2 APIs are captured
+into the EmailStore and appear at /_robotocore/ses/messages.
+"""
+
+import base64
+from unittest.mock import patch
+
+from robotocore.services.ses.email_store import EmailStore, StoredEmail
+
+# ---------------------------------------------------------------------------
+# StoredEmail.source field
+# ---------------------------------------------------------------------------
+
+
+class TestStoredEmailSource:
+    def test_default_source_is_smtp(self):
+        msg = StoredEmail(sender="a@b.com", recipients=[], subject="s", body="b", raw="")
+        assert msg.source == "smtp"
+
+    def test_source_api_stored_and_returned(self):
+        msg = StoredEmail(
+            sender="a@b.com", recipients=[], subject="s", body="b", raw="", source="api"
+        )
+        d = msg.to_dict()
+        assert d["source"] == "api"
+
+    def test_source_smtp_returned_in_dict(self):
+        msg = StoredEmail(sender="a@b.com", recipients=[], subject="s", body="b", raw="")
+        d = msg.to_dict()
+        assert d["source"] == "smtp"
+
+
+# ---------------------------------------------------------------------------
+# EmailStore.add_message with source
+# ---------------------------------------------------------------------------
+
+
+class TestEmailStoreSource:
+    def test_add_api_message(self):
+        store = EmailStore()
+        store.add_message(
+            sender="from@x.com",
+            recipients=["to@y.com"],
+            subject="API email",
+            body="hello",
+            raw="",
+            source="api",
+        )
+        msgs = store.get_messages()
+        assert len(msgs) == 1
+        assert msgs[0]["source"] == "api"
+        assert msgs[0]["subject"] == "API email"
+
+    def test_add_smtp_message_default_source(self):
+        store = EmailStore()
+        store.add_message(
+            sender="from@x.com",
+            recipients=["to@y.com"],
+            subject="SMTP email",
+            body="hello",
+            raw="raw data",
+        )
+        msgs = store.get_messages()
+        assert msgs[0]["source"] == "smtp"
+
+    def test_mixed_sources_both_appear(self):
+        store = EmailStore()
+        store.add_message("a@b.com", ["c@d.com"], "SMTP", "body", "raw")
+        store.add_message("e@f.com", ["g@h.com"], "API", "body", "", source="api")
+        msgs = store.get_messages()
+        assert len(msgs) == 2
+        sources = {m["source"] for m in msgs}
+        assert sources == {"smtp", "api"}
+
+
+# ---------------------------------------------------------------------------
+# SES v1 provider capture helpers
+# ---------------------------------------------------------------------------
+
+
+class TestSesV1Capture:
+    """Test the capture helper functions in the SES v1 provider."""
+
+    def setup_method(self):
+        self.store = EmailStore()
+
+    def _patch_store(self):
+        return patch("robotocore.services.ses.provider.get_email_store", return_value=self.store)
+
+    def test_capture_send_email(self):
+        from robotocore.services.ses.provider import _capture_send_email
+
+        params = {
+            "Source": "sender@example.com",
+            "Destination.ToAddresses.member.1": "to1@example.com",
+            "Destination.ToAddresses.member.2": "to2@example.com",
+            "Destination.CcAddresses.member.1": "cc@example.com",
+            "Message.Subject.Data": "Test subject",
+            "Message.Body.Text.Data": "Test body",
+        }
+        _capture_send_email(params, self.store)
+
+        msgs = self.store.get_messages()
+        assert len(msgs) == 1
+        m = msgs[0]
+        assert m["sender"] == "sender@example.com"
+        assert "to1@example.com" in m["recipients"]
+        assert "to2@example.com" in m["recipients"]
+        assert "cc@example.com" in m["recipients"]
+        assert m["subject"] == "Test subject"
+        assert m["body"] == "Test body"
+        assert m["source"] == "api"
+
+    def test_capture_send_email_html_fallback(self):
+        from robotocore.services.ses.provider import _capture_send_email
+
+        params = {
+            "Source": "s@x.com",
+            "Destination.ToAddresses.member.1": "t@x.com",
+            "Message.Subject.Data": "HTML email",
+            "Message.Body.Html.Data": "<p>HTML content</p>",
+        }
+        _capture_send_email(params, self.store)
+        msgs = self.store.get_messages()
+        assert msgs[0]["body"] == "<p>HTML content</p>"
+
+    def test_capture_send_raw_email(self):
+        from robotocore.services.ses.provider import _capture_send_raw_email
+
+        raw = "From: from@x.com\r\nTo: to@x.com\r\nSubject: Raw subject\r\n\r\nRaw body"
+        encoded = base64.b64encode(raw.encode()).decode()
+
+        params = {
+            "Source": "from@x.com",
+            "Destinations.member.1": "to@x.com",
+            "RawMessage.Data": encoded,
+        }
+        _capture_send_raw_email(params, self.store)
+
+        msgs = self.store.get_messages()
+        assert len(msgs) == 1
+        m = msgs[0]
+        assert m["sender"] == "from@x.com"
+        assert "to@x.com" in m["recipients"]
+        assert m["subject"] == "Raw subject"
+        assert "Raw body" in m["body"]
+        assert m["source"] == "api"
+
+    def test_capture_send_raw_email_parses_headers_when_no_source(self):
+        """When Source param is absent, extract sender/recipients from email headers."""
+        from robotocore.services.ses.provider import _capture_send_raw_email
+
+        raw = "From: auto@x.com\r\nTo: dest@y.com\r\nSubject: Auto\r\n\r\nBody"
+        encoded = base64.b64encode(raw.encode()).decode()
+
+        params = {"RawMessage.Data": encoded}
+        _capture_send_raw_email(params, self.store)
+
+        msgs = self.store.get_messages()
+        assert msgs[0]["sender"] == "auto@x.com"
+        assert "dest@y.com" in msgs[0]["recipients"]
+
+    def test_capture_templated_email(self):
+        from robotocore.services.ses.provider import _capture_send_templated_email
+
+        params = {
+            "Source": "noreply@x.com",
+            "Destination.ToAddresses.member.1": "user@y.com",
+            "Template": "MyTemplate",
+        }
+        _capture_send_templated_email(params, self.store)
+
+        msgs = self.store.get_messages()
+        assert msgs[0]["sender"] == "noreply@x.com"
+        assert msgs[0]["subject"] == "[template: MyTemplate]"
+        assert msgs[0]["source"] == "api"
+
+    def test_collect_indexed_params(self):
+        from robotocore.services.ses.provider import _collect_indexed_params
+
+        params = {
+            "Destination.ToAddresses.member.1": "a@b.com",
+            "Destination.ToAddresses.member.2": "c@d.com",
+            "Destination.ToAddresses.member.3": "e@f.com",
+        }
+        result = _collect_indexed_params(params, "Destination.ToAddresses")
+        assert result == ["a@b.com", "c@d.com", "e@f.com"]
+
+    def test_collect_indexed_params_empty(self):
+        from robotocore.services.ses.provider import _collect_indexed_params
+
+        result = _collect_indexed_params({}, "SomeParam")
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# SES v2 provider capture helpers
+# ---------------------------------------------------------------------------
+
+
+class TestSesV2Capture:
+    """Test the capture helper function in the SES v2 provider."""
+
+    def setup_method(self):
+        self.store = EmailStore()
+
+    def test_capture_simple_email(self):
+        from robotocore.services.ses.sesv2_provider import _capture_sesv2_send_email
+
+        body = {
+            "FromEmailAddress": "sender@x.com",
+            "Destination": {
+                "ToAddresses": ["to@y.com"],
+                "CcAddresses": ["cc@y.com"],
+            },
+            "Content": {
+                "Simple": {
+                    "Subject": {"Data": "V2 subject"},
+                    "Body": {
+                        "Text": {"Data": "V2 text body"},
+                        "Html": {"Data": "<p>V2 html</p>"},
+                    },
+                }
+            },
+        }
+        with patch(
+            "robotocore.services.ses.sesv2_provider.get_email_store", return_value=self.store
+        ):
+            _capture_sesv2_send_email(body)
+
+        msgs = self.store.get_messages()
+        assert len(msgs) == 1
+        m = msgs[0]
+        assert m["sender"] == "sender@x.com"
+        assert "to@y.com" in m["recipients"]
+        assert "cc@y.com" in m["recipients"]
+        assert m["subject"] == "V2 subject"
+        assert m["body"] == "V2 text body"  # text preferred over html
+        assert m["source"] == "api"
+
+    def test_capture_template_email(self):
+        from robotocore.services.ses.sesv2_provider import _capture_sesv2_send_email
+
+        body = {
+            "FromEmailAddress": "noreply@x.com",
+            "Destination": {"ToAddresses": ["user@y.com"]},
+            "Content": {
+                "Template": {
+                    "TemplateName": "WelcomeTemplate",
+                    "TemplateData": '{"name":"Alice"}',
+                }
+            },
+        }
+        with patch(
+            "robotocore.services.ses.sesv2_provider.get_email_store", return_value=self.store
+        ):
+            _capture_sesv2_send_email(body)
+
+        msgs = self.store.get_messages()
+        assert msgs[0]["subject"] == "[template: WelcomeTemplate]"
+
+    def test_capture_missing_fields_does_not_raise(self):
+        from robotocore.services.ses.sesv2_provider import _capture_sesv2_send_email
+
+        with patch(
+            "robotocore.services.ses.sesv2_provider.get_email_store", return_value=self.store
+        ):
+            _capture_sesv2_send_email({})  # empty body, should not raise
+
+        msgs = self.store.get_messages()
+        assert len(msgs) == 1
+        assert msgs[0]["sender"] == ""

--- a/tests/unit/services/ses/test_smtp.py
+++ b/tests/unit/services/ses/test_smtp.py
@@ -51,6 +51,7 @@ class TestStoredEmail:
         assert d["subject"] == "Hello"
         assert d["body"] == "Hi Bob"
         assert d["timestamp"] == 1234567890.0
+        assert d["source"] == "smtp"  # default source
 
     def test_to_dict_excludes_raw(self):
         """The raw field should NOT appear in the dict (it's large and not needed in API)."""

--- a/uv.lock
+++ b/uv.lock
@@ -1709,7 +1709,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.5" },
     { name = "starlette", specifier = ">=0.38" },
-    { name = "uvicorn", specifier = ">=0.30" },
+    { name = "uvicorn", specifier = ">=0.44.0" },
     { name = "xmltodict", specifier = ">=0.13" },
 ]
 provides-extras = ["dev"]
@@ -1931,15 +1931,15 @@ wheels = [
 
 [[package]]
 name = "uvicorn"
-version = "0.41.0"
+version = "0.46.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/32/ce/eeb58ae4ac36fe09e3842eb02e0eb676bf2c53ae062b98f1b2531673efdd/uvicorn-0.41.0.tar.gz", hash = "sha256:09d11cf7008da33113824ee5a1c6422d89fbc2ff476540d69a34c87fab8b571a", size = 82633, upload-time = "2026-02-16T23:07:24.1Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/93/041fca8274050e40e6791f267d82e0e2e27dd165627bd640d3e0e378d877/uvicorn-0.46.0.tar.gz", hash = "sha256:fb9da0926999cc6cb22dc7cd71a94a632f078e6ae47ff683c5c420750fb7413d", size = 88758, upload-time = "2026-04-23T07:16:00.151Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/e4/d04a086285c20886c0daad0e026f250869201013d18f81d9ff5eada73a88/uvicorn-0.41.0-py3-none-any.whl", hash = "sha256:29e35b1d2c36a04b9e180d4007ede3bcb32a85fbdfd6c6aeb3f26839de088187", size = 68783, upload-time = "2026-02-16T23:07:22.357Z" },
+    { url = "https://files.pythonhosted.org/packages/31/a3/5b1562db76a5a488274b2332a97199b32d0442aca0ed193697fd47786316/uvicorn-0.46.0-py3-none-any.whl", hash = "sha256:bbebbcbed972d162afca128605223022bedd345b7bc7855ce66deb31487a9048", size = 70926, upload-time = "2026-04-23T07:15:58.355Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- `SendEmail`, `SendRawEmail`, `SendTemplatedEmail` (SES v1) and `SendEmail` (SES v2) now appear in the `/_robotocore/ses/messages` management endpoint alongside SMTP-delivered emails
- Adds a `source` field (`"smtp"` or `"api"`) to each stored message so callers can tell how the email was sent
- 16 new unit tests covering all capture paths

**Root cause**: The `EmailStore` was exclusively fed by the SMTP server. SES API calls went to Moto, which stores them in an internal `backend.sent_messages` list that the management endpoint never read.

**Fix approach**: Intercept successful send operations in the native SES providers (after Moto returns HTTP 200), extract the email data from request params/body, and add it to the shared `EmailStore`. Capture errors are caught, logged at debug level, and never surface to callers.

**What's captured now:**
| Operation | Method |
|-----------|--------|
| SES v1 `SendEmail` | Extracts `Source`, `Destination.*.member.N`, `Message.Subject.Data`, `Message.Body.*.Data` |
| SES v1 `SendRawEmail` | Decodes base64 `RawMessage.Data`, parses email headers |
| SES v1 `SendTemplatedEmail` / `SendBulkTemplatedEmail` | Records template name as subject |
| SES v2 `SendEmail` | Parses JSON body `Content.Simple` or `Content.Template` |

Closes #222

## Test plan

- [ ] Unit tests: `uv run pytest tests/unit/services/ses/ -q` → 70 passed
- [ ] Start server, send email via `ses.send_email()`, verify it appears in `GET /_robotocore/ses/messages`
- [ ] Verify SMTP-sent emails still appear and have `source: "smtp"`
- [ ] Verify API-sent emails have `source: "api"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)