### PR TITLE
fix: Logs Insights never auto-discovers JSON fields, parse/filter reject dotted names

### DIFF
--- a/prompts/20260712-053000-cloudwatch-insights-json-autodiscovery.md
+++ b/prompts/20260712-053000-cloudwatch-insights-json-autodiscovery.md
@@ -1,0 +1,36 @@
+---
+session: 20260712
+slug: cloudwatch-insights-json-autodiscovery
+type: fix
+---
+
+## Context
+
+Continuing the token-logging correctness review of `launchdarkly/terraform#25240` (follow-up to `fix/cloudwatch-metric-filter-value-extraction`, #291): the dashboard's Logs Insights widgets — the per-engineer/per-permission-set cost breakdown, the whole point of the "oversight" panel — never worked against robotocore's query engine.
+
+## Root cause
+
+Four compounding bugs in `robotocore/services/cloudwatch/insights.py`:
+
+1. **JSON log fields were never auto-discovered.** Real Logs Insights auto-flattens a JSON log message's nested fields into dotted-path row fields (`input.inputTokenCount`, `identity.arn`, ...) with no `parse` needed. robotocore's rows only ever had `timestamp`/`message`/`logStream`/`ptr` — so `stats sum(input.inputTokenCount)` referenced a field that never existed.
+2. **Aggregation and filter field-name regexes rejected dots.** Even with (1) fixed, `sum(input.inputTokenCount)` failed to parse as an aggregation at all (its field regex was `\w*`, no dot) and silently degraded to `count(*)`. Same story for `filter`/`sort` field names.
+3. **`parse` rejected dotted source fields and glob wildcards.** `parse identity.arn "*assumed-role/AWSReservedSSO_*_*/*" as ...` — the standard AWS glob-parse idiom this module uses to split an ARN into permission-set/engineer — never matched `_parse_command`'s regex (`\w+` source, and the `*` wildcards were later passed straight to `re.search` as a literal regex, which would raise `nothing to repeat` on the leading `*`). The whole `parse` step silently vanished from the pipeline.
+4. **`filter field = 'value'` (single-quoted) wasn't recognized.** Every specific matcher in `_evaluate_filter` only accepted double quotes; single-quoted filters (used by this module's "still on Administrator" oversight query) fell through to a substring-of-the-raw-message fallback that never matches.
+
+Also fixed in passing: `stats sum(x) as alias` — the `as` alias was parsed and thrown away, so results always came back keyed by the raw `func(field)` label instead of the name the query asked for.
+
+All four/five fail silently: valid-looking queries that always return zero, or one big bucket instead of a real breakdown.
+
+## Fix
+
+- `execute_pipeline` now flattens each JSON log message into dotted-path fields (`_flatten_json_message`) and merges them into the row before running the pipeline.
+- Field-name character classes in the aggregation, filter, sort, and parse-source regexes now allow dots/brackets/hyphens (`[\w.\[\]-]`).
+- `parse`'s regex now accepts either delimiter (`/regex/` for real regex — unchanged behavior — or `"glob"` for AWS's bare-`*`-wildcard syntax, converted to an anchored regex with one capture group per `*` via `_glob_to_regex`).
+- Filter comparisons (`=`, `!=`, `like`) accept single or double quotes via a backreferenced delimiter group.
+- `stats func(field) as alias` now uses `alias` as the result column name when present.
+
+## Verification
+
+- Manual end-to-end repro of all three dashboard log-widget queries against realistic Bedrock invocation-log JSON: before, every one returned zero rows or a single ungrouped bucket; after, correct per-permission-set/per-engineer/per-model token breakdowns.
+- 4 new unit tests (`TestInsightsJsonAutoDiscovery`): JSON auto-discovery without `parse`, dotted-source glob `parse`, regex-mode `parse` still works unchanged, single-quoted `filter`.
+- Full local suite: 8741 unit (4 new) passed. `ruff`/`mypy`/`bandit`/`validate_test_quality`/`lint_project --fail` all clean.

--- a/src/robotocore/services/cloudwatch/insights.py
+++ b/src/robotocore/services/cloudwatch/insights.py
@@ -1,9 +1,12 @@
 """CloudWatch Logs Insights query engine.
 
-Supports: fields, filter, stats (with group-by), sort, limit, parse (regex extraction).
+Supports: fields, filter, stats (with group-by), sort, limit, parse (glob or regex
+extraction). JSON log messages have their fields auto-discovered as dotted-path row
+fields (e.g. `identity.arn`, `input.inputTokenCount`), matching real Logs Insights.
 Pipeline executor against in-memory log data.
 """
 
+import json
 import logging
 import re
 import threading
@@ -195,12 +198,17 @@ def _parse_command(text: str) -> dict | None:
     if limit_match:
         return {"type": "limit", "count": int(limit_match.group(1))}
 
-    # parse @message /regex/ as @field1, @field2
-    parse_match = re.match(r'parse\s+(@?\w+)\s+[/"](.+?)[/"]\s+as\s+(.+)', text, re.IGNORECASE)
+    # parse @message /regex/ as @field1, @field2   (real regex, explicit capture groups)
+    # parse identity.arn "*literal*" as @field1, @field2   (AWS glob syntax, bare `*` wildcards)
+    parse_match = re.match(
+        r'parse\s+(@?[\w.\[\]-]+)\s+([/"])(.+?)\2\s+as\s+(.+)', text, re.IGNORECASE
+    )
     if parse_match:
         source = parse_match.group(1).lstrip("@")
-        pattern = parse_match.group(2)
-        field_names = [f.strip().lstrip("@") for f in parse_match.group(3).split(",")]
+        delimiter = parse_match.group(2)
+        raw_pattern = parse_match.group(3)
+        field_names = [f.strip().lstrip("@") for f in parse_match.group(4).split(",")]
+        pattern = raw_pattern if delimiter == "/" else _glob_to_regex(raw_pattern)
         return {
             "type": "parse",
             "source": source,
@@ -211,6 +219,18 @@ def _parse_command(text: str) -> dict | None:
     return None
 
 
+def _glob_to_regex(glob_pattern: str) -> str:
+    """Convert a Logs Insights glob-style parse pattern (bare `*` wildcards, one
+    capture per `*`) into an anchored regex with one capture group per wildcard."""
+    literal_parts = glob_pattern.split("*")
+    body = re.escape(literal_parts[0])
+    for i, literal in enumerate(literal_parts[1:], start=1):
+        is_last = i == len(literal_parts) - 1
+        body += "(.*)" if is_last else "(.*?)"
+        body += re.escape(literal)
+    return f"^{body}$"
+
+
 def _parse_aggregations(text: str) -> list[dict]:
     """Parse aggregation expressions like 'count(*)', 'avg(field)', 'sum(@duration)'."""
     result: list[dict] = []
@@ -218,11 +238,16 @@ def _parse_aggregations(text: str) -> list[dict]:
     parts = _split_aggregations(text)
     for part in parts:
         part = part.strip()
-        agg_match = re.match(r"(\w+)\s*\(\s*(@?\w*\*?)\s*\)", part)
+        agg_match = re.match(
+            r"(\w+)\s*\(\s*(@?[\w.\[\]-]*\*?)\s*\)(?:\s+as\s+(\w+))?", part, re.IGNORECASE
+        )
         if agg_match:
             func = agg_match.group(1).lower()
             field = agg_match.group(2).lstrip("@") or "*"
-            result.append({"func": func, "field": field})
+            entry = {"func": func, "field": field}
+            if agg_match.group(3):
+                entry["alias"] = agg_match.group(3)
+            result.append(entry)
         else:
             result.append({"func": "count", "field": "*"})
     return result
@@ -248,6 +273,32 @@ def _split_aggregations(text: str) -> list[str]:
     if current:
         parts.append("".join(current))
     return parts
+
+
+def _flatten_json_message(message: str) -> dict[str, object]:
+    """Auto-discover fields from a JSON log message as dotted-path row fields,
+    e.g. `{"input": {"inputTokenCount": 5}}` -> `{"input.inputTokenCount": 5}`.
+    Real Logs Insights does this for any JSON-formatted log event; non-JSON
+    messages (or non-dict top level) contribute no extra fields.
+    """
+    try:
+        data = json.loads(message)
+    except (json.JSONDecodeError, TypeError):
+        return {}
+    if not isinstance(data, dict):
+        return {}
+
+    flat: dict[str, object] = {}
+
+    def _walk(obj: object, prefix: str) -> None:
+        if isinstance(obj, dict):
+            for key, value in obj.items():
+                _walk(value, f"{prefix}.{key}" if prefix else str(key))
+        else:
+            flat[prefix] = obj
+
+    _walk(data, "")
+    return flat
 
 
 # ---------------------------------------------------------------------------
@@ -276,12 +327,14 @@ def execute_pipeline(
     # Convert events to row dicts
     rows: list[dict] = []
     for event in log_events:
+        message = event.get("message", "")
         row = {
             "timestamp": str(event.get("timestamp", "")),
-            "message": event.get("message", ""),
+            "message": message,
             "logStream": event.get("logStreamName", ""),
             "ptr": event.get("eventId", ""),
         }
+        row.update(_flatten_json_message(message))
         rows.append(row)
 
     for cmd in commands:
@@ -343,37 +396,37 @@ def _evaluate_filter(row: dict, expression: str) -> bool:
     expression = expression.strip()
 
     # like with regex: @field like /pattern/
-    like_regex = re.match(r"(@?\w+)\s+like\s+/(.+)/", expression, re.IGNORECASE)
+    like_regex = re.match(r"(@?[\w.\[\]-]+)\s+like\s+/(.+)/", expression, re.IGNORECASE)
     if like_regex:
         field = like_regex.group(1).lstrip("@")
         pattern = like_regex.group(2)
         val = str(row.get(field, ""))
         return bool(re.search(pattern, val))
 
-    # like with string: @field like "text"
-    like_str = re.match(r'(@?\w+)\s+like\s+"([^"]*)"', expression, re.IGNORECASE)
+    # like with string: @field like "text" (single or double quoted)
+    like_str = re.match(r'(@?[\w.\[\]-]+)\s+like\s+([\'"])(.*?)\2', expression, re.IGNORECASE)
     if like_str:
         field = like_str.group(1).lstrip("@")
-        text = like_str.group(2)
+        text = like_str.group(3)
         val = str(row.get(field, ""))
         return text in val
 
-    # Exact match: @field = "value"
-    eq_match = re.match(r'(@?\w+)\s*=\s*"([^"]*)"', expression)
+    # Exact match: @field = "value" or @field = 'value'
+    eq_match = re.match(r'(@?[\w.\[\]-]+)\s*=\s*([\'"])(.*?)\2', expression)
     if eq_match:
         field = eq_match.group(1).lstrip("@")
-        value = eq_match.group(2)
+        value = eq_match.group(3)
         return str(row.get(field, "")) == value
 
-    # Not equal: @field != "value"
-    neq_match = re.match(r'(@?\w+)\s*!=\s*"([^"]*)"', expression)
+    # Not equal: @field != "value" or @field != 'value'
+    neq_match = re.match(r'(@?[\w.\[\]-]+)\s*!=\s*([\'"])(.*?)\2', expression)
     if neq_match:
         field = neq_match.group(1).lstrip("@")
-        value = neq_match.group(2)
+        value = neq_match.group(3)
         return str(row.get(field, "")) != value
 
     # Numeric comparisons: @field > N, @field >= N, @field < N, @field <= N, @field = N
-    num_match = re.match(r"(@?\w+)\s*(>=|<=|!=|>|<|=)\s*(-?\d+\.?\d*)", expression)
+    num_match = re.match(r"(@?[\w.\[\]-]+)\s*(>=|<=|!=|>|<|=)\s*(-?\d+\.?\d*)", expression)
     if num_match:
         field = num_match.group(1).lstrip("@")
         op = num_match.group(2)
@@ -417,7 +470,7 @@ def _exec_stats(rows: list[dict], cmd: dict) -> list[dict]:
                 out_row[g] = str(key[i])
             for agg in aggregations:
                 agg_val = _compute_aggregation(agg, group_rows)
-                label = f"{agg['func']}({agg['field']})"
+                label = agg.get("alias") or f"{agg['func']}({agg['field']})"
                 out_row[label] = str(agg_val)
             result.append(out_row)
         return result

--- a/tests/unit/services/test_cloudwatch_bugs.py
+++ b/tests/unit/services/test_cloudwatch_bugs.py
@@ -248,3 +248,60 @@ class TestMetricFilterExtraction:
         cw_backend = get_backend("cloudwatch")[account][region]
         matching = [d for d in cw_backend.metric_data if d.name == "Whatever"]
         assert matching == []
+
+
+# ===================================================================
+# Bug 10: Logs Insights never auto-discovers JSON message fields, `parse`
+# rejects dotted source names and glob wildcards, and filter/stats field
+# regexes reject dotted paths and single-quoted string literals — found
+# alongside Bug 9, reviewing the same Bedrock invocation-logging module.
+# ===================================================================
+
+
+class TestInsightsJsonAutoDiscovery:
+    def test_nested_json_fields_are_queryable_without_parse(self):
+        """A JSON log message's nested fields are auto-discovered as dotted-path
+        fields, matching real Logs Insights — no `parse` needed for JSON bodies."""
+        msg = json.dumps({"input": {"inputTokenCount": 1500}, "modelId": "kimi"})
+        cmds = parse_query(
+            "stats sum(input.inputTokenCount) as input_tokens, count(*) as calls by modelId"
+        )
+        result = execute_pipeline(cmds, [{"message": msg}])
+        assert result == [{"modelId": "kimi", "input_tokens": "1500.0", "calls": "1.0"}]
+
+    def test_parse_with_dotted_source_and_glob_wildcards(self):
+        """`parse identity.arn "*literal*" as a, b` — the real AWS glob idiom for ARN
+        extraction — must resolve dotted source fields and treat `*` as a wildcard,
+        not a literal regex quantifier."""
+        msg = json.dumps(
+            {
+                "identity": {
+                    "arn": "arn:aws:sts::222222222222:assumed-role/"
+                    "AWSReservedSSO_BedrockEngineer_abc123/jack@ld.com"
+                }
+            }
+        )
+        cmds = parse_query(
+            'parse identity.arn "*assumed-role/AWSReservedSSO_*_*/*" '
+            "as arn_prefix, permission_set, sso_id, engineer"
+        )
+        result = execute_pipeline(cmds, [{"message": msg}])
+        assert result[0]["permission_set"] == "BedrockEngineer"
+        assert result[0]["engineer"] == "jack@ld.com"
+
+    def test_regex_mode_parse_still_supported(self):
+        """Slash-delimited `parse` patterns remain real regexes with explicit groups."""
+        cmds = parse_query("parse @message /user=(\\w+)/ as @user")
+        result = execute_pipeline(cmds, [{"message": "user=alice"}])
+        assert result[0]["user"] == "alice"
+
+    def test_filter_supports_single_quoted_string_literal(self):
+        """`filter field = 'value'` (single quotes) must work, not just double quotes."""
+        cmds = parse_query("filter permission_set = 'Administrator'")
+        rows = [
+            {"message": json.dumps({"permission_set": "Administrator"})},
+            {"message": json.dumps({"permission_set": "BedrockEngineer"})},
+        ]
+        result = execute_pipeline(cmds, rows)
+        assert len(result) == 1
+        assert result[0]["permission_set"] == "Administrator"


### PR DESCRIPTION
## What

Follow-up to #291. Continuing the token-logging correctness review of `launchdarkly/terraform#25240`: the dashboard's Logs Insights widgets (per-engineer/per-permission-set cost breakdown — the actual point of the "oversight" panel) never produced real data against robotocore.

Four compounding bugs in `services/cloudwatch/insights.py`:

1. JSON log message fields were never auto-flattened into queryable dotted-path row fields (real Logs Insights does this automatically). `stats sum(input.inputTokenCount)` referenced a field that never existed.
2. Aggregation/filter/sort field-name regexes rejected dots, so even after (1), `sum(input.inputTokenCount)` silently degraded to `count(*)`.
3. `parse identity.arn "*assumed-role/AWSReservedSSO_*_*/*" as ...` — the standard AWS glob-parse idiom, and exactly what this module uses to split an ARN into permission-set/engineer — was dropped from the pipeline entirely (dotted source name + bare `*` wildcards both unsupported).
4. `filter field = 'value'` (single-quoted) fell through every matcher to a substring-of-raw-message fallback that never matches.

Also fixed: `stats func(x) as alias` — the alias was parsed and discarded, so results always came back keyed by `func(field)` instead of the requested name.

All fail silently — a valid-looking query just returns zero rows or one ungrouped bucket, no error anywhere.

## Fix

- `execute_pipeline` flattens JSON messages into dotted-path fields before running the pipeline.
- Field-name regexes across aggregation/filter/sort/parse now allow `[\w.\[\]-]`.
- `parse` supports both real regex (`/.../`, unchanged) and AWS glob syntax (`"..."` with bare `*` wildcards, converted to an anchored regex).
- Filter comparisons accept single or double quotes.
- `stats ... as alias` is honored.

## Verification

- Manual repro of all three dashboard log-widget queries with realistic Bedrock invocation-log JSON: before → zero rows/one bucket; after → correct per-permission-set/per-engineer/per-model breakdowns.
- 4 new unit tests (`TestInsightsJsonAutoDiscovery`).
- Full local suite: 8741 unit passed (4 new), `ruff`/`mypy`/`bandit`/`validate_test_quality`/`lint_project --fail` all clean.