### PR TITLE
fix: CloudWatch Logs metric filters drop wildcard matches, dimensions, and extracted values

### DIFF
--- a/prompts/20260712-050000-cloudwatch-metric-filter-value-extraction.md
+++ b/prompts/20260712-050000-cloudwatch-metric-filter-value-extraction.md
@@ -1,0 +1,32 @@
+---
+session: 20260712
+slug: cloudwatch-metric-filter-value-extraction
+type: fix
+---
+
+## Context
+
+Re-reviewing `launchdarkly/terraform#25240` (the Bedrock invocation-logging module) against latest robotocore, specifically checking that token-count logging is correct end-to-end — not just that `terraform apply` succeeds.
+
+## Root cause
+
+Three compounding bugs in `robotocore/services/cloudwatch/filters.py`, all in the metric-filter engine that turns `PutLogEvents` into CloudWatch metrics:
+
+1. **JSON pattern `*` wildcard was matched literally.** `{ $.input.inputTokenCount = * }` (the standard "field is present" idiom, and the exact pattern this module uses) compared the field's value against the literal string `"*"` instead of treating it as a wildcard — so the filter never matched anything, and no metric was ever emitted.
+2. **`metricValue` was never extracted from the message.** AWS lets `metricValue` be a `$.field.path` extractor (used here for the real token count) or a literal. `_emit_metric_from_filter` only ever did `float(literal)`; for an extractor string like `$.input.inputTokenCount` that raises `ValueError` and falls back to a hardcoded `1.0` — so even with (1) fixed, every metric point would silently record "1" instead of the real token count.
+3. **Metric-transformation `dimensions` were dropped entirely.** `MetricTransformation` never stored them and `_emit_metric_from_filter` never built a `Dimensions` list, so per-`ModelId` breakdown (what the whole dashboard is built around) was never possible — `PutMetricData` calls came back dimensionless.
+
+All three fail silently: no error, no hang, just permanently empty or wrong data. Same class of bug as the Smithy CBOR gap (`fix/cloudwatch-smithy-rpc-v2-cbor`) — a real, common AWS idiom nobody had exercised — but worse, because nothing anywhere signals it's broken.
+
+## Fix
+
+- `matches_filter_pattern`/`_match_json_pattern`: extracted field-path resolution into `_resolve_json_field`; `expected == "*"` with `=` now means "field present", matching real AWS semantics.
+- `MetricTransformation` gained a `dimensions: dict[str, str]` field (the raw `$.field` template per dimension name).
+- `_emit_metric_from_filter` now takes the raw log message, resolves `metricValue` and every dimension's template via a shared `_resolve_transform_field` helper (literal or `$.path` extractor), and skips the metric point cleanly if any referenced field is missing (falls back to `defaultValue` only for the metric value itself, matching AWS).
+
+## Verification
+
+- Real `terraform apply` on the actual PR module against a fresh robotocore instance: all 7 resources apply clean (unchanged from before this fix — the bug was invisible to `terraform apply`, only to the data the module produces).
+- End-to-end manual repro: `PutLogEvents` with a realistic Bedrock invocation log record, then `GetMetricStatistics`/`ListMetrics` — before the fix, zero datapoints; after, `InputTokens`/`OutputTokens` show the real token counts (1500/400, not "1") with the correct `ModelId` dimension.
+- 5 new unit tests (`TestMetricFilterExtraction` in `test_cloudwatch_bugs.py`): wildcard match/no-match, value extraction with dimensions, a filter with no `dimensions` key (the common case, must be unaffected), and a missing-field extractor skipping cleanly instead of emitting garbage.
+- Full local suite: 8737 unit (5 new) + existing compat/integration untouched. `ruff`/`mypy`/`bandit`/`validate_test_quality`/`lint_project --fail` all clean.

--- a/src/robotocore/services/cloudwatch/filters.py
+++ b/src/robotocore/services/cloudwatch/filters.py
@@ -23,6 +23,8 @@ class MetricTransformation:
     metric_namespace: str
     metric_value: str
     default_value: float | None = None
+    dimensions: dict[str, str] = field(default_factory=dict)
+    # {dimension_name: "$.field.path"} template, resolved per-event against the log message
 
 
 @dataclass
@@ -77,6 +79,7 @@ class FilterStore:
                     metric_namespace=mt.get("metricNamespace", ""),
                     metric_value=mt.get("metricValue", "1"),
                     default_value=mt.get("defaultValue"),
+                    dimensions=mt.get("dimensions", {}),
                 )
                 for mt in metric_transformations
             ]
@@ -202,18 +205,9 @@ def matches_filter_pattern(pattern: str, message: str) -> bool:
     return _match_terms(pattern, message)
 
 
-def _match_json_pattern(match: re.Match, message: str) -> bool:
-    """Match a JSON extraction pattern against a log message."""
-    field_path = match.group(1)
-    operator = match.group(2)
-    expected = match.group(3)
-
-    try:
-        data = json.loads(message)
-    except (json.JSONDecodeError, TypeError):
-        return False
-
-    # Navigate the field path (supports hyphens and array indices like items[0])
+def _resolve_json_field(data: object, field_path: str) -> object | None:
+    """Navigate a `$.field.path` (supports hyphens and array indices like items[0])
+    against parsed JSON. Returns None if any segment is missing."""
     parts = field_path.split(".")
     current = data
     for part in parts:
@@ -225,17 +219,38 @@ def _match_json_pattern(match: re.Match, message: str) -> bool:
             if isinstance(current, dict):
                 current = current.get(field_name)
             else:
-                return False
+                return None
             if isinstance(current, list) and index < len(current):
                 current = current[index]
             else:
-                return False
+                return None
         elif isinstance(current, dict):
             current = current.get(part)
         else:
-            return False
+            return None
         if current is None:
-            return False
+            return None
+    return current
+
+
+def _match_json_pattern(match: re.Match, message: str) -> bool:
+    """Match a JSON extraction pattern against a log message."""
+    field_path = match.group(1)
+    operator = match.group(2)
+    expected = match.group(3)
+
+    try:
+        data = json.loads(message)
+    except (json.JSONDecodeError, TypeError):
+        return False
+
+    current = _resolve_json_field(data, field_path)
+    if current is None:
+        return False
+
+    # `*` is a wildcard meaning "field is present", regardless of value.
+    if expected == "*" and operator == "=":
+        return True
 
     actual = str(current)
 
@@ -332,7 +347,7 @@ def process_log_events(
         for event in events:
             message = event.get("message", "")
             if matches_filter_pattern(mf.filter_pattern, message):
-                _emit_metric_from_filter(mf, region, account_id)
+                _emit_metric_from_filter(mf, message, region, account_id)
 
     # Process subscription filters
     sub_filters = store.get_subscription_filters_for_group(log_group_name)
@@ -344,17 +359,49 @@ def process_log_events(
             _deliver_to_subscription(sf, log_group_name, log_stream_name, matching_events, region)
 
 
-def _emit_metric_from_filter(mf: MetricFilter, region: str, account_id: str) -> None:
-    """Emit metric data from a matching metric filter."""
+def _resolve_transform_field(raw: str, data: object) -> str | None:
+    """A metricValue/dimension value is either a literal or a `$.field.path` extractor."""
+    if not raw.startswith("$."):
+        return raw
+    resolved = _resolve_json_field(data, raw[2:])
+    return None if resolved is None else str(resolved)
+
+
+def _emit_metric_from_filter(mf: MetricFilter, message: str, region: str, account_id: str) -> None:
+    """Emit metric data from a matching metric filter, extracting the metric value and
+    any dimensions from the log message (both may be `$.field.path` extractors)."""
+    try:
+        data = json.loads(message)
+    except (json.JSONDecodeError, TypeError):
+        data = None
+
     try:
         from moto.backends import get_backend  # noqa: I001
 
         cw_backend = get_backend("cloudwatch")[account_id][region]
         for transform in mf.metric_transformations:
-            try:
-                value = float(transform.metric_value)
-            except (ValueError, TypeError):
-                value = 1.0
+            raw_value = _resolve_transform_field(transform.metric_value, data)
+            if raw_value is None:
+                if transform.default_value is None:
+                    continue
+                value = transform.default_value
+            else:
+                try:
+                    value = float(raw_value)
+                except (ValueError, TypeError):
+                    continue
+
+            dimensions = []
+            skip = False
+            for dim_name, dim_path in transform.dimensions.items():
+                dim_value = _resolve_transform_field(dim_path, data)
+                if dim_value is None:
+                    skip = True
+                    break
+                dimensions.append({"Name": dim_name, "Value": dim_value})
+            if skip:
+                continue
+
             cw_backend.put_metric_data(
                 namespace=transform.metric_namespace,
                 metric_data=[
@@ -362,6 +409,7 @@ def _emit_metric_from_filter(mf: MetricFilter, region: str, account_id: str) -> 
                         "MetricName": transform.metric_name,
                         "Value": value,
                         "Unit": "Count",
+                        "Dimensions": dimensions,
                     }
                 ],
             )

--- a/tests/unit/services/test_cloudwatch_bugs.py
+++ b/tests/unit/services/test_cloudwatch_bugs.py
@@ -7,7 +7,11 @@ import json
 
 import pytest
 
-from robotocore.services.cloudwatch.filters import matches_filter_pattern
+from robotocore.services.cloudwatch.filters import (
+    get_filter_store,
+    matches_filter_pattern,
+    process_log_events,
+)
 from robotocore.services.cloudwatch.insights import (
     execute_pipeline,
     parse_query,
@@ -149,3 +153,98 @@ class TestInsightsSortMixedTypes:
         cmds = parse_query("sort @timestamp asc")
         result = execute_pipeline(cmds, events)
         assert len(result) == 3
+
+
+# ===================================================================
+# Bug 9: Metric filters silently drop wildcard matches, dimensions,
+# and extracted metric values (found reviewing the Bedrock invocation-
+# logging terraform module, which relies on all three).
+# ===================================================================
+
+
+class TestMetricFilterExtraction:
+    def test_wildcard_json_pattern_matches_present_field(self):
+        """`{ $.field = * }` means "field is present", not the literal string "*"."""
+        msg = json.dumps({"input": {"inputTokenCount": 1500}})
+        assert matches_filter_pattern("{ $.input.inputTokenCount = * }", msg) is True
+
+    def test_wildcard_json_pattern_does_not_match_missing_field(self):
+        msg = json.dumps({"output": {"outputTokenCount": 400}})
+        assert matches_filter_pattern("{ $.input.inputTokenCount = * }", msg) is False
+
+    def test_metric_value_extracted_from_message_not_hardcoded_to_one(self):
+        """metricValue may be a `$.field.path` extractor, not just a literal."""
+        region, account = "us-east-1", "999999999999"
+        store = get_filter_store(region)
+        store.put_metric_filter(
+            "/aws/bedrock/engineer-inference",
+            "BedrockInputTokensByModel",
+            "{ $.input.inputTokenCount = * }",
+            [
+                {
+                    "metricName": "InputTokens",
+                    "metricNamespace": "BedrockEngineerUsage",
+                    "metricValue": "$.input.inputTokenCount",
+                    "dimensions": {"ModelId": "$.modelId"},
+                }
+            ],
+        )
+        msg = json.dumps({"modelId": "moonshotai.kimi-k2.5", "input": {"inputTokenCount": 1500}})
+        process_log_events(
+            "/aws/bedrock/engineer-inference", "stream1", [{"message": msg}], region, account
+        )
+
+        from moto.backends import get_backend
+
+        cw_backend = get_backend("cloudwatch")[account][region]
+        matching = [d for d in cw_backend.metric_data if d.name == "InputTokens"]
+        assert len(matching) == 1
+        assert matching[0].value == 1500.0
+        dim_pairs = {(d.name, d.value) for d in matching[0].dimensions}
+        assert ("ModelId", "moonshotai.kimi-k2.5") in dim_pairs
+
+    def test_metric_filter_without_dimensions_still_works(self):
+        """A metric filter with no `dimensions` key (the common case) is unaffected."""
+        region, account = "us-east-1", "999999999998"
+        store = get_filter_store(region)
+        store.put_metric_filter(
+            "/some/group",
+            "PlainCount",
+            '{ $.status = "ERROR" }',
+            [{"metricName": "Errors", "metricNamespace": "MyApp", "metricValue": "1"}],
+        )
+        msg = json.dumps({"status": "ERROR"})
+        process_log_events("/some/group", "stream1", [{"message": msg}], region, account)
+
+        from moto.backends import get_backend
+
+        cw_backend = get_backend("cloudwatch")[account][region]
+        matching = [d for d in cw_backend.metric_data if d.name == "Errors"]
+        assert len(matching) == 1
+        assert matching[0].value == 1.0
+        assert list(matching[0].dimensions) == []
+
+    def test_metric_not_emitted_when_extracted_value_missing(self):
+        """If metricValue references a field the message doesn't have, skip cleanly."""
+        region, account = "us-east-1", "999999999997"
+        store = get_filter_store(region)
+        store.put_metric_filter(
+            "/some/group",
+            "MissingField",
+            "",
+            [
+                {
+                    "metricName": "Whatever",
+                    "metricNamespace": "MyApp",
+                    "metricValue": "$.does.not.exist",
+                }
+            ],
+        )
+        msg = json.dumps({"other": "field"})
+        process_log_events("/some/group", "stream1", [{"message": msg}], region, account)
+
+        from moto.backends import get_backend
+
+        cw_backend = get_backend("cloudwatch")[account][region]
+        matching = [d for d in cw_backend.metric_data if d.name == "Whatever"]
+        assert matching == []


### PR DESCRIPTION
## What

Three compounding bugs in the CloudWatch Logs metric-filter engine (`services/cloudwatch/filters.py`), found while re-reviewing `launchdarkly/terraform#25240`'s Bedrock token-usage dashboard against latest robotocore:

1. `{ $.field = * }` — the standard "field is present" wildcard — was matched against the literal string `"*"`, so it never matched anything real.
2. `metricValue` as a `$.field.path` extractor (used to pull the real token count out of the log record) was never resolved; it always fell back to a hardcoded `1.0`.
3. `dimensions` on a metric transformation (e.g. `ModelId`) were parsed from the request but never attached to the emitted `PutMetricData` call.

All three fail **silently** — no error, no hang, just permanently empty or wrong CloudWatch metrics. Terraform apply/plan for a module using this pattern looks completely healthy; only the resulting dashboard data is wrong.

## Fix

- Extracted JSON field-path resolution into `_resolve_json_field`; `expected == "*"` now means "field present".
- `MetricTransformation` gained `dimensions: dict[str, str]`.
- `_emit_metric_from_filter` now resolves `metricValue` and every dimension template (literal or `$.path` extractor) against the actual log message, skipping cleanly if a referenced field is missing.

## Verification

- Real `terraform apply` of the actual PR module (7 resources) against a fresh robotocore instance: still applies clean (the bug was invisible to `apply`, only to the data produced).
- Manual end-to-end repro: `PutLogEvents` with a realistic Bedrock invocation-log record → before, `GetMetricStatistics`/`ListMetrics` returns zero datapoints; after, correct `InputTokens`/`OutputTokens` (1500/400, not "1") with the `ModelId` dimension present.
- 5 new unit tests (`TestMetricFilterExtraction`).
- Full local suite: 8737 unit passed (5 new), `ruff`/`mypy`/`bandit`/`validate_test_quality`/`lint_project --fail` all clean.