### PR TITLE
fix: use DOTNET_SYSTEM_GLOBALIZATION_INVARIANT to avoid libicu dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -636,6 +636,14 @@ jobs:
       - name: Build java-and-dotnet Docker image
         run: docker build --target java-and-dotnet -t robotocore:java-and-dotnet .
 
+      - name: Verify dotnet CLI is functional in java-and-dotnet image
+        # Catches missing ICU / globalization setup before the container even starts.
+        # This fails fast if DOTNET_SYSTEM_GLOBALIZATION_INVARIANT is missing or the
+        # .NET install is broken (e.g. wrong architecture, missing shared libs).
+        run: |
+          docker run --rm robotocore:java-and-dotnet dotnet --version
+          docker run --rm robotocore:java-and-dotnet java -version
+
       - name: Start java-and-dotnet container
         run: |
           docker run -d -p 4566:4566 --name robotocore-full robotocore:java-and-dotnet

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -637,9 +637,9 @@ jobs:
         run: docker build --target java-and-dotnet -t robotocore:java-and-dotnet .
 
       - name: Verify dotnet CLI is functional in java-and-dotnet image
-        # Catches missing ICU / globalization setup before the container even starts.
-        # This fails fast if DOTNET_SYSTEM_GLOBALIZATION_INVARIANT is missing or the
-        # .NET install is broken (e.g. wrong architecture, missing shared libs).
+        # Fails fast if the runtime toolchain is broken (missing ICU/globalization
+        # setup, wrong architecture, missing shared libs) before starting the
+        # long-running robotocore-full service container.
         run: |
           docker run --rm robotocore:java-and-dotnet dotnet --version
           docker run --rm robotocore:java-and-dotnet java -version

--- a/Dockerfile
+++ b/Dockerfile
@@ -116,6 +116,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends wget ca-certifi
 ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
 ENV DOTNET_NOLOGO=1
 ENV DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+# Use invariant globalization mode: avoids a hard dependency on libicu (whose
+# package name changes between Debian releases, e.g. libicu72 → libicu74).
+# Lambda runtimes don't need locale-sensitive string operations, so invariant
+# mode is fine and matches what Microsoft recommends for Alpine/slim images.
+ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1
 # Shared NuGet package cache writable by all users (primed during build)
 ENV NUGET_PACKAGES=/opt/nuget-packages
 

--- a/src/robotocore/services/lambda_/runtimes/dotnet.py
+++ b/src/robotocore/services/lambda_/runtimes/dotnet.py
@@ -31,6 +31,24 @@ logger = logging.getLogger(__name__)
 _cached_tfm: str | None = None
 
 
+def _dotnet_compile_env() -> dict[str, str]:
+    """Environment for dotnet CLI subprocess calls (compile and introspection).
+
+    Starts from the current process environment so PATH, HOME, NUGET_PACKAGES,
+    etc. are inherited, then force-sets the vars needed for reliable operation
+    on minimal Docker images that don't ship libicu.
+    """
+    env = os.environ.copy()
+    env["DOTNET_CLI_TELEMETRY_OPTOUT"] = "1"
+    env["DOTNET_NOLOGO"] = "1"
+    env["DOTNET_SKIP_FIRST_TIME_EXPERIENCE"] = "1"
+    # Required on slim Debian images: libicu package name changes between
+    # releases (libicu72 → libicu74) making it fragile to install.
+    # Invariant mode is sufficient for Lambda runtimes.
+    env["DOTNET_SYSTEM_GLOBALIZATION_INVARIANT"] = "1"
+    return env
+
+
 def _detect_tfm() -> str:
     """Detect the best available .NET target framework moniker (e.g., 'net9.0').
 
@@ -47,6 +65,7 @@ def _detect_tfm() -> str:
             capture_output=True,
             text=True,
             timeout=10,
+            env=_dotnet_compile_env(),
         )
         if proc.returncode == 0:
             # Parse lines like: Microsoft.NETCore.App 9.0.12 [/path]
@@ -204,6 +223,9 @@ class DotnetExecutor:
 
         tmpdir = extract_code(code_zip, layer_zips, code_dir=code_dir, function_name=function_name)
         env = build_env(function_name, region, account_id, timeout, memory_size, handler, env_vars)
+        # Required for dotnet exec on slim images that lack libicu.
+        # Set after build_env so it always wins over any user-provided env var.
+        env["DOTNET_SYSTEM_GLOBALIZATION_INVARIANT"] = "1"
 
         # Parse handler: "Assembly::Type::Method"
         parts = handler.split("::")
@@ -277,15 +299,9 @@ class DotnetExecutor:
         with open(proj_path, "w") as f:
             f.write(proj_content)
 
-        # Build a clean env for dotnet that inherits system essentials.
-        # The Lambda env may override HOME/DOTNET_ROOT etc. in ways that
-        # break dotnet CLI tooling, so we merge carefully.
-        compile_env = os.environ.copy()
-        # Suppress .NET CLI telemetry and first-run experience which can
-        # hang or write to unexpected locations in CI.
-        compile_env["DOTNET_CLI_TELEMETRY_OPTOUT"] = "1"
-        compile_env["DOTNET_NOLOGO"] = "1"
-        compile_env["DOTNET_SKIP_FIRST_TIME_EXPERIENCE"] = "1"
+        # Use a clean dotnet env so Lambda env vars (HOME, DOTNET_ROOT, etc.)
+        # don't interfere with compilation tooling.
+        compile_env = _dotnet_compile_env()
 
         try:
             proc = subprocess.run(
@@ -342,10 +358,7 @@ class DotnetExecutor:
 
             # Build the bootstrap using a clean env (not the Lambda env)
             # to avoid issues with DOTNET_ROOT, HOME, etc.
-            compile_env = os.environ.copy()
-            compile_env["DOTNET_CLI_TELEMETRY_OPTOUT"] = "1"
-            compile_env["DOTNET_NOLOGO"] = "1"
-            compile_env["DOTNET_SKIP_FIRST_TIME_EXPERIENCE"] = "1"
+            compile_env = _dotnet_compile_env()
             try:
                 build_proc = subprocess.run(
                     [

--- a/tests/compatibility/test_lambda_dotnet_compat.py
+++ b/tests/compatibility/test_lambda_dotnet_compat.py
@@ -24,12 +24,15 @@ pytestmark = skip_if_runtime_unavailable("dotnet", also_requires="dotnet")
 
 def _detect_tfm() -> str:
     """Detect the highest .NET runtime version available."""
+    env = os.environ.copy()
+    env["DOTNET_SYSTEM_GLOBALIZATION_INVARIANT"] = "1"
     try:
         proc = subprocess.run(
             ["dotnet", "--list-runtimes"],
             capture_output=True,
             text=True,
             timeout=10,
+            env=env,
         )
         versions = []
         for line in proc.stdout.splitlines():
@@ -76,12 +79,15 @@ def _compile_cs_to_zip(
 
         # Compile
         out_dir = os.path.join(tmpdir, "out")
+        build_env = os.environ.copy()
+        build_env["DOTNET_SYSTEM_GLOBALIZATION_INVARIANT"] = "1"
         proc = subprocess.run(
             ["dotnet", "build", "-c", "Release", "-o", out_dir, "--nologo", "-v", "quiet"],
             capture_output=True,
             text=True,
             timeout=60,
             cwd=tmpdir,
+            env=build_env,
         )
         if proc.returncode != 0:
             raise RuntimeError(f"dotnet build failed:\n{proc.stderr}\n{proc.stdout}")

--- a/tests/unit/services/lambda_/test_dotnet_runtime.py
+++ b/tests/unit/services/lambda_/test_dotnet_runtime.py
@@ -1,16 +1,22 @@
 """Tests for the .NET runtime executor."""
 
 import shutil
+from unittest.mock import MagicMock, patch
 
 import pytest
 
-from robotocore.services.lambda_.runtimes.dotnet import DotnetExecutor
+from robotocore.services.lambda_.runtimes.dotnet import (
+    DotnetExecutor,
+    _dotnet_compile_env,
+)
 from tests.unit.services.lambda_.helpers import make_zip
 
-pytestmark = pytest.mark.skipif(shutil.which("dotnet") is None, reason=".NET SDK not installed")
+_DOTNET_AVAILABLE = shutil.which("dotnet") is not None
 
 
 class TestDotnetExecutor:
+    pytestmark = pytest.mark.skipif(not _DOTNET_AVAILABLE, reason=".NET SDK not installed")
+
     def setup_method(self):
         self.executor = DotnetExecutor()
 
@@ -37,3 +43,81 @@ class TestDotnetExecutor:
         )
         assert error_type == "Runtime.HandlerNotFound"
         assert "Assembly::Type::Method" in logs
+
+
+class TestDotnetCompileEnv:
+    """Verify that all dotnet subprocess calls include DOTNET_SYSTEM_GLOBALIZATION_INVARIANT.
+
+    These tests use mocks and do not require .NET to be installed. They exist to
+    catch regressions where the env var is dropped from subprocess calls, which
+    causes dotnet to crash on slim Debian images that don't ship libicu.
+    """
+
+    def test_dotnet_compile_env_includes_globalization_invariant(self):
+        env = _dotnet_compile_env()
+        assert env.get("DOTNET_SYSTEM_GLOBALIZATION_INVARIANT") == "1"
+
+    def test_dotnet_compile_env_includes_standard_suppressions(self):
+        env = _dotnet_compile_env()
+        assert env["DOTNET_CLI_TELEMETRY_OPTOUT"] == "1"
+        assert env["DOTNET_NOLOGO"] == "1"
+        assert env["DOTNET_SKIP_FIRST_TIME_EXPERIENCE"] == "1"
+
+    def test_detect_tfm_passes_invariant_env_to_subprocess(self):
+        import robotocore.services.lambda_.runtimes.dotnet as dotnet_mod
+
+        dotnet_mod._cached_tfm = None  # reset module-level cache
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+        mock_proc.stdout = "Microsoft.NETCore.App 8.0.1 [/usr/share/dotnet]\n"
+
+        with patch("subprocess.run", return_value=mock_proc) as mock_run:
+            dotnet_mod._detect_tfm()
+
+        passed_env = mock_run.call_args.kwargs.get("env") or mock_run.call_args[1].get("env")
+        assert passed_env is not None, "_detect_tfm did not pass env= to subprocess.run"
+        assert passed_env.get("DOTNET_SYSTEM_GLOBALIZATION_INVARIANT") == "1", (
+            "_detect_tfm subprocess call is missing DOTNET_SYSTEM_GLOBALIZATION_INVARIANT; "
+            "dotnet --list-runtimes will crash on slim images without libicu"
+        )
+
+    def test_executor_sets_invariant_mode_on_lambda_execution_env(self):
+        """DotnetExecutor.execute() must inject the invariant flag into the Lambda env
+        so dotnet exec doesn't crash on slim images, even when user env_vars don't include it."""
+        executor = DotnetExecutor()
+        code_zip = make_zip({"Handler.dll": b"\x00" * 16})  # fake DLL
+
+        captured_envs: list[dict] = []
+
+        def fake_run(cmd, **kwargs):
+            captured_envs.append(dict(kwargs.get("env") or {}))
+            proc = MagicMock()
+            proc.returncode = 0
+            proc.stdout = '{"ok": true}'
+            proc.stderr = ""
+            return proc
+
+        with (
+            patch("shutil.which", return_value="/usr/bin/dotnet"),
+            patch("subprocess.run", side_effect=fake_run),
+            patch(
+                "robotocore.services.lambda_.runtimes.dotnet.extract_code",
+                return_value="/tmp/fake",
+            ),
+            patch("os.path.exists", return_value=True),
+            patch("os.listdir", return_value=["Handler.dll"]),
+        ):
+            executor.execute(
+                code_zip=code_zip,
+                handler="Handler::Handler::HandleRequest",
+                event={},
+                function_name="fn",
+                timeout=3,
+                env_vars={},
+            )
+
+        assert captured_envs, "No subprocess.run calls were captured"
+        for env in captured_envs:
+            assert env.get("DOTNET_SYSTEM_GLOBALIZATION_INVARIANT") == "1", (
+                f"A subprocess call is missing DOTNET_SYSTEM_GLOBALIZATION_INVARIANT: {env}"
+            )


### PR DESCRIPTION
## Summary

- Sets `DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1` in the `java-and-dotnet` Dockerfile stage instead of installing a version-pinned `libicu` package
- Adds a CI step that runs `dotnet --version` and `java -version` immediately after the image build — catches broken toolchain before the container starts

## Problem

The `java-and-dotnet` image build was crashing with:

```
Process terminated. Couldn't find a valid ICU package installed on the system.
Please install libicu (or icu-libs) using your package manager and try again.
```

The root cause is that `.NET` requires ICU (International Components for Unicode) for globalization, and the `python:3.12-slim` base image doesn't include it. Pinning a specific package like `libicu72` is fragile — the version number changes between Debian releases (Bookworm → Trixie), breaking the build silently when the base image is updated.

## Fix

`DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=1` tells .NET to use invariant culture instead of ICU. This is Microsoft's recommended approach for Alpine and other minimal containers, and is appropriate here because Lambda runtimes don't need locale-sensitive string operations.

## Test

Added a dedicated CI step right after `docker build`:

```yaml
- name: Verify dotnet CLI is functional in java-and-dotnet image
  run: |
    docker run --rm robotocore:java-and-dotnet dotnet --version
    docker run --rm robotocore:java-and-dotnet java -version
```

This would have caught the ICU failure immediately — `dotnet --version` crashes with a core dump when ICU is missing, which is a much clearer signal than a mid-build prewarm failure.

## Test plan

- [ ] `docker build --target java-and-dotnet` completes without error
- [ ] CI "Verify dotnet CLI is functional" step passes
- [ ] Lambda .NET smoke test passes end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)