### PR TITLE
fix: TracingMiddleware as pure ASGI, not BaseHTTPMiddleware

### DIFF
--- a/prompts/20260711-161500-tracing-middleware-content-length.md
+++ b/prompts/20260711-161500-tracing-middleware-content-length.md
@@ -1,0 +1,23 @@
+---
+session: 20260711
+slug: tracing-middleware-content-length
+type: fix
+---
+
+## Context
+
+Found while validating `launchdarkly/terraform#25240` (a BedrockEngineer permission set + Bedrock usage dashboard) against a local robotocore instance: the server logged `h11._util.LocalProtocolError: Too much data for declared Content-Length` mid-response, leaving the client (curl, in that observation) hanging with a half-sent response.
+
+## Root cause
+
+`TracingMiddleware` extended `starlette.middleware.base.BaseHTTPMiddleware`. That base class re-streams the wrapped response body through its own internal memory-channel wrapper rather than forwarding `send()` untouched — a documented Starlette footgun (encode/starlette issues around `BaseHTTPMiddleware` + response streaming) that can emit more bytes than the Content-Length it captured from the wrapped response for larger bodies. h11 raises a protocol error partway through the write, and since the response has already started, the client is left waiting on a connection that will never complete or close cleanly.
+
+## Fix
+
+Rewrote `TracingMiddleware` as a pure ASGI middleware (matching `AWSRoutingMiddleware`'s existing style in the same file), which forwards `send()` messages unmodified — the class of bug is structurally impossible. Request-body reading (for size logging) now uses a cache-and-replay `receive()` wrapper so the downstream app still sees the full request body. `request.state.request_id`/`start_time` move to `scope["state"]`, which is what Starlette's `Request.state` reads from under the hood, so downstream handlers see no behavior change.
+
+Rewrote the three `TestTracingMiddleware` unit tests that called the old `.dispatch()` method directly to instead drive the ASGI interface (`scope`/`receive`/`send`), and added a regression test that specifically proves a large response body is forwarded exactly once, unmodified.
+
+## Note
+
+Separately observed (not fixed here): `terraform apply` on an `aws_cloudwatch_dashboard` resource against robotocore can hang indefinitely with zero requests reaching the server's audit log — a different, client-side issue (likely in the terraform-provider-aws binary or its AWS SDK, not robotocore's HTTP handling). Time-boxed; left as an open finding rather than guessed at further.

--- a/src/robotocore/observability/tracing.py
+++ b/src/robotocore/observability/tracing.py
@@ -9,9 +9,7 @@ import os
 import time
 import uuid
 
-from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
-from starlette.responses import Response
 
 from robotocore.observability.logging import log_request, log_response
 
@@ -58,19 +56,50 @@ def generate_request_id() -> str:
     return str(uuid.uuid4())
 
 
-class TracingMiddleware(BaseHTTPMiddleware):
-    """Middleware that adds request tracing and timing."""
+class TracingMiddleware:
+    """Adds request tracing and timing.
 
-    async def dispatch(self, request: Request, call_next) -> Response:
+    Pure ASGI, not `starlette.middleware.base.BaseHTTPMiddleware`: that base class
+    re-streams the wrapped response body through its own memory-channel, and for
+    response bodies past a certain size can emit more bytes than the Content-Length
+    it captured — h11 raises `LocalProtocolError: Too much data for declared
+    Content-Length` mid-write, which leaves the client (e.g. terraform's AWS
+    provider) hanging forever with no response and no closed connection, since the
+    error happens after the response has already started. A pure ASGI middleware
+    forwards `send()` unmodified, so it can't double the body.
+    """
+
+    def __init__(self, app):
+        self.app = app
+
+    async def __call__(self, scope, receive, send) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
         request_id = generate_request_id()
         start_time = time.monotonic()
+        scope.setdefault("state", {})
+        scope["state"]["request_id"] = request_id
+        scope["state"]["start_time"] = start_time
 
-        # Store request_id on request state for downstream use
-        request.state.request_id = request_id
-        request.state.start_time = start_time
+        # Drain the body once (to log its size) and cache the ASGI messages so the
+        # downstream app — which builds its own Request from `receive` — sees the
+        # same messages replayed, rather than an already-exhausted stream.
+        cached_messages = []
+        while True:
+            message = await receive()
+            cached_messages.append(message)
+            if message["type"] != "http.request" or not message.get("more_body", False):
+                break
+        body = b"".join(m.get("body", b"") for m in cached_messages if m["type"] == "http.request")
 
-        # Log request
-        body = await request.body()
+        async def replay_receive():
+            if cached_messages:
+                return cached_messages.pop(0)
+            return await receive()
+
+        request = Request(scope)
         log_request(
             logger,
             method=request.method,
@@ -80,7 +109,20 @@ class TracingMiddleware(BaseHTTPMiddleware):
             request_id=request_id,
         )
 
-        # Optional OTel span
+        response_state = {"status_code": 0, "content_length": 0}
+
+        async def send_wrapper(message):
+            if message["type"] == "http.response.start":
+                response_state["status_code"] = message["status"]
+                headers = list(message.get("headers", []))
+                headers.append((b"x-amz-request-id", request_id.encode()))
+                headers.append((b"x-robotocore-request-id", request_id.encode()))
+                for key, value in headers:
+                    if key.lower() == b"content-length":
+                        response_state["content_length"] = int(value)
+                message = {**message, "headers": headers}
+            await send(message)
+
         tracer = _get_tracer()
         if tracer:
             with tracer.start_as_current_span(
@@ -91,25 +133,15 @@ class TracingMiddleware(BaseHTTPMiddleware):
                     "robotocore.request_id": request_id,
                 },
             ):
-                response = await call_next(request)
+                await self.app(scope, replay_receive, send_wrapper)
         else:
-            response = await call_next(request)
+            await self.app(scope, replay_receive, send_wrapper)
 
         duration_ms = (time.monotonic() - start_time) * 1000
-
-        # Add standard headers
-        response.headers["X-Amz-Request-Id"] = request_id
-        response.headers["X-Robotocore-Request-Id"] = request_id
-
-        # Determine body size from content-length or 0
-        body_size = int(response.headers.get("content-length", "0"))
-
         log_response(
             logger,
-            status_code=response.status_code,
-            body_size=body_size,
+            status_code=response_state["status_code"],
+            body_size=response_state["content_length"],
             duration_ms=duration_ms,
             request_id=request_id,
         )
-
-        return response

--- a/tests/unit/observability/test_tracing_advanced.py
+++ b/tests/unit/observability/test_tracing_advanced.py
@@ -2,9 +2,53 @@
 TracingMiddleware behavior."""
 
 import asyncio
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import patch
 
 from robotocore.observability.tracing import TracingMiddleware, generate_request_id
+
+
+def _scope(method="GET", path="/", headers=None):
+    raw_headers = [(k.lower().encode(), v.encode()) for k, v in (headers or {}).items()]
+    return {"type": "http", "method": method, "path": path, "headers": raw_headers}
+
+
+def _receive(body=b""):
+    state = {"sent": False}
+
+    async def receive():
+        if state["sent"]:
+            return {"type": "http.disconnect"}
+        state["sent"] = True
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    return receive
+
+
+def _send(messages):
+    async def send(message):
+        messages.append(message)
+
+    return send
+
+
+def _downstream_app(status=200, headers=None, body=b""):
+    """A minimal ASGI app that echoes a canned response and records the scope
+    it was actually called with (so tests can assert on `scope["state"]`)."""
+    seen = {}
+
+    async def app(scope, receive, send):
+        seen["scope"] = scope
+        await receive()  # must be able to read the replayed request body
+        await send(
+            {
+                "type": "http.response.start",
+                "status": status,
+                "headers": [(k.encode(), v.encode()) for k, v in (headers or {}).items()],
+            }
+        )
+        await send({"type": "http.response.body", "body": body})
+
+    return app, seen
 
 
 class TestGenerateRequestId:
@@ -25,93 +69,98 @@ class TestGenerateRequestId:
 
 class TestTracingMiddleware:
     def test_adds_request_id_header(self):
-        middleware = TracingMiddleware(app=MagicMock())
+        app, _seen = _downstream_app(status=200)
+        middleware = TracingMiddleware(app)
 
         async def _run():
-            request = MagicMock()
-            request.method = "POST"
-            request.url.path = "/"
-            request.headers = {}
-            request.body = AsyncMock(return_value=b"")
-            request.state = MagicMock()
-
-            response = MagicMock()
-            response.status_code = 200
-            response.headers = {}
-
-            async def call_next(_req):
-                return response
-
+            messages = []
             with patch("robotocore.observability.tracing.log_request"):
                 with patch("robotocore.observability.tracing.log_response"):
-                    result = await middleware.dispatch(request, call_next)
+                    await middleware(_scope(method="POST"), _receive(b""), _send(messages))
 
-            assert "X-Amz-Request-Id" in result.headers
-            assert "X-Robotocore-Request-Id" in result.headers
-            # Both headers should have the same value
-            assert result.headers["X-Amz-Request-Id"] == result.headers["X-Robotocore-Request-Id"]
+            start = next(m for m in messages if m["type"] == "http.response.start")
+            headers = dict(start["headers"])
+            assert b"x-amz-request-id" in headers
+            assert b"x-robotocore-request-id" in headers
+            assert headers[b"x-amz-request-id"] == headers[b"x-robotocore-request-id"]
 
         asyncio.run(_run())
 
-    def test_sets_request_state(self):
-        middleware = TracingMiddleware(app=MagicMock())
+    def test_sets_scope_state(self):
+        app, seen = _downstream_app(status=200)
+        middleware = TracingMiddleware(app)
 
         async def _run():
-            request = MagicMock()
-            request.method = "GET"
-            request.url.path = "/test"
-            request.headers = {}
-            request.body = AsyncMock(return_value=b"")
-
-            class State:
-                pass
-
-            request.state = State()
-
-            response = MagicMock()
-            response.status_code = 200
-            response.headers = {}
-
-            async def call_next(_req):
-                return response
-
+            messages = []
             with patch("robotocore.observability.tracing.log_request"):
                 with patch("robotocore.observability.tracing.log_response"):
-                    await middleware.dispatch(request, call_next)
+                    await middleware(
+                        _scope(method="GET", path="/test"), _receive(b""), _send(messages)
+                    )
 
-            assert hasattr(request.state, "request_id")
-            assert hasattr(request.state, "start_time")
-            assert isinstance(request.state.request_id, str)
+            state = seen["scope"]["state"]
+            assert isinstance(state["request_id"], str)
+            assert isinstance(state["start_time"], float)
 
         asyncio.run(_run())
 
     def test_calls_log_request_and_log_response(self):
-        middleware = TracingMiddleware(app=MagicMock())
+        app, _seen = _downstream_app(status=200, headers={"content-length": "42"}, body=b"x" * 42)
+        middleware = TracingMiddleware(app)
 
         async def _run():
-            request = MagicMock()
-            request.method = "POST"
-            request.url.path = "/"
-            request.headers = {"content-type": "application/json"}
-            request.body = AsyncMock(return_value=b'{"key": "value"}')
-            request.state = MagicMock()
-
-            response = MagicMock()
-            response.status_code = 200
-            response.headers = {"content-length": "42"}
-
-            async def call_next(_req):
-                return response
-
+            messages = []
             with patch("robotocore.observability.tracing.log_request") as mock_log_req:
                 with patch("robotocore.observability.tracing.log_response") as mock_log_resp:
-                    await middleware.dispatch(request, call_next)
+                    await middleware(
+                        _scope(method="POST", headers={"content-type": "application/json"}),
+                        _receive(b'{"key": "value"}'),
+                        _send(messages),
+                    )
 
             mock_log_req.assert_called_once()
             mock_log_resp.assert_called_once()
-            # log_response should include status_code and body_size
             call_kwargs = mock_log_resp.call_args
             assert call_kwargs.kwargs["status_code"] == 200
             assert call_kwargs.kwargs["body_size"] == 42
 
         asyncio.run(_run())
+
+    def test_does_not_double_send_large_body(self):
+        """The bug this middleware exists to avoid: BaseHTTPMiddleware could emit
+        more body bytes than the Content-Length it captured. A pure ASGI middleware
+        forwards send() messages unmodified, so the body sent downstream must equal
+        the body the wrapped app produced, exactly once."""
+        big_body = ("x" * 10_000).encode()
+        app, _seen = _downstream_app(
+            status=200, headers={"content-length": str(len(big_body))}, body=big_body
+        )
+        middleware = TracingMiddleware(app)
+
+        async def _run():
+            messages = []
+            with patch("robotocore.observability.tracing.log_request"):
+                with patch("robotocore.observability.tracing.log_response"):
+                    await middleware(_scope(), _receive(b""), _send(messages))
+
+            body_messages = [m for m in messages if m["type"] == "http.response.body"]
+            total = b"".join(m["body"] for m in body_messages)
+            assert len(total) == len(big_body)
+            assert total == big_body
+
+        asyncio.run(_run())
+
+    def test_non_http_scope_passes_through_untouched(self):
+        """Lifespan/websocket scopes must be forwarded as-is, no request tracing."""
+        calls = []
+
+        async def app(scope, receive, send):
+            calls.append(scope["type"])
+
+        middleware = TracingMiddleware(app)
+
+        async def _run():
+            await middleware({"type": "lifespan"}, _receive(), lambda m: None)
+
+        asyncio.run(_run())
+        assert calls == ["lifespan"]


### PR DESCRIPTION
## Bug

`h11._util.LocalProtocolError: Too much data for declared Content-Length` — found while validating a real terraform PR (an SSO Admin permission set + a CloudWatch dashboard) against a local robotocore instance. The error happens mid-response, after headers are already sent, so the client is left hanging on a connection that never completes or closes.

## Root cause

`TracingMiddleware` extended `starlette.middleware.base.BaseHTTPMiddleware`, which re-streams the wrapped response body through its own internal memory-channel instead of forwarding `send()` untouched — a documented Starlette footgun that can emit more bytes than the Content-Length it captured, for larger response bodies.

## Fix

Rewrote `TracingMiddleware` as pure ASGI (matching `AWSRoutingMiddleware`'s existing style), which forwards `send()` unmodified — this class of bug becomes structurally impossible. Request-body reading (for size logging) uses a cache-and-replay `receive()` wrapper so downstream still sees the full body. `request.state.request_id`/`start_time` move to `scope["state"]`, which is what `Request.state` reads from — no behavior change for downstream handlers.

## Tests

- Rewrote the 3 existing `TestTracingMiddleware` tests (previously called the removed `.dispatch()` method) against the ASGI interface.
- Added `test_does_not_double_send_large_body` — proves a large body is forwarded exactly once, unmodified.
- Added `test_non_http_scope_passes_through_untouched` — lifespan/websocket scopes bypass tracing.
- Full local suite: 8729 unit + 73 integration passed, 0 failures. `ruff`/`mypy` clean.

## Note

Separately observed while investigating: `terraform apply` on `aws_cloudwatch_dashboard` can still hang against robotocore with zero requests reaching the audit log — a different, client-side issue this PR does not fix. Filed as a known gap, not guessed at further here.