### PR TITLE
fix: support Smithy RPC v2 CBOR protocol for CloudWatch

### DIFF
--- a/prompts/20260711-170000-cloudwatch-smithy-rpc-v2-cbor.md
+++ b/prompts/20260711-170000-cloudwatch-smithy-rpc-v2-cbor.md
@@ -1,0 +1,32 @@
+---
+session: 20260711
+slug: cloudwatch-smithy-rpc-v2-cbor
+type: fix
+---
+
+## Context
+
+Follow-up to the previous `TracingMiddleware` fix (`fix/tracing-middleware-content-length`), which turned out not to be the actual cause of the reported symptom: `terraform apply` on `aws_cloudwatch_dashboard` hanging against robotocore for minutes, appearing as an unresolvable client-side issue (zero requests reaching the audit log).
+
+Root-caused with `TF_LOG=trace`: the real issue was in my own test harness (a stale port in a hand-written `_override.tf`, pointing at a different, long-running robotocore instance instead of the one being iterated on) — masking the actual server-side bug underneath.
+
+## Root cause
+
+`terraform-provider-aws` 6.54.0 (`aws-sdk-go-v2`) sends `CloudWatch/PutDashboard` using AWS's newer **Smithy RPC v2 CBOR** protocol: a binary CBOR-encoded body, POSTed to `/service/{ServiceId}/operation/{OperationName}` with a `smithy-protocol: rpc-v2-cbor` header — no `X-Amz-Target`, no JSON, no query string.
+
+`handle_cloudwatch_request` only recognized two protocols (JSON via `X-Amz-Target`, and classic query/form-encoded). Neither branch matched, so the request fell through with `action = ""`, matched no `_ACTION_MAP` entry, and was forwarded to Moto — whose query-protocol dispatcher tried to UTF-8-decode the raw CBOR bytes and raised `UnicodeDecodeError: 'utf-8' codec can't decode byte 0xa2 in position 0`.
+
+That surfaced as an HTTP 500, which `aws-sdk-go-v2` treats as retryable — it retried with exponential backoff up to 25 attempts (~2 minutes), which is indistinguishable from a hang within any test window shorter than that.
+
+## Fix
+
+- Added `cbor2` as a dependency.
+- `handle_cloudwatch_request` now detects `smithy-protocol: rpc-v2-cbor` before the JSON/query branches, decodes the body with `cbor2.loads`, and reads the operation name from the URL path (`/operation/{name}`) since there's no `X-Amz-Target` to parse.
+- Added `_success_response`/`_error_body_response` helpers so every response site (6 call sites previously duplicated the `if use_json_protocol: ... else: ...` shape) picks JSON, CBOR, or XML consistently — CBOR responses get `media_type="application/cbor"` and the `smithy-protocol` header back, which the AWS SDK's CBOR deserializer requires.
+- An unmapped CBOR action now fails closed with a real `501 NotImplemented` (still CBOR-encoded) instead of falling through to Moto, which has no CBOR support at all and would hit the identical UTF-8 crash.
+
+## Verification
+
+- Real `terraform apply`/`destroy` on the actual PR HCL (`aws_cloudwatch_dashboard` + 6 sibling resources from a Bedrock-usage-logging module) now completes in ~0s per resource instead of hanging.
+- 3 new unit tests (`TestCloudWatchCborProtocol`): a full CBOR round-trip, a CBOR-encoded error response, and a negative test proving an unmapped CBOR action does NOT fall through to Moto.
+- Full local suite: 8732 unit (3 new) + 140 integration/compat passed. `ruff`/`mypy`/`bandit` clean.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "aiosmtpd>=1.4",
     "dnslib>=0.9",
     "docker>=7.0",
+    "cbor2>=5.6",
 ]
 
 [project.optional-dependencies]

--- a/src/robotocore/services/cloudwatch/provider.py
+++ b/src/robotocore/services/cloudwatch/provider.py
@@ -13,6 +13,7 @@ import time
 from collections.abc import Callable
 from urllib.parse import parse_qs
 
+import cbor2
 from starlette.requests import Request
 from starlette.responses import Response
 
@@ -687,6 +688,43 @@ def _dispatch_ec2_action(
 # ---------------------------------------------------------------------------
 
 
+def _success_response(
+    result: dict, action: str, use_json_protocol: bool, use_cbor_protocol: bool
+) -> Response:
+    """Shape a 200 response for whichever protocol the client sent."""
+    if use_cbor_protocol:
+        return Response(
+            content=cbor2.dumps(result),
+            status_code=200,
+            media_type="application/cbor",
+            headers={"smithy-protocol": "rpc-v2-cbor"},
+        )
+    if use_json_protocol:
+        return Response(
+            content=json.dumps(result), status_code=200, media_type="application/x-amz-json-1.0"
+        )
+    return _xml_response(action + "Response", result)
+
+
+def _error_body_response(
+    code: str, message: str, status: int, use_json_protocol: bool, use_cbor_protocol: bool
+) -> Response:
+    """Shape an error response for whichever protocol the client sent."""
+    if use_cbor_protocol:
+        return Response(
+            content=cbor2.dumps({"__type": code, "message": message}),
+            status_code=status,
+            media_type="application/cbor",
+            headers={"smithy-protocol": "rpc-v2-cbor"},
+        )
+    if use_json_protocol:
+        err_body = json.dumps({"__type": code, "message": message})
+        return Response(
+            content=err_body, status_code=status, media_type="application/x-amz-json-1.0"
+        )
+    return _error_response(code, message, status)
+
+
 async def handle_cloudwatch_request(request: Request, region: str, account_id: str) -> Response:
     """Handle CloudWatch API requests.
 
@@ -696,9 +734,19 @@ async def handle_cloudwatch_request(request: Request, region: str, account_id: s
     body = await request.body()
     content_type = request.headers.get("content-type", "")
     amz_target = request.headers.get("x-amz-target", "")
-    use_json_protocol = "x-amz-json" in content_type and amz_target
+    use_json_protocol = bool("x-amz-json" in content_type and amz_target)
+    # Smithy RPC v2 CBOR: newer AWS SDKs (aws-sdk-go-v2) send a CBOR-encoded body with no
+    # X-Amz-Target, routed by path (/service/{ServiceId}/operation/{OperationName}) instead —
+    # this protocol has no query-string/form-encoded fallback, so it must be decoded before
+    # falling through to the query-protocol branch below (which would try to UTF-8-decode the
+    # binary CBOR body, or hand it to Moto's query-protocol parser, which does the same).
+    use_cbor_protocol = request.headers.get("smithy-protocol", "") == "rpc-v2-cbor"
 
-    if use_json_protocol:
+    if use_cbor_protocol:
+        params = cbor2.loads(body) if body else {}
+        action = request.url.path.rsplit("/operation/", 1)[-1]
+        params["Action"] = action
+    elif use_json_protocol:
         # Modern boto3 sends JSON with X-Amz-Target header
         # e.g. "GraniteServiceVersion20100801.DisableAlarmActions"
         action = amz_target.rsplit(".", 1)[-1] if "." in amz_target else amz_target
@@ -721,13 +769,7 @@ async def handle_cloudwatch_request(request: Request, region: str, account_id: s
         if "CompositeAlarm" in alarm_types:
             composites = describe_composite_alarms(params, region, account_id)
             result = {"CompositeAlarms": composites, "MetricAlarms": []}
-            if use_json_protocol:
-                return Response(
-                    content=json.dumps(result),
-                    status_code=200,
-                    media_type="application/x-amz-json-1.0",
-                )
-            return _xml_response("DescribeAlarmsResponse", result)
+            return _success_response(result, action, use_json_protocol, use_cbor_protocol)
 
     # GetMetricStatistics: intercept when ExtendedStatistics requested (Moto doesn't compute them)
     if action == "GetMetricStatistics":
@@ -749,13 +791,7 @@ async def handle_cloudwatch_request(request: Request, region: str, account_id: s
             params["ExtendedStatistics"] = ext_stats
             try:
                 result = _handle_get_metric_statistics(params, region, account_id)
-                if use_json_protocol:
-                    return Response(
-                        content=json.dumps(result),
-                        status_code=200,
-                        media_type="application/x-amz-json-1.0",
-                    )
-                return _xml_response("GetMetricStatisticsResponse", result)
+                return _success_response(result, action, use_json_protocol, use_cbor_protocol)
             except Exception as e:  # noqa: BLE001
                 logger.error("ExtendedStatistics error: %s", e)
 
@@ -763,27 +799,22 @@ async def handle_cloudwatch_request(request: Request, region: str, account_id: s
     if handler is not None:
         try:
             result = handler(params, region, account_id)
-            if use_json_protocol:
-                return Response(
-                    content=json.dumps(result),
-                    status_code=200,
-                    media_type="application/x-amz-json-1.0",
-                )
-            return _xml_response(action + "Response", result)
+            return _success_response(result, action, use_json_protocol, use_cbor_protocol)
         except CloudWatchError as e:
-            if use_json_protocol:
-                err_body = json.dumps({"__type": e.code, "message": e.message})
-                return Response(
-                    content=err_body, status_code=e.status, media_type="application/x-amz-json-1.0"
-                )
-            return _error_response(e.code, e.message, e.status)
+            return _error_body_response(
+                e.code, e.message, e.status, use_json_protocol, use_cbor_protocol
+            )
         except Exception as e:  # noqa: BLE001
-            if use_json_protocol:
-                err_body = json.dumps({"__type": "InternalError", "message": str(e)})
-                return Response(
-                    content=err_body, status_code=500, media_type="application/x-amz-json-1.0"
-                )
-            return _error_response("InternalError", str(e), 500)
+            return _error_body_response(
+                "InternalError", str(e), 500, use_json_protocol, use_cbor_protocol
+            )
+
+    if use_cbor_protocol:
+        # Moto has no CBOR support at all — forwarding would hit the same UTF-8-decode crash
+        # this protocol exists to avoid. Fail closed and honestly rather than 500 on garbage.
+        return _error_body_response(
+            "NotImplemented", f"CloudWatch {action} is not implemented", 501, False, True
+        )
 
     # Fall back to Moto for everything else
     return await forward_to_moto(request, "cloudwatch", account_id=account_id)

--- a/tests/unit/services/test_cloudwatch_provider.py
+++ b/tests/unit/services/test_cloudwatch_provider.py
@@ -891,6 +891,83 @@ class TestCloudWatchJsonProtocol:
             mock_moto.assert_called_once()
 
 
+class TestCloudWatchCborProtocol:
+    """Smithy RPC v2 CBOR: newer AWS SDKs (aws-sdk-go-v2, e.g. terraform-provider-aws)
+    send a CBOR-encoded body with no X-Amz-Target, routed by path instead of header.
+    Before this protocol was decoded, the request fell through to Moto's query-protocol
+    parser, which tried to UTF-8-decode the binary CBOR body and raised UnicodeDecodeError
+    on every call — a 500 the AWS SDK retries ~25 times with backoff, which looks
+    indistinguishable from a hang."""
+
+    @pytest.fixture
+    def app(self):
+        from robotocore.services.cloudwatch.provider import handle_cloudwatch_request
+
+        return handle_cloudwatch_request
+
+    def _make_cbor_request(self, action, params=None):
+        import cbor2
+
+        req = MagicMock()
+        req.headers = {
+            "content-type": "application/cbor",
+            "smithy-protocol": "rpc-v2-cbor",
+        }
+        req.url = MagicMock()
+        req.url.query = ""
+        req.url.path = f"/service/GraniteServiceVersion20100801/operation/{action}"
+
+        body_bytes = cbor2.dumps(params or {})
+
+        async def mock_body():
+            return body_bytes
+
+        req.body = mock_body
+        return req
+
+    @pytest.mark.asyncio
+    async def test_put_dashboard_cbor_round_trip(self, app):
+        """The exact bug: PutDashboard via CBOR must decode the request and respond
+        with a CBOR body the client can parse, not a UTF-8 decode crash."""
+        import cbor2
+
+        req = self._make_cbor_request(
+            "PutDashboard",
+            {"DashboardName": "my-dash", "DashboardBody": '{"widgets": [{"type": "text"}]}'},
+        )
+        resp = await app(req, "us-east-1", "123456789012")
+        assert resp.status_code == 200
+        assert resp.media_type == "application/cbor"
+        assert resp.headers["smithy-protocol"] == "rpc-v2-cbor"
+        decoded = cbor2.loads(resp.body)
+        assert decoded == {"DashboardValidationMessages": []}
+
+    @pytest.mark.asyncio
+    async def test_put_dashboard_cbor_invalid_json_returns_cbor_error(self, app):
+        """A CloudWatchError raised by a handler must still come back as CBOR, not JSON —
+        a JSON error body is exactly what the AWS SDK's CBOR deserializer can't parse."""
+        import cbor2
+
+        req = self._make_cbor_request(
+            "PutDashboard", {"DashboardName": "my-dash", "DashboardBody": "not json"}
+        )
+        resp = await app(req, "us-east-1", "123456789012")
+        assert resp.status_code == 400
+        assert resp.media_type == "application/cbor"
+        decoded = cbor2.loads(resp.body)
+        assert decoded["__type"] == "InvalidParameterInput"
+
+    @pytest.mark.asyncio
+    async def test_unmapped_cbor_action_fails_closed_not_to_moto(self, app):
+        """Moto has no CBOR support — forwarding a CBOR request to it would hit the
+        exact same UTF-8-decode crash this protocol handling exists to avoid."""
+        with patch("robotocore.services.cloudwatch.provider.forward_to_moto") as mock_moto:
+            req = self._make_cbor_request("SomeFutureOperationNotYetMapped", {})
+            resp = await app(req, "us-east-1", "123456789012")
+            mock_moto.assert_not_called()
+            assert resp.status_code == 501
+
+
 # ===================================================================
 # CATEGORICAL BUG TESTS
 # These test patterns that likely exist across many providers.

--- a/uv.lock
+++ b/uv.lock
@@ -136,6 +136,46 @@ wheels = [
 ]
 
 [[package]]
+name = "cbor2"
+version = "6.1.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/6f/07b4af8da8bd27f640362b1ac8271d80895407f2ede0c2bcc9433c06e1ca/cbor2-6.1.3.tar.gz", hash = "sha256:8d70680acb55c04ea5b5ad86da094f9612b53d5a8a65d0f5b3aafc3ce917ecbb", size = 89503, upload-time = "2026-07-04T10:36:48.793Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/16/cff14259c3d19a7f0ae88b6996fe4c85f6ff1764dad889ac8a39e843e39c/cbor2-6.1.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3d939f55097c21e032f5a2d67592fcc57298986281f219356e2f519e4466f4ea", size = 412779, upload-time = "2026-07-04T10:36:04.975Z" },
+    { url = "https://files.pythonhosted.org/packages/50/6c/f3641d19b7b85a63cb2756c10164131489c2cb46b379ec51ae22283fefb9/cbor2-6.1.3-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:b025009478d644dab407164fd60e3ef4381af284f5af6966df94c663756d949e", size = 457781, upload-time = "2026-07-04T10:36:06.349Z" },
+    { url = "https://files.pythonhosted.org/packages/55/85/0c55a66f3037056bfb8e1c7184168085fdea67ae5830404498bcf466233b/cbor2-6.1.3-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:2226d32e102e375737656ad5d141ad8c6ae3e705e04e263f24756f0eb379c6c1", size = 468373, upload-time = "2026-07-04T10:36:07.769Z" },
+    { url = "https://files.pythonhosted.org/packages/46/74/40f7db3e0d880560193916a5c9b744fcf299558bed7113f77c28237c7c29/cbor2-6.1.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e61d465244d66ffed36492eef3b44d43795d76a2bba0663a2f15c186af7f7513", size = 523844, upload-time = "2026-07-04T10:36:09.404Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/a1/b5e07d6a08441c3a552fe2ae48ccb7e9dfc5065b9f6a3bae9879b4f0fbc0/cbor2-6.1.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:87fe7be8fab6ec4796aa127c1a52e09e79dbafd2aa31caf809cf04b8080a5975", size = 536238, upload-time = "2026-07-04T10:36:10.914Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/99/e166be0fd74bf3a91f5a0d103e34883efbc438d970f72cc8200e274787e5/cbor2-6.1.3-cp312-cp312-win32.whl", hash = "sha256:da25d345f01e6a40b2e5c57ef96b4dcff7be69394fb62f0f70e07f437f2376a9", size = 279858, upload-time = "2026-07-04T10:36:12.247Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/1b/90b4a121e40aba189c55a5822dd3c698eaf487e1d4a780ab18c804a5ef1c/cbor2-6.1.3-cp312-cp312-win_amd64.whl", hash = "sha256:d5514f693db6fa6f433b4096e9b604e6a7bf151c9ef1d2db86d0858e4c5e768f", size = 300929, upload-time = "2026-07-04T10:36:13.564Z" },
+    { url = "https://files.pythonhosted.org/packages/19/db/52c58a8d33464927389dde8103997b3fa51b081ce29b347ac2cc4fd0dfbf/cbor2-6.1.3-cp312-cp312-win_arm64.whl", hash = "sha256:3d43183d7beb3d3cd198d69b31bd2ee487ed704a1150c75cb0a66d6ad63d8c1a", size = 290908, upload-time = "2026-07-04T10:36:14.857Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/8c/5024d623dcf3f2057ec8c991f584b939ba5f9025a5ce8c31f6fac067137a/cbor2-6.1.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:21c74b8ab67977c8b87b727247eeb730145b0068ad6d47f71e9f80f6b48c65f8", size = 412334, upload-time = "2026-07-04T10:36:16.299Z" },
+    { url = "https://files.pythonhosted.org/packages/61/f3/e50654203c3b746166a96bea680eb6463b20c2c160cc14dfbe43f215ef6c/cbor2-6.1.3-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:f291a0ae4c1ed96eadb0afa9752568c7424f7d6fa818676d5e33005fcd22ddd9", size = 457125, upload-time = "2026-07-04T10:36:17.684Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/6ef007f0d4f7afba90a80cb1657984de542e7474d2afaa7e920ac9860df3/cbor2-6.1.3-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:dc8e44c7bf172687195dcd428157885bc00ea06efc0ea30fb371163b92bef733", size = 467651, upload-time = "2026-07-04T10:36:19.007Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/f4/b5aa27813c02f37e03eb86bd908163562edd6fc7f99665bc7bbb25ef5e6c/cbor2-6.1.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:8ccf4d263983d830dd429d2b01f27be58ac02ba7c790c45d861f767eb63963e5", size = 523296, upload-time = "2026-07-04T10:36:20.504Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/46/e17b2bce2efdc26bfa045b4f6168f02923ac5f0e79732a1b3c42ce9ca9de/cbor2-6.1.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8719a7a2a2a82168844533389957b8f617a139f5f40e4d0ad7ed905fd3abebd1", size = 535537, upload-time = "2026-07-04T10:36:21.761Z" },
+    { url = "https://files.pythonhosted.org/packages/54/bc/add350acf37f367ae429f997f2e047b042f2d5ef9ca62461c923fbb0f3c3/cbor2-6.1.3-cp313-cp313-win32.whl", hash = "sha256:c73b54ce09dd8d522f3c1540426e36172ba0f34abf3d89eb93909a5e14590003", size = 279233, upload-time = "2026-07-04T10:36:23.071Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/6f/1bbfce3b3131e4e03e8a86966a38ff92ebb72215fcf36aeecea1547f3e4b/cbor2-6.1.3-cp313-cp313-win_amd64.whl", hash = "sha256:b77df56c462c10eb3444db8ef78d8c3e71d9ef8d021ea92e97c1f9e3aa918690", size = 300585, upload-time = "2026-07-04T10:36:24.563Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/65/3945702dd84b6e5b7800c9c7f1ada038d33d12d0042de10e38164cc03dfd/cbor2-6.1.3-cp313-cp313-win_arm64.whl", hash = "sha256:b144be2ab3e9584ee7b6359d2a92fee0a5bec1d00dbd34c215ccc2040ac0b2ab", size = 290357, upload-time = "2026-07-04T10:36:25.983Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/40/04ad7d34182b27487a1824422b361b32d2607727ef20e563056eba62d12a/cbor2-6.1.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:3f3167ca9920b90db4ff72652db109dfd93b56ee0d583aca12f3a5d9a7019477", size = 414615, upload-time = "2026-07-04T10:36:27.299Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/29/94238c61f90653a606535e7509a2af312089fe10dafcb4cf82d6905a7a1a/cbor2-6.1.3-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:48c677971e4b71e685491e1a267d9924dc205e7ddbe3f34fd2562f16c0f6bfca", size = 459084, upload-time = "2026-07-04T10:36:28.717Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/cb/6bd33461e8be8ded7ebb0fa38994a63752aefae2b4fcd1b2cc71ee3c06f1/cbor2-6.1.3-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:ad4f3c6dfc6b83331eb04c6975efb2839ab65a3aa81502bc2b3f7945d4c4aa44", size = 469310, upload-time = "2026-07-04T10:36:30.136Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/d1/94195bcd8fcc1030ecaf22a7a825faa08891b5bb2d3553e465e50fe115f5/cbor2-6.1.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8bcd609eab4a39745123bfb28e73311abba3d14975a87f5906e0e8b910d918ac", size = 524287, upload-time = "2026-07-04T10:36:31.453Z" },
+    { url = "https://files.pythonhosted.org/packages/06/55/57178fbf2d1206af5299c688f9c917b83f30636694c8f932dc89c6652545/cbor2-6.1.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:672727ecb27d7fb3ca0bf8a58fc489d5374ab1fee680ed3d0348a11d9d3ca78f", size = 537031, upload-time = "2026-07-04T10:36:32.769Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/01/beefe26258d66ce39a9b057b679bc67dba81698d5a63e0ada5b4752a5c87/cbor2-6.1.3-cp314-cp314-win32.whl", hash = "sha256:1413cef2aa7f478a38298cd3492a055e8e8e45d17fb53bbe103e79ca15c33f3c", size = 286256, upload-time = "2026-07-04T10:36:34.078Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/2d/79eb513a2586a2053a6f18b33693beda65e2c766820d99676a306573fed5/cbor2-6.1.3-cp314-cp314-win_amd64.whl", hash = "sha256:59df264d4a508ba61daaa0bf3c2f92d63275509549a0875c1fa38176f651e4f8", size = 313744, upload-time = "2026-07-04T10:36:35.58Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/c7/ab9828e4efc26badf89f1397f866f3ef03ef65cdcd55518254b84bdaf86e/cbor2-6.1.3-cp314-cp314-win_arm64.whl", hash = "sha256:b62b5d80a0eb4305cd5f0217faa4d7747bd64fe0dff9b88415e7be3782f8249b", size = 304280, upload-time = "2026-07-04T10:36:36.865Z" },
+    { url = "https://files.pythonhosted.org/packages/33/cf/54a497ad1026833c1c92d482edbda0bdebb48314b51563d2fcea24ab89b4/cbor2-6.1.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:856ab525bfc599588b8d2a45babb7c3400c693ea0bb574d818467d997102fe24", size = 409638, upload-time = "2026-07-04T10:36:38.089Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/03/efdecd0848b9c9e43242537f6dd8ac5d441a077d362e5e6954c7775b866a/cbor2-6.1.3-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:a076f35abf1dd0a4de6e2f7f4d4932abafc951a26275b6aa4a3b370c2fd3bbf4", size = 452193, upload-time = "2026-07-04T10:36:39.56Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/bf/b5f43c75dc5f0ca3127919d3273d8671917932aa3e90767da63867e0f06f/cbor2-6.1.3-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:37ccab1d0bd3f57ff536a41e44165d0c99cb166ac6e5ffb8b93c42304b56e48d", size = 466614, upload-time = "2026-07-04T10:36:40.936Z" },
+    { url = "https://files.pythonhosted.org/packages/23/ee/e85b2ddd46b3b43e39a986704353b433efab0881234e1b4d824229fc2a75/cbor2-6.1.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:76d257ce797e651fa430b0269e8e8c43549c54ce8b0d12860569b3709bf1326f", size = 518503, upload-time = "2026-07-04T10:36:42.289Z" },
+    { url = "https://files.pythonhosted.org/packages/60/13/c740c0002f127dc3e9e87b61a5d1285dd3b71aa11d8e0f6a408fc1f36173/cbor2-6.1.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4af35baadb66f7c9cbb3998eab469767c04641552416c1c69dd4d3d183797119", size = 534236, upload-time = "2026-07-04T10:36:43.641Z" },
+    { url = "https://files.pythonhosted.org/packages/73/cd/a57d97177f3777c96f3406efb0ad60794fdbf249d497ec24559bfd1d0328/cbor2-6.1.3-cp314-cp314t-win32.whl", hash = "sha256:61c92661665bccfed4ffa69d1fe10097f2c820d262f56a8cf909a5ebf9f6d8c6", size = 282446, upload-time = "2026-07-04T10:36:44.888Z" },
+    { url = "https://files.pythonhosted.org/packages/11/c8/dd54878589df22c863d526cb82e1bb20e953d40223436449a52481c49804/cbor2-6.1.3-cp314-cp314t-win_amd64.whl", hash = "sha256:dc6bcd030bf5043662b84b0ca0f0ca942491bf509105db30cedca6e2ce82d158", size = 310300, upload-time = "2026-07-04T10:36:46.212Z" },
+    { url = "https://files.pythonhosted.org/packages/05/d0/b0780a396d145e3356bfdc48578d021ade1818a6c7d7842a3d6bc6f16fbb/cbor2-6.1.3-cp314-cp314t-win_arm64.whl", hash = "sha256:da98a5e0ae9487bed497ac74e2c850b49975a3b7b5314b76c3843e2c83a6c8c4", size = 299391, upload-time = "2026-07-04T10:36:47.629Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
@@ -1654,6 +1694,7 @@ dependencies = [
     { name = "aiosmtpd" },
     { name = "boto3" },
     { name = "botocore" },
+    { name = "cbor2" },
     { name = "dnslib" },
     { name = "docker" },
     { name = "httpx" },
@@ -1692,6 +1733,7 @@ requires-dist = [
     { name = "bandit", marker = "extra == 'dev'", specifier = ">=1.7" },
     { name = "boto3", specifier = ">=1.34" },
     { name = "botocore", specifier = ">=1.34" },
+    { name = "cbor2", specifier = ">=5.6" },
     { name = "coverage", marker = "extra == 'dev'", specifier = ">=7.5" },
     { name = "dnslib", specifier = ">=0.9" },
     { name = "docker", specifier = ">=7.0" },


### PR DESCRIPTION
## Bug

`terraform apply` on `aws_cloudwatch_dashboard` (and any CloudWatch resource created via a recent `aws-sdk-go-v2`/terraform-provider-aws) hangs for minutes against robotocore, with the request never even reaching the audit log — looked like an unresolvable client-side issue.

## Root cause

`terraform-provider-aws` 6.54.0 sends `PutDashboard` using AWS's newer **Smithy RPC v2 CBOR** protocol: a binary CBOR body POSTed to `/service/{ServiceId}/operation/{OperationName}`, with `smithy-protocol: rpc-v2-cbor` — no `X-Amz-Target`, no JSON, no query string.

`handle_cloudwatch_request` only recognized JSON (`X-Amz-Target`) and classic query/form protocols. Neither matched, so `action` ended up empty, matched nothing in `_ACTION_MAP`, and the request fell through to Moto's query-protocol dispatcher — which tried to UTF-8-decode the raw CBOR bytes and raised `UnicodeDecodeError`. That's a 500, and `aws-sdk-go-v2` retries 5xx up to 25 times with backoff — indistinguishable from a hang inside any test window shorter than ~2 minutes.

## Fix

- Added `cbor2` as a dependency.
- Detect `smithy-protocol: rpc-v2-cbor` before the JSON/query branches; decode with `cbor2.loads`; read the operation name from the URL path since there's no `X-Amz-Target`.
- Added `_success_response`/`_error_body_response` helpers so all 6 response sites in this handler pick JSON/CBOR/XML consistently — CBOR responses get `media_type="application/cbor"` and the `smithy-protocol` header back.
- An unmapped CBOR action fails closed with a real `501` instead of falling through to Moto (which has zero CBOR support).

## Verification

Ran the actual real-world terraform PR that surfaced this (a Bedrock usage-logging module: `aws_cloudwatch_dashboard` + 6 sibling resources):
```
$ terraform apply -auto-approve
aws_cloudwatch_dashboard.bedrock_usage: Creation complete after 0s [id=bedrock-engineer-usage]
Apply complete! Resources: 7 added, 0 changed, 0 destroyed.
$ terraform destroy -auto-approve
Destroy complete! Resources: 7 destroyed.
```
Previously this hung for 2+ minutes then failed.

- 3 new unit tests (`TestCloudWatchCborProtocol`): full CBOR round-trip, CBOR-encoded error response, and a negative test proving an unmapped CBOR action does not fall through to Moto.
- Full local suite: 8732 unit (3 new) + 140 integration/compat passed. `ruff`/`mypy`/`bandit` clean.