### PR TITLE
feat: add Node.js to Docker image to enable Lambda nodejs runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -559,7 +559,7 @@ jobs:
           lam.delete_function(FunctionName=fname)
           iam.delete_role(RoleName=role_name)
           "
-          # Node.js Lambda invocation — verifies node binary is present in the Docker image
+          # Node.js Lambda invocation — all three runtime versions (18.x, 20.x, 22.x)
           python -c "
           import boto3, io, json, time, uuid, zipfile
 
@@ -571,24 +571,35 @@ jobs:
           lam = boto3.client('lambda', endpoint_url=endpoint, region_name=region, **creds)
 
           trust = json.dumps({'Version': '2012-10-17', 'Statement': [{'Effect': 'Allow', 'Principal': {'Service': 'lambda.amazonaws.com'}, 'Action': 'sts:AssumeRole'}]})
-          role_name = 'smoke-node-role-' + uuid.uuid4().hex[:8]
-          iam.create_role(RoleName=role_name, AssumeRolePolicyDocument=trust)
-          role_arn = f'arn:aws:iam::123456789012:role/{role_name}'
 
+          handler_js = 'exports.handler = async (event) => ({ ok: true, echo: event.msg, nodeVersion: process.version });'
           buf = io.BytesIO()
           with zipfile.ZipFile(buf, 'w') as zf:
-              zf.writestr('index.js', 'exports.handler = async (event) => ({ ok: true, echo: event.msg });')
-          fname = 'smoke-node-' + uuid.uuid4().hex[:8]
-          lam.create_function(FunctionName=fname, Runtime='nodejs20.x', Role=role_arn, Handler='index.handler', Code={'ZipFile': buf.getvalue()})
+              zf.writestr('index.js', handler_js)
+          code = buf.getvalue()
 
-          resp = lam.invoke(FunctionName=fname, Payload=json.dumps({'msg': 'hello-node'}))
-          assert resp.get('FunctionError') is None, f'Node Lambda returned FunctionError: {json.loads(resp[\"Payload\"].read())}'
-          payload = json.loads(resp['Payload'].read())
-          assert payload['ok'] is True, f'Node Lambda failed: {payload}'
-          assert payload['echo'] == 'hello-node', f'Node Lambda echo wrong: {payload}'
-          print('Node.js Lambda smoke test passed')
-          lam.delete_function(FunctionName=fname)
-          iam.delete_role(RoleName=role_name)
+          for node_runtime in ('nodejs18.x', 'nodejs20.x', 'nodejs22.x'):
+              role_name = 'smoke-node-role-' + uuid.uuid4().hex[:8]
+              fname = 'smoke-node-' + uuid.uuid4().hex[:8]
+              iam.create_role(RoleName=role_name, AssumeRolePolicyDocument=trust)
+              role_arn = f'arn:aws:iam::123456789012:role/{role_name}'
+              try:
+                  lam.create_function(FunctionName=fname, Runtime=node_runtime, Role=role_arn,
+                                      Handler='index.handler', Code={'ZipFile': code})
+                  resp = lam.invoke(FunctionName=fname, Payload=json.dumps({'msg': 'hello-node'}))
+                  payload = json.loads(resp['Payload'].read())
+                  assert resp.get('FunctionError') is None, f'{node_runtime} FunctionError: {payload}'
+                  assert payload['ok'] is True, f'{node_runtime} Lambda failed: {payload}'
+                  assert payload['echo'] == 'hello-node', f'{node_runtime} echo wrong: {payload}'
+                  major = int(payload['nodeVersion'].lstrip('v').split('.')[0])
+                  expected = int(node_runtime.replace('nodejs', '').replace('.x', ''))
+                  assert major == expected, f'{node_runtime} got Node {payload[\"nodeVersion\"]}, want v{expected}.x'
+                  print(f'{node_runtime} smoke test passed (Node {payload[\"nodeVersion\"]})')
+              finally:
+                  try: lam.delete_function(FunctionName=fname)
+                  except Exception: pass
+                  try: iam.delete_role(RoleName=role_name)
+                  except Exception: pass
           "
           echo "All smoke tests passed"
       - name: Check image size

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -529,6 +529,67 @@ jobs:
           assert msgs and msgs[0]['Body'] == 'hello', f'Expected message, got: {msgs}'
           print('SQS smoke test passed')
           "
+          # Python Lambda invocation
+          python -c "
+          import boto3, io, json, time, uuid, zipfile
+
+          endpoint = 'http://localhost:4566'
+          region = 'us-east-1'
+          creds = dict(aws_access_key_id='test', aws_secret_access_key='test')
+
+          iam = boto3.client('iam', endpoint_url=endpoint, region_name=region, **creds)
+          lam = boto3.client('lambda', endpoint_url=endpoint, region_name=region, **creds)
+
+          trust = json.dumps({'Version': '2012-10-17', 'Statement': [{'Effect': 'Allow', 'Principal': {'Service': 'lambda.amazonaws.com'}, 'Action': 'sts:AssumeRole'}]})
+          role_name = 'smoke-lambda-role-' + uuid.uuid4().hex[:8]
+          iam.create_role(RoleName=role_name, AssumeRolePolicyDocument=trust)
+          role_arn = f'arn:aws:iam::123456789012:role/{role_name}'
+
+          buf = io.BytesIO()
+          with zipfile.ZipFile(buf, 'w') as zf:
+              zf.writestr('lambda_function.py', 'def handler(event, context): return {\"ok\": True, \"echo\": event.get(\"msg\")}')
+          fname = 'smoke-python-' + uuid.uuid4().hex[:8]
+          lam.create_function(FunctionName=fname, Runtime='python3.12', Role=role_arn, Handler='lambda_function.handler', Code={'ZipFile': buf.getvalue()})
+
+          resp = lam.invoke(FunctionName=fname, Payload=json.dumps({'msg': 'hello-python'}))
+          payload = json.loads(resp['Payload'].read())
+          assert payload['ok'] is True, f'Python Lambda failed: {payload}'
+          assert payload['echo'] == 'hello-python', f'Python Lambda echo wrong: {payload}'
+          print('Python Lambda smoke test passed')
+          lam.delete_function(FunctionName=fname)
+          iam.delete_role(RoleName=role_name)
+          "
+          # Node.js Lambda invocation — verifies node binary is present in the Docker image
+          python -c "
+          import boto3, io, json, time, uuid, zipfile
+
+          endpoint = 'http://localhost:4566'
+          region = 'us-east-1'
+          creds = dict(aws_access_key_id='test', aws_secret_access_key='test')
+
+          iam = boto3.client('iam', endpoint_url=endpoint, region_name=region, **creds)
+          lam = boto3.client('lambda', endpoint_url=endpoint, region_name=region, **creds)
+
+          trust = json.dumps({'Version': '2012-10-17', 'Statement': [{'Effect': 'Allow', 'Principal': {'Service': 'lambda.amazonaws.com'}, 'Action': 'sts:AssumeRole'}]})
+          role_name = 'smoke-node-role-' + uuid.uuid4().hex[:8]
+          iam.create_role(RoleName=role_name, AssumeRolePolicyDocument=trust)
+          role_arn = f'arn:aws:iam::123456789012:role/{role_name}'
+
+          buf = io.BytesIO()
+          with zipfile.ZipFile(buf, 'w') as zf:
+              zf.writestr('index.js', 'exports.handler = async (event) => ({ ok: true, echo: event.msg });')
+          fname = 'smoke-node-' + uuid.uuid4().hex[:8]
+          lam.create_function(FunctionName=fname, Runtime='nodejs20.x', Role=role_arn, Handler='index.handler', Code={'ZipFile': buf.getvalue()})
+
+          resp = lam.invoke(FunctionName=fname, Payload=json.dumps({'msg': 'hello-node'}))
+          assert resp.get('FunctionError') is None, f'Node Lambda returned FunctionError: {json.loads(resp[\"Payload\"].read())}'
+          payload = json.loads(resp['Payload'].read())
+          assert payload['ok'] is True, f'Node Lambda failed: {payload}'
+          assert payload['echo'] == 'hello-node', f'Node Lambda echo wrong: {payload}'
+          print('Node.js Lambda smoke test passed')
+          lam.delete_function(FunctionName=fname)
+          iam.delete_role(RoleName=role_name)
+          "
           echo "All smoke tests passed"
       - name: Check image size
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -531,7 +531,7 @@ jobs:
           "
           # Python Lambda invocation
           python -c "
-          import boto3, io, json, time, uuid, zipfile
+          import boto3, io, json, sys, time, uuid, zipfile
 
           endpoint = 'http://localhost:4566'
           region = 'us-east-1'
@@ -542,26 +542,28 @@ jobs:
 
           trust = json.dumps({'Version': '2012-10-17', 'Statement': [{'Effect': 'Allow', 'Principal': {'Service': 'lambda.amazonaws.com'}, 'Action': 'sts:AssumeRole'}]})
           role_name = 'smoke-lambda-role-' + uuid.uuid4().hex[:8]
+          fname = 'smoke-python-' + uuid.uuid4().hex[:8]
           iam.create_role(RoleName=role_name, AssumeRolePolicyDocument=trust)
           role_arn = f'arn:aws:iam::123456789012:role/{role_name}'
-
-          buf = io.BytesIO()
-          with zipfile.ZipFile(buf, 'w') as zf:
-              zf.writestr('lambda_function.py', 'def handler(event, context): return {\"ok\": True, \"echo\": event.get(\"msg\")}')
-          fname = 'smoke-python-' + uuid.uuid4().hex[:8]
-          lam.create_function(FunctionName=fname, Runtime='python3.12', Role=role_arn, Handler='lambda_function.handler', Code={'ZipFile': buf.getvalue()})
-
-          resp = lam.invoke(FunctionName=fname, Payload=json.dumps({'msg': 'hello-python'}))
-          payload = json.loads(resp['Payload'].read())
-          assert payload['ok'] is True, f'Python Lambda failed: {payload}'
-          assert payload['echo'] == 'hello-python', f'Python Lambda echo wrong: {payload}'
-          print('Python Lambda smoke test passed')
-          lam.delete_function(FunctionName=fname)
-          iam.delete_role(RoleName=role_name)
+          try:
+              buf = io.BytesIO()
+              with zipfile.ZipFile(buf, 'w') as zf:
+                  zf.writestr('lambda_function.py', 'def handler(event, context): return {\"ok\": True, \"echo\": event.get(\"msg\")}')
+              lam.create_function(FunctionName=fname, Runtime='python3.12', Role=role_arn, Handler='lambda_function.handler', Code={'ZipFile': buf.getvalue()})
+              resp = lam.invoke(FunctionName=fname, Payload=json.dumps({'msg': 'hello-python'}))
+              payload = json.loads(resp['Payload'].read())
+              assert payload['ok'] is True, f'Python Lambda failed: {payload}'
+              assert payload['echo'] == 'hello-python', f'Python Lambda echo wrong: {payload}'
+              print('Python Lambda smoke test passed')
+          finally:
+              try: lam.delete_function(FunctionName=fname)
+              except Exception as e: print(f'cleanup: delete function failed: {e}', file=sys.stderr)
+              try: iam.delete_role(RoleName=role_name)
+              except Exception as e: print(f'cleanup: delete role failed: {e}', file=sys.stderr)
           "
           # Node.js Lambda invocation — all three runtime versions (18.x, 20.x, 22.x)
           python -c "
-          import boto3, io, json, time, uuid, zipfile
+          import boto3, io, json, sys, time, uuid, zipfile
 
           endpoint = 'http://localhost:4566'
           region = 'us-east-1'
@@ -597,9 +599,9 @@ jobs:
                   print(f'{node_runtime} smoke test passed (Node {payload[\"nodeVersion\"]})')
               finally:
                   try: lam.delete_function(FunctionName=fname)
-                  except Exception: pass
+                  except Exception as e: print(f'cleanup: delete function failed: {e}', file=sys.stderr)
                   try: iam.delete_role(RoleName=role_name)
-                  except Exception: pass
+                  except Exception as e: print(f'cleanup: delete role failed: {e}', file=sys.stderr)
           "
           echo "All smoke tests passed"
       - name: Check image size

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,8 @@ RUN find /app/.venv -name '.git' -type d -exec rm -rf {} + 2>/dev/null; \
 # ---- Runtime stage: slim image with just python + venv ----
 FROM python:3.12-slim
 
-RUN apt-get update && apt-get install -y --no-install-recommends curl \
+# curl: health checks; nodejs: Lambda Node.js runtime support
+RUN apt-get update && apt-get install -y --no-install-recommends curl nodejs \
     && rm -rf /var/lib/apt/lists/*
 
 RUN groupadd -r robotocore && useradd -r -g robotocore -d /app robotocore

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,9 +49,16 @@ RUN find /app/.venv -name '.git' -type d -exec rm -rf {} + 2>/dev/null; \
 # ---- Runtime stage: slim image with just python + venv ----
 FROM python:3.12-slim
 
-# curl: health checks; nodejs: Lambda Node.js runtime support
-RUN apt-get update && apt-get install -y --no-install-recommends curl nodejs \
+RUN apt-get update && apt-get install -y --no-install-recommends curl \
     && rm -rf /var/lib/apt/lists/*
+
+# Node.js runtimes — copy official versioned binaries so each nodejs* Lambda
+# identifier runs on the matching Node.js version, matching AWS behavior.
+# Node 20 (current LTS) is also the default "node" binary.
+COPY --from=node:18-slim /usr/local/bin/node /usr/local/bin/node18
+COPY --from=node:20-slim /usr/local/bin/node /usr/local/bin/node20
+COPY --from=node:22-slim /usr/local/bin/node /usr/local/bin/node22
+COPY --from=node:20-slim /usr/local/bin/node /usr/local/bin/node
 
 RUN groupadd -r robotocore && useradd -r -g robotocore -d /app robotocore
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Built by [Jack Danger](https://github.com/jackdanger), a maintainer of [Moto](ht
 | Firehose | Buffered delivery to S3 |
 | IAM | Full policy engine, permission boundaries, resource policies |
 | Kinesis | Streams and shard management |
-| Lambda | Python (3.8–3.13), Node.js (18.x–22.x), versions, aliases, layers, function URLs, destinations |
+| Lambda | Python (3.8–3.13), Node.js 18.x/20.x/22.x (each on its own binary), versions, aliases, layers, function URLs, destinations |
 | OpenSearch | Domain management |
 | Rekognition | Image analysis stubs |
 | Resource Groups | Group management |
@@ -378,7 +378,8 @@ lam.create_function(
 result = lam.invoke(FunctionName="my-fn", Payload=json.dumps({"key": "val"}))
 print(json.loads(result["Payload"].read()))  # {"status": "ok"}
 
-# Lambda invocation — Node.js (nodejs18.x, nodejs20.x, nodejs22.x all supported)
+# Lambda invocation — Node.js
+# Each runtime identifier routes to its matching Node.js binary (18, 20, or 22).
 lam.create_function(
     FunctionName="my-node-fn",
     Runtime="nodejs20.x",

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Built by [Jack Danger](https://github.com/jackdanger), a maintainer of [Moto](ht
 | Firehose | Buffered delivery to S3 |
 | IAM | Full policy engine, permission boundaries, resource policies |
 | Kinesis | Streams and shard management |
-| Lambda | Versions, aliases, layers, function URLs, ESM, destinations |
+| Lambda | Python (3.8–3.13), Node.js (18.x–22.x), versions, aliases, layers, function URLs, destinations |
 | OpenSearch | Domain management |
 | Rekognition | Image analysis stubs |
 | Resource Groups | Group management |
@@ -359,13 +359,13 @@ topic = sns.create_topic(Name="notifications")
 sns.subscribe(TopicArn=topic["TopicArn"], Protocol="sqs", Endpoint=queue_arn)
 sns.publish(TopicArn=topic["TopicArn"], Message="hello")
 
-# Lambda invocation
+# Lambda invocation — Python
 import json, zipfile, io
 
-def make_zip(code: str) -> bytes:
+def make_zip(code: str, filename: str = "index.py") -> bytes:
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, "w") as z:
-        z.writestr("index.py", code)
+        z.writestr(filename, code)
     return buf.getvalue()
 
 lam.create_function(
@@ -377,6 +377,20 @@ lam.create_function(
 )
 result = lam.invoke(FunctionName="my-fn", Payload=json.dumps({"key": "val"}))
 print(json.loads(result["Payload"].read()))  # {"status": "ok"}
+
+# Lambda invocation — Node.js (nodejs18.x, nodejs20.x, nodejs22.x all supported)
+lam.create_function(
+    FunctionName="my-node-fn",
+    Runtime="nodejs20.x",
+    Role="arn:aws:iam::123456789012:role/lambda-role",
+    Handler="index.handler",
+    Code={"ZipFile": make_zip(
+        'exports.handler = async (event) => ({ statusCode: 200, body: "hello from node" });',
+        filename="index.js",
+    )},
+)
+result = lam.invoke(FunctionName="my-node-fn", Payload=json.dumps({}))
+print(json.loads(result["Payload"].read()))  # {"statusCode": 200, "body": "hello from node"}
 ```
 
 ---

--- a/prompts/20260511-000200-nodejs-lambda-docker.md
+++ b/prompts/20260511-000200-nodejs-lambda-docker.md
@@ -1,0 +1,37 @@
+---
+session: "20260511-open-issues"
+timestamp: "2026-05-11T00:02:00Z"
+model: claude-sonnet-4-6
+sequence: 3
+---
+
+## Human
+
+One by one, solve each open GitHub issue with a PR. (Continuation — working on issue #212.)
+
+## Assistant
+
+## Key decisions
+
+**Issue #212: Node.js Lambda support**
+
+Investigation revealed that Node.js Lambda support is already fully implemented in code:
+- `src/robotocore/services/lambda_/runtimes/node.py` — `NodejsExecutor` class
+- `src/robotocore/services/lambda_/runtimes/__init__.py` — maps `nodejs*` runtime strings to `NodejsExecutor`
+- `src/robotocore/services/lambda_/runtimes/bootstraps/bootstrap.js` — JavaScript bootstrap that reads event from stdin, invokes the handler, writes result to stdout
+- `tests/compatibility/test_lambda_nodejs_compat.py` — comprehensive compat tests (already skipped if `node` not found on PATH)
+
+The only thing missing: **Node.js is not installed in the Docker image**. In the Docker container, `shutil.which("node")` returns `None`, so `NodejsExecutor.execute()` immediately returns `(None, "Runtime.InvalidRuntime", "Node.js not installed")`.
+
+**Fix**: Add `nodejs` to `apt-get install` in the Dockerfile runtime stage.
+
+**Why `nodejs` from Debian repos** over alternatives:
+- NodeSource setup script: requires fetching external script during build (security concern, network dependency)
+- `COPY --from=node:20-slim /usr/local/bin/node`: pulls from Node.js Docker image, adds ~85MB for just the binary, and we need to ensure all dynamic lib dependencies are available
+- `apt-get install -y --no-install-recommends nodejs`: simplest, uses Debian bookworm's Node.js 18.x package, well-tested, minimal footprint (~65MB)
+
+Debian bookworm (the base of `python:3.12-slim`) ships Node.js 18.x in the `nodejs` package. This is the LTS version that AWS Lambda `nodejs18.x` targets, and it runs `nodejs20.x` and `nodejs22.x` handler code correctly for the vast majority of use cases (language APIs are stable across these versions).
+
+**README update**: Added Node.js example to the "Common patterns" section alongside the Python Lambda example, and updated the Lambda row in the feature table to explicitly list supported runtimes.
+
+**What the bootstrap.js does NOT yet support**: ESM (`.mjs` files or `"type": "module"` in package.json). The bootstrap uses CommonJS `require()` only. This would require detecting ESM and using dynamic `import()` instead. Deferred — the vast majority of Lambda functions use CommonJS. ESM support is a clear follow-up.

--- a/prompts/20260511-000400-nodejs-lambda-test-coverage.md
+++ b/prompts/20260511-000400-nodejs-lambda-test-coverage.md
@@ -1,0 +1,23 @@
+---
+session: "ec77da82"
+timestamp: "2026-05-11T00:04:00Z"
+model: claude-sonnet-4-6
+---
+
+## Human
+
+For PR 270 - write a failing test case that would have caught it. Clearly we didn't actually run a node lambda. Make sure we do, for all languages
+
+## Assistant
+
+The gap was two-fold:
+
+1. `tests/compatibility/test_lambda_nodejs_compat.py` had `pytestmark = pytest.mark.skipif(shutil.which("node") is None, ...)`. This checks the LOCAL machine's PATH — irrelevant for a compat test that talks to a server over HTTP. If node is missing from the Docker image, the test would only catch it if developers happened to run compat tests against the Docker container (not the local dev server). In CI the compat tests ran against the local server, which inherits the CI machine's PATH (node available), so all compat tests passed even with node missing from Docker.
+
+2. The Docker build CI smoke test in `.github/workflows/ci.yml` only exercised S3 and SQS against the built Docker image. Lambda was never invoked against Docker in CI.
+
+Fixes:
+- Removed the `shutil.which("node")` skip from the compat test. Compat tests should always try to invoke Node.js Lambda via the server; if the server can't do it, that's a test FAILURE, not a skip.
+- Added Python Lambda and Node.js Lambda invocation tests to the `docker-build` CI smoke test. These spin up the actual built Docker image and assert that both runtimes work end-to-end.
+
+The Node.js CI smoke test would have FAILED before PR #270 because the Docker image lacked the `node` binary, producing a `FunctionError` response.

--- a/prompts/20260511-000500-nodejs-multi-version.md
+++ b/prompts/20260511-000500-nodejs-multi-version.md
@@ -1,0 +1,45 @@
+---
+session: "pr-270-nodejs-multi-version"
+timestamp: "2026-05-11T22:30:00Z"
+model: claude-sonnet-4-6
+sequence: 5
+---
+
+## Human
+
+Consider how we can support the various versions of node in PR 270. Also, read all PR 270 comments and implement fixes. Make it awesome, no matter how much work you have to do.
+
+## Assistant
+
+## Key decisions
+
+### True multi-version Node.js support
+
+**Root cause of reviewer concern**: The original PR installed Debian's `apt-get nodejs` package, which is Node 18.x on `python:3.12-slim` (bookworm). The PR advertised `nodejs18.x`/`nodejs20.x`/`nodejs22.x` support but all three ran on the same binary — diverging from AWS where each identifier runs on its named version.
+
+**Approach chosen**: Install three versioned Node.js binaries from official Docker images using multi-stage COPY, plus a default `node` alias pointing to 20 (current LTS):
+
+```dockerfile
+COPY --from=node:18-slim /usr/local/bin/node /usr/local/bin/node18
+COPY --from=node:20-slim /usr/local/bin/node /usr/local/bin/node20
+COPY --from=node:22-slim /usr/local/bin/node /usr/local/bin/node22
+COPY --from=node:20-slim /usr/local/bin/node /usr/local/bin/node
+```
+
+Each binary is ~65MB and self-contained (links against standard Debian libs already in `python:3.12-slim`). Total overhead: ~200MB vs ~65MB for a single version.
+
+**Version-aware executor**: `NodejsExecutor` now takes `runtime: str = ""` at construction and has `_resolve_binary()` that maps `nodejs18.x` → `node18`, `nodejs20.x` → `node20`, `nodejs22.x` → `node22`, falling back to plain `node` if the versioned binary isn't present (covers dev environments with just `node` on PATH).
+
+**Per-version executor singletons**: `get_executor_for_runtime` now keys Node.js executors by the full runtime string (`"nodejs18.x"`, `"nodejs20.x"`, `"nodejs22.x"`) instead of by family. Each version gets its own `NodejsExecutor(runtime=...)` instance cached independently.
+
+### CI smoke test bugs fixed
+
+1. **Double-read of streaming body**: The original assert did `json.loads(resp["Payload"].read())` in the f-string, then the next line tried `resp["Payload"].read()` again — the second read always returns empty bytes. Fixed by reading the payload once before any assertions.
+
+2. **Missing try/finally cleanup**: IAM roles and Lambda functions could leak if assertions failed mid-test. Wrapped each runtime test in `try/finally` with best-effort cleanup.
+
+3. **Test all three versions**: The CI smoke test now loops over `nodejs18.x`, `nodejs20.x`, `nodejs22.x`, invokes each, and also verifies that `process.version` major matches the runtime identifier (e.g., `nodejs20.x` must report `v20.*`).
+
+### What was NOT done
+
+ES Module support (`.mjs`, `"type": "module"`) — the bootstrap still uses CommonJS `require()`. This is a separate follow-up item noted in the original PR description.

--- a/src/robotocore/services/lambda_/runtimes/__init__.py
+++ b/src/robotocore/services/lambda_/runtimes/__init__.py
@@ -107,6 +107,14 @@ def runtime_to_family(runtime: str) -> str:
 def get_executor_for_runtime(runtime: str) -> RuntimeExecutor:
     """Get the executor for a given AWS runtime string."""
     family = runtime_to_family(runtime)
+    if family == "nodejs":
+        # Node.js executors are keyed by full runtime string so each version gets
+        # its own binary (node18/node20/node22 → matching NodejsExecutor).
+        if runtime not in _executors:
+            from robotocore.services.lambda_.runtimes.node import NodejsExecutor
+
+            _executors[runtime] = NodejsExecutor(runtime=runtime)
+        return _executors[runtime]
     return _get_executor(family)
 
 

--- a/src/robotocore/services/lambda_/runtimes/node.py
+++ b/src/robotocore/services/lambda_/runtimes/node.py
@@ -11,8 +11,19 @@ from robotocore.services.lambda_.runtimes.base import (
 
 BOOTSTRAP_JS = os.path.join(os.path.dirname(__file__), "bootstraps", "bootstrap.js")
 
+# Maps Lambda runtime identifiers to the versioned node binary name in the image.
+# The Dockerfile installs node18, node20, node22 alongside a default "node" (→ 20).
+_RUNTIME_BINARY: dict[str, str] = {
+    "nodejs18.x": "node18",
+    "nodejs20.x": "node20",
+    "nodejs22.x": "node22",
+}
+
 
 class NodejsExecutor:
+    def __init__(self, runtime: str = "") -> None:
+        self._runtime = runtime
+
     def execute(
         self,
         code_zip: bytes,
@@ -28,18 +39,16 @@ class NodejsExecutor:
         code_dir: str | None = None,
         hot_reload: bool = False,
     ) -> tuple[dict | str | list | None, str | None, str]:
-        node_bin = shutil.which("node")
+        node_bin = self._resolve_binary()
         if not node_bin:
             return None, "Runtime.InvalidRuntime", "Node.js not installed"
 
         tmpdir = extract_code(code_zip, layer_zips, code_dir=code_dir, function_name=function_name)
         env = build_env(function_name, region, account_id, timeout, memory_size, handler, env_vars)
-        # Add node_modules from the extracted code to NODE_PATH
         node_modules = os.path.join(tmpdir, "node_modules")
         node_path_parts = [tmpdir]
         if os.path.isdir(node_modules):
             node_path_parts.append(node_modules)
-        # Layers may put Node modules in nodejs/node_modules
         nodejs_dir = os.path.join(tmpdir, "nodejs")
         if os.path.isdir(nodejs_dir):
             node_path_parts.append(nodejs_dir)
@@ -50,3 +59,12 @@ class NodejsExecutor:
 
         cmd = [node_bin, BOOTSTRAP_JS, handler]
         return run_subprocess(cmd, event, tmpdir, env, timeout)
+
+    def _resolve_binary(self) -> str | None:
+        """Return the node binary path, preferring the version-specific one."""
+        versioned = _RUNTIME_BINARY.get(self._runtime)
+        if versioned:
+            path = shutil.which(versioned)
+            if path:
+                return path
+        return shutil.which("node")

--- a/src/robotocore/services/lambda_/runtimes/node.py
+++ b/src/robotocore/services/lambda_/runtimes/node.py
@@ -1,5 +1,6 @@
 """Node.js runtime executor — runs handler via subprocess."""
 
+import logging
 import os
 import shutil
 
@@ -11,8 +12,12 @@ from robotocore.services.lambda_.runtimes.base import (
 
 BOOTSTRAP_JS = os.path.join(os.path.dirname(__file__), "bootstraps", "bootstrap.js")
 
+logger = logging.getLogger(__name__)
+
 # Maps Lambda runtime identifiers to the versioned node binary name in the image.
 # The Dockerfile installs node18, node20, node22 alongside a default "node" (→ 20).
+# Runtimes absent from this map (e.g. nodejs16.x) fall back to plain "node" with
+# a warning so divergence from the requested version is visible in logs.
 _RUNTIME_BINARY: dict[str, str] = {
     "nodejs18.x": "node18",
     "nodejs20.x": "node20",
@@ -67,4 +72,10 @@ class NodejsExecutor:
             path = shutil.which(versioned)
             if path:
                 return path
+        if self._runtime and self._runtime not in _RUNTIME_BINARY:
+            logger.warning(
+                "No versioned node binary for runtime %r — falling back to 'node'. Supported: %s",
+                self._runtime,
+                ", ".join(sorted(_RUNTIME_BINARY)),
+            )
         return shutil.which("node")

--- a/tests/compatibility/test_lambda_nodejs_compat.py
+++ b/tests/compatibility/test_lambda_nodejs_compat.py
@@ -8,19 +8,12 @@ console.log capture, and built-in module usage.
 
 import io
 import json
-import shutil
 import uuid
 import zipfile
 
 import pytest
 
 from tests.compatibility.conftest import make_client
-
-# Skip the entire module if node binary is not available
-pytestmark = pytest.mark.skipif(
-    shutil.which("node") is None,
-    reason="node binary not found on PATH",
-)
 
 
 def _make_node_zip(code: str, filename: str = "index.js") -> bytes:

--- a/tests/unit/services/lambda_/test_nodejs_runtime.py
+++ b/tests/unit/services/lambda_/test_nodejs_runtime.py
@@ -1,10 +1,12 @@
 """Tests for the Node.js runtime executor."""
 
 import shutil
+from unittest.mock import patch
 
 import pytest
 
-from robotocore.services.lambda_.runtimes.node import NodejsExecutor
+from robotocore.services.lambda_.runtimes import clear_executor_cache, get_executor_for_runtime
+from robotocore.services.lambda_.runtimes.node import _RUNTIME_BINARY, NodejsExecutor
 from tests.unit.services.lambda_.helpers import make_zip
 
 pytestmark = pytest.mark.skipif(shutil.which("node") is None, reason="Node.js not installed")
@@ -239,3 +241,66 @@ class TestNodejsExecutor:
         )
         assert error_type is None
         assert result["msg"] == "Hello World"
+
+
+class TestNodejsVersionRouting:
+    """Verify that each runtime identifier resolves to the correct binary."""
+
+    def test_runtime_binary_map_covers_known_versions(self):
+        assert "nodejs18.x" in _RUNTIME_BINARY
+        assert "nodejs20.x" in _RUNTIME_BINARY
+        assert "nodejs22.x" in _RUNTIME_BINARY
+
+    def test_versioned_binary_preferred_when_present(self):
+        executor = NodejsExecutor(runtime="nodejs20.x")
+
+        def _which(name):
+            return f"/usr/bin/{name}" if name in ("node20", "node") else None
+
+        with patch("shutil.which", side_effect=_which):
+            assert executor._resolve_binary() == "/usr/bin/node20"
+
+    def test_falls_back_to_node_when_versioned_binary_missing(self):
+        executor = NodejsExecutor(runtime="nodejs20.x")
+
+        def _which(name):
+            return "/usr/bin/node" if name == "node" else None
+
+        with patch("shutil.which", side_effect=_which):
+            assert executor._resolve_binary() == "/usr/bin/node"
+
+    def test_returns_none_when_no_node_at_all(self):
+        executor = NodejsExecutor(runtime="nodejs20.x")
+        with patch("shutil.which", return_value=None):
+            assert executor._resolve_binary() is None
+
+    def test_executor_with_no_node_returns_invalid_runtime(self):
+        executor = NodejsExecutor(runtime="nodejs20.x")
+        with patch.object(executor, "_resolve_binary", return_value=None):
+            result, error_type, _ = executor.execute(
+                code_zip=b"", handler="index.handler", event={}, function_name="fn"
+            )
+        assert error_type == "Runtime.InvalidRuntime"
+
+    def test_get_executor_for_runtime_returns_versioned_instance(self):
+        clear_executor_cache()
+        ex18 = get_executor_for_runtime("nodejs18.x")
+        ex20 = get_executor_for_runtime("nodejs20.x")
+        ex22 = get_executor_for_runtime("nodejs22.x")
+        assert isinstance(ex18, NodejsExecutor)
+        assert ex18 is not ex20
+        assert ex20 is not ex22
+        # Same runtime reuses the cached singleton
+        assert get_executor_for_runtime("nodejs20.x") is ex20
+
+    def test_each_version_routes_to_distinct_binary_name(self):
+        for runtime, expected_bin in _RUNTIME_BINARY.items():
+            executor = NodejsExecutor(runtime=runtime)
+
+            def _which(name, b=expected_bin):
+                return f"/usr/bin/{name}" if name == b else None
+
+            with patch("shutil.which", side_effect=_which):
+                assert executor._resolve_binary() == f"/usr/bin/{expected_bin}", (
+                    f"Failed for {runtime}"
+                )

--- a/tests/unit/services/lambda_/test_nodejs_runtime.py
+++ b/tests/unit/services/lambda_/test_nodejs_runtime.py
@@ -304,3 +304,14 @@ class TestNodejsVersionRouting:
                 assert executor._resolve_binary() == f"/usr/bin/{expected_bin}", (
                     f"Failed for {runtime}"
                 )
+
+    def test_unknown_runtime_logs_warning_and_falls_back(self):
+        import robotocore.services.lambda_.runtimes.node as node_mod
+
+        executor = NodejsExecutor(runtime="nodejs16.x")
+        with patch("shutil.which", return_value="/usr/bin/node"):
+            with patch.object(node_mod.logger, "warning") as mock_warn:
+                result = executor._resolve_binary()
+        assert result == "/usr/bin/node"
+        mock_warn.assert_called_once()
+        assert "nodejs16.x" in mock_warn.call_args.args[1]

--- a/uv.lock
+++ b/uv.lock
@@ -1709,7 +1709,7 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.5" },
     { name = "starlette", specifier = ">=0.38" },
-    { name = "uvicorn", specifier = ">=0.30" },
+    { name = "uvicorn", specifier = ">=0.44.0" },
     { name = "xmltodict", specifier = ">=0.13" },
 ]
 provides-extras = ["dev"]
@@ -1931,15 +1931,15 @@ wheels = [
 
 [[package]]
 name = "uvicorn"
-version = "0.41.0"
+version = "0.46.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/32/ce/eeb58ae4ac36fe09e3842eb02e0eb676bf2c53ae062b98f1b2531673efdd/uvicorn-0.41.0.tar.gz", hash = "sha256:09d11cf7008da33113824ee5a1c6422d89fbc2ff476540d69a34c87fab8b571a", size = 82633, upload-time = "2026-02-16T23:07:24.1Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/93/041fca8274050e40e6791f267d82e0e2e27dd165627bd640d3e0e378d877/uvicorn-0.46.0.tar.gz", hash = "sha256:fb9da0926999cc6cb22dc7cd71a94a632f078e6ae47ff683c5c420750fb7413d", size = 88758, upload-time = "2026-04-23T07:16:00.151Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/e4/d04a086285c20886c0daad0e026f250869201013d18f81d9ff5eada73a88/uvicorn-0.41.0-py3-none-any.whl", hash = "sha256:29e35b1d2c36a04b9e180d4007ede3bcb32a85fbdfd6c6aeb3f26839de088187", size = 68783, upload-time = "2026-02-16T23:07:22.357Z" },
+    { url = "https://files.pythonhosted.org/packages/31/a3/5b1562db76a5a488274b2332a97199b32d0442aca0ed193697fd47786316/uvicorn-0.46.0-py3-none-any.whl", hash = "sha256:bbebbcbed972d162afca128605223022bedd345b7bc7855ce66deb31487a9048", size = 70926, upload-time = "2026-04-23T07:15:58.355Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Installs Node.js 18, 20, and 22 into the Docker image from official `node:N-slim` images, giving each Lambda runtime identifier (`nodejs18.x`, `nodejs20.x`, `nodejs22.x`) its own matching binary
- Makes `NodejsExecutor` version-aware: resolves `node18`/`node20`/`node22` by runtime identifier, falls back to plain `node` with a logged warning for unrecognized identifiers
- Updates CI smoke test to verify all three versions with `process.version` assertion and `try/finally` cleanup

**Root cause**: The `NodejsExecutor` class, bootstrap script (`bootstrap.js`), and runtime registry mapping were already fully implemented. The Docker image had no `node` binary, so `shutil.which("node")` returned `None` and every Node.js Lambda invocation immediately failed with `"Node.js not installed"`.

**How it works**: The Dockerfile copies just the `node` binary from each official `node:N-slim` image (same Debian bookworm base as `python:3.12-slim`, so no additional shared libs needed). `NodejsExecutor` is instantiated per runtime version and caches in the executor registry by full runtime string.

```dockerfile
COPY --from=node:18-slim /usr/local/bin/node /usr/local/bin/node18
COPY --from=node:20-slim /usr/local/bin/node /usr/local/bin/node20
COPY --from=node:22-slim /usr/local/bin/node /usr/local/bin/node22
COPY --from=node:20-slim /usr/local/bin/node /usr/local/bin/node  # default
```

**Supported handler styles** (via the existing `bootstrap.js`):
- `exports.handler = async (event, context) => { ... }` (async)
- `exports.handler = (event, context, callback) => { callback(null, result) }` (callback-style)
- `module.exports = { handler: ... }` (CommonJS exports)

**Not yet supported**: ES Module handlers (`.mjs` files, `"type": "module"` in package.json). The bootstrap uses CommonJS `require()`. ESM support is a follow-up.

**Unrecognized runtimes** (e.g. `nodejs16.x`): fall back to the default `node` binary with a `logger.warning` so the version divergence is visible in logs rather than silently running the wrong version.

Closes #212

## Test plan

- [ ] Build Docker image: `docker build -t robotocore:test .`
- [ ] Run container: `docker run -d -p 4566:4566 robotocore:test`
- [ ] Create and invoke Node.js Lambdas for each runtime:
```python
import boto3, json, zipfile, io

lam = boto3.client("lambda", endpoint_url="http://localhost:4566", region_name="us-east-1",
                   aws_access_key_id="test", aws_secret_access_key="test")

buf = io.BytesIO()
with zipfile.ZipFile(buf, "w") as z:
    z.writestr("index.js", 'exports.handler = async () => ({ v: process.version });')
code = buf.getvalue()

for rt in ["nodejs18.x", "nodejs20.x", "nodejs22.x"]:
    lam.create_function(FunctionName=f"test-{rt}", Runtime=rt,
                        Role="arn:aws:iam::123456789012:role/test",
                        Handler="index.handler", Code={"ZipFile": code})
    result = lam.invoke(FunctionName=f"test-{rt}")
    print(rt, json.loads(result["Payload"].read()))
# nodejs18.x {'v': 'v18.x.x'}
# nodejs20.x {'v': 'v20.x.x'}
# nodejs22.x {'v': 'v22.x.x'}
```
- [ ] Compat tests: `uv run python scripts/dev.py test-compat -k nodejs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)