### PR TITLE
fix: AppSync/API Gateway v2 Update operations silently drop fields

### DIFF
--- a/prompts/20260711-223704-appsync-httpconfig-update.md
+++ b/prompts/20260711-223704-appsync-httpconfig-update.md
@@ -1,0 +1,39 @@
+---
+session: 20260711
+slug: appsync-httpconfig-update
+type: fix
+---
+
+## Context
+
+Reviewing the AppSync provider for correctness bugs in update operations. The bug class being hunted is: request/response fields that are parsed but then IGNORED, dimensions/attributes that are accepted but never attached to what's returned.
+
+## Root cause
+
+In `src/robotocore/services/appsync/provider.py`, the `_update_data_source` function was missing the `httpConfig` field in its update loop. The field was correctly stored in `_create_data_source` but silently ignored during updates.
+
+The function only updated these fields:
+- type
+- description
+- serviceRoleArn
+- dynamodbConfig
+- lambdaConfig
+
+But `httpConfig` was missing, even though it's a valid data source configuration field (for HTTP data sources) that was stored at creation time.
+
+## Fix
+
+Added `httpConfig` to the list of fields that get updated in `_update_data_source`:
+
+```python
+if "httpConfig" in params:
+    ds["httpConfig"] = params["httpConfig"]
+```
+
+## Verification
+
+- 2 new unit tests in `tests/unit/services/test_appsync_bugs.py`:
+  - `test_update_data_source_http_config`: Verifies httpConfig is updated
+  - `test_update_data_source_preserves_other_fields`: Verifies other fields are preserved when updating httpConfig
+- Full unit suite: 8742 passed (2 new), 23 skipped
+- Linting: ruff clean

--- a/prompts/20260711-223705-apigatewayv2-stage-update.md
+++ b/prompts/20260711-223705-apigatewayv2-stage-update.md
@@ -1,0 +1,51 @@
+---
+session: 20260711
+slug: apigatewayv2-stage-update
+type: fix
+---
+
+## Context
+
+Reviewing the API Gateway v2 provider for correctness bugs in update operations. The bug class being hunted is: request/response fields that are parsed but then IGNORED, dimensions/attributes that are accepted but never attached to what's returned.
+
+## Root cause
+
+In `src/robotocore/services/apigatewayv2/provider.py`, the `_update_stage` function was missing the `AccessLogSettings` and `Tags` fields in its update loop. These fields were correctly stored in `_create_stage` but silently ignored during updates.
+
+The function only updated these fields:
+- AutoDeploy
+- Description
+- StageVariables
+- DeploymentId
+- DefaultRouteSettings
+- RouteSettings
+
+But `AccessLogSettings` and `Tags` were missing, even though they are valid stage configuration fields that were stored at creation time.
+
+## Fix
+
+Added `AccessLogSettings` and `Tags` to the list of fields that get updated in `_update_stage`:
+
+```python
+for key in (
+    "AutoDeploy",
+    "Description",
+    "StageVariables",
+    "DeploymentId",
+    "DefaultRouteSettings",
+    "RouteSettings",
+    "AccessLogSettings",  # Added
+    "Tags",               # Added
+):
+    if key in params:
+        stage[key] = params[key]
+```
+
+## Verification
+
+- 3 new unit tests in `tests/unit/services/test_apigatewayv2_bugs.py`:
+  - `test_update_stage_access_log_settings`: Verifies AccessLogSettings is updated
+  - `test_update_stage_tags`: Verifies Tags are updated
+  - `test_update_stage_preserves_other_fields`: Verifies other fields are preserved when updating AccessLogSettings
+- Full unit suite: 8742 passed (3 new), 23 skipped
+- Linting: ruff clean

--- a/src/robotocore/services/apigatewayv2/provider.py
+++ b/src/robotocore/services/apigatewayv2/provider.py
@@ -961,6 +961,8 @@ def _update_stage(
             "DeploymentId",
             "DefaultRouteSettings",
             "RouteSettings",
+            "AccessLogSettings",
+            "Tags",
         ):
             if key in params:
                 stage[key] = params[key]

--- a/src/robotocore/services/appsync/provider.py
+++ b/src/robotocore/services/appsync/provider.py
@@ -690,6 +690,8 @@ def _update_data_source(
             ds["dynamodbConfig"] = params["dynamodbConfig"]
         if "lambdaConfig" in params:
             ds["lambdaConfig"] = params["lambdaConfig"]
+        if "httpConfig" in params:
+            ds["httpConfig"] = params["httpConfig"]
     return {"dataSource": ds}
 
 

--- a/tests/unit/services/test_apigatewayv2_bugs.py
+++ b/tests/unit/services/test_apigatewayv2_bugs.py
@@ -1,0 +1,123 @@
+"""Tests for correctness bugs found and fixed in API Gateway v2 provider.
+
+Each test documents a specific bug that has been fixed.
+"""
+
+from robotocore.services.apigatewayv2.provider import (
+    _create_api,
+    _create_stage,
+    _delete_api,
+    _update_stage,
+)
+
+REGION = "us-east-1"
+ACCOUNT = "123456789012"
+
+
+# ===================================================================
+# Bug 1: _update_stage ignores AccessLogSettings and Tags fields
+# ===================================================================
+
+
+class TestUpdateStageMissingFields:
+    """Test that AccessLogSettings and Tags are properly updated in _update_stage."""
+
+    def test_update_stage_access_log_settings(self):
+        """AccessLogSettings field should be updated when provided in params."""
+        # Create an API first
+        api_result = _create_api(
+            {"Name": "test-api", "ProtocolType": "HTTP"}, REGION, ACCOUNT
+        )
+        api_id = api_result["ApiId"]
+
+        # Create a stage with AccessLogSettings
+        create_params = {
+            "StageName": "prod",
+            "AccessLogSettings": {
+                "DestinationArn": "arn:aws:logs:us-east-1:123456789012:log-group:old-group",
+                "Format": "{\"requestId\": \"$context.requestId\"}",
+            },
+        }
+        result = _create_stage(api_id, create_params, REGION, ACCOUNT)
+        assert result["AccessLogSettings"]["DestinationArn"].endswith("old-group")
+
+        # Update the AccessLogSettings
+        update_params = {
+            "AccessLogSettings": {
+                "DestinationArn": "arn:aws:logs:us-east-1:123456789012:log-group:new-group",
+                "Format": "{\"updated\": true}",
+            }
+        }
+        result = _update_stage(api_id, "prod", update_params, REGION, ACCOUNT)
+
+        # Bug: AccessLogSettings was silently ignored in _update_stage
+        # After fix, the AccessLogSettings should be updated
+        assert (
+            result["AccessLogSettings"]["DestinationArn"].endswith("new-group")
+        ), f"Expected updated DestinationArn, got: {result.get('AccessLogSettings')}"
+        assert (
+            result["AccessLogSettings"]["Format"] == '{"updated": true}'
+        ), f"Expected updated Format, got: {result.get('AccessLogSettings')}"
+
+    def test_update_stage_tags(self):
+        """Tags field should be updated when provided in params."""
+        # Create an API first
+        api_result = _create_api(
+            {"Name": "test-api", "ProtocolType": "HTTP"}, REGION, ACCOUNT
+        )
+        api_id = api_result["ApiId"]
+
+        # Create a stage with Tags
+        create_params = {"StageName": "prod", "Tags": {"env": "old-env", "team": "backend"}}
+        result = _create_stage(api_id, create_params, REGION, ACCOUNT)
+        assert result["Tags"]["env"] == "old-env"
+
+        # Update the Tags
+        update_params = {"Tags": {"env": "new-env", "team": "backend"}}
+        result = _update_stage(api_id, "prod", update_params, REGION, ACCOUNT)
+
+        # Bug: Tags was silently ignored in _update_stage
+        # After fix, the Tags should be updated
+        assert (
+            result["Tags"]["env"] == "new-env"
+        ), f"Expected updated tag, got: {result.get('Tags')}"
+        # Other tags should be preserved
+        assert result["Tags"]["team"] == "backend"
+
+    def test_update_stage_preserves_other_fields(self):
+        """Updating AccessLogSettings should not affect other fields."""
+        # Create an API first
+        api_result = _create_api(
+            {"Name": "test-api", "ProtocolType": "HTTP"}, REGION, ACCOUNT
+        )
+        api_id = api_result["ApiId"]
+
+        # Create a stage with multiple fields
+        create_params = {
+            "StageName": "prod",
+            "Description": "Original description",
+            "StageVariables": {"key": "value"},
+            "AccessLogSettings": {
+                "DestinationArn": "arn:aws:logs:us-east-1:123456789012:log-group:old-group",
+                "Format": "{\"requestId\": \"$context.requestId\"}",
+            },
+        }
+        _create_stage(api_id, create_params, REGION, ACCOUNT)
+
+        # Update only AccessLogSettings
+        update_params = {
+            "AccessLogSettings": {
+                "DestinationArn": "arn:aws:logs:us-east-1:123456789012:log-group:new-group",
+                "Format": "{\"updated\": true}",
+            }
+        }
+        result = _update_stage(api_id, "prod", update_params, REGION, ACCOUNT)
+
+        # Other fields should be preserved
+        assert result["Description"] == "Original description"
+        assert result["StageVariables"]["key"] == "value"
+        # AccessLogSettings should be updated
+        assert result["AccessLogSettings"]["DestinationArn"].endswith("new-group")
+
+        # Cleanup
+        _delete_api(api_id, REGION, ACCOUNT)

--- a/tests/unit/services/test_apigatewayv2_bugs.py
+++ b/tests/unit/services/test_apigatewayv2_bugs.py
@@ -25,9 +25,7 @@ class TestUpdateStageMissingFields:
     def test_update_stage_access_log_settings(self):
         """AccessLogSettings field should be updated when provided in params."""
         # Create an API first
-        api_result = _create_api(
-            {"Name": "test-api", "ProtocolType": "HTTP"}, REGION, ACCOUNT
-        )
+        api_result = _create_api({"Name": "test-api", "ProtocolType": "HTTP"}, REGION, ACCOUNT)
         api_id = api_result["ApiId"]
 
         # Create a stage with AccessLogSettings
@@ -35,7 +33,7 @@ class TestUpdateStageMissingFields:
             "StageName": "prod",
             "AccessLogSettings": {
                 "DestinationArn": "arn:aws:logs:us-east-1:123456789012:log-group:old-group",
-                "Format": "{\"requestId\": \"$context.requestId\"}",
+                "Format": '{"requestId": "$context.requestId"}',
             },
         }
         result = _create_stage(api_id, create_params, REGION, ACCOUNT)
@@ -45,26 +43,24 @@ class TestUpdateStageMissingFields:
         update_params = {
             "AccessLogSettings": {
                 "DestinationArn": "arn:aws:logs:us-east-1:123456789012:log-group:new-group",
-                "Format": "{\"updated\": true}",
+                "Format": '{"updated": true}',
             }
         }
         result = _update_stage(api_id, "prod", update_params, REGION, ACCOUNT)
 
         # Bug: AccessLogSettings was silently ignored in _update_stage
         # After fix, the AccessLogSettings should be updated
-        assert (
-            result["AccessLogSettings"]["DestinationArn"].endswith("new-group")
-        ), f"Expected updated DestinationArn, got: {result.get('AccessLogSettings')}"
-        assert (
-            result["AccessLogSettings"]["Format"] == '{"updated": true}'
-        ), f"Expected updated Format, got: {result.get('AccessLogSettings')}"
+        assert result["AccessLogSettings"]["DestinationArn"].endswith("new-group"), (
+            f"Expected updated DestinationArn, got: {result.get('AccessLogSettings')}"
+        )
+        assert result["AccessLogSettings"]["Format"] == '{"updated": true}', (
+            f"Expected updated Format, got: {result.get('AccessLogSettings')}"
+        )
 
     def test_update_stage_tags(self):
         """Tags field should be updated when provided in params."""
         # Create an API first
-        api_result = _create_api(
-            {"Name": "test-api", "ProtocolType": "HTTP"}, REGION, ACCOUNT
-        )
+        api_result = _create_api({"Name": "test-api", "ProtocolType": "HTTP"}, REGION, ACCOUNT)
         api_id = api_result["ApiId"]
 
         # Create a stage with Tags
@@ -78,18 +74,16 @@ class TestUpdateStageMissingFields:
 
         # Bug: Tags was silently ignored in _update_stage
         # After fix, the Tags should be updated
-        assert (
-            result["Tags"]["env"] == "new-env"
-        ), f"Expected updated tag, got: {result.get('Tags')}"
+        assert result["Tags"]["env"] == "new-env", (
+            f"Expected updated tag, got: {result.get('Tags')}"
+        )
         # Other tags should be preserved
         assert result["Tags"]["team"] == "backend"
 
     def test_update_stage_preserves_other_fields(self):
         """Updating AccessLogSettings should not affect other fields."""
         # Create an API first
-        api_result = _create_api(
-            {"Name": "test-api", "ProtocolType": "HTTP"}, REGION, ACCOUNT
-        )
+        api_result = _create_api({"Name": "test-api", "ProtocolType": "HTTP"}, REGION, ACCOUNT)
         api_id = api_result["ApiId"]
 
         # Create a stage with multiple fields
@@ -99,7 +93,7 @@ class TestUpdateStageMissingFields:
             "StageVariables": {"key": "value"},
             "AccessLogSettings": {
                 "DestinationArn": "arn:aws:logs:us-east-1:123456789012:log-group:old-group",
-                "Format": "{\"requestId\": \"$context.requestId\"}",
+                "Format": '{"requestId": "$context.requestId"}',
             },
         }
         _create_stage(api_id, create_params, REGION, ACCOUNT)
@@ -108,7 +102,7 @@ class TestUpdateStageMissingFields:
         update_params = {
             "AccessLogSettings": {
                 "DestinationArn": "arn:aws:logs:us-east-1:123456789012:log-group:new-group",
-                "Format": "{\"updated\": true}",
+                "Format": '{"updated": true}',
             }
         }
         result = _update_stage(api_id, "prod", update_params, REGION, ACCOUNT)

--- a/tests/unit/services/test_appsync_bugs.py
+++ b/tests/unit/services/test_appsync_bugs.py
@@ -47,9 +47,9 @@ class TestUpdateDataSourceHttpConfig:
 
         # Bug: httpConfig was silently ignored in _update_data_source
         # After fix, the httpConfig should be updated
-        assert (
-            result["dataSource"]["httpConfig"]["endpoint"] == "https://newdomain.com/api"
-        ), f"Expected updated endpoint, got: {result['dataSource'].get('httpConfig')}"
+        assert result["dataSource"]["httpConfig"]["endpoint"] == "https://newdomain.com/api", (
+            f"Expected updated endpoint, got: {result['dataSource'].get('httpConfig')}"
+        )
 
     def test_update_data_source_preserves_other_fields(self):
         """Updating httpConfig should not affect other fields."""

--- a/tests/unit/services/test_appsync_bugs.py
+++ b/tests/unit/services/test_appsync_bugs.py
@@ -1,0 +1,81 @@
+"""Tests for correctness bugs found and fixed in AppSync provider.
+
+Each test documents a specific bug that has been fixed.
+"""
+
+from robotocore.services.appsync.provider import (
+    AppSyncStore,
+    _create_data_source,
+    _create_graphql_api,
+    _update_data_source,
+)
+
+REGION = "us-east-1"
+ACCOUNT = "123456789012"
+
+
+# ===================================================================
+# Bug 1: _update_data_source ignores httpConfig field
+# ===================================================================
+
+
+class TestUpdateDataSourceHttpConfig:
+    """Test that httpConfig is properly updated in _update_data_source."""
+
+    def test_update_data_source_http_config(self):
+        """httpConfig field should be updated when provided in params."""
+        store = AppSyncStore()
+
+        # Create an API first
+        api_result = _create_graphql_api(
+            store, {"name": "test-api", "authenticationType": "API_KEY"}, REGION, ACCOUNT
+        )
+        api_id = api_result["graphqlApi"]["apiId"]
+
+        # Create a data source with httpConfig
+        create_params = {
+            "name": "http-ds",
+            "type": "HTTP",
+            "httpConfig": {"endpoint": "https://example.com/api"},
+        }
+        result = _create_data_source(store, api_id, create_params, REGION, ACCOUNT)
+        assert result["dataSource"]["httpConfig"]["endpoint"] == "https://example.com/api"
+
+        # Update the httpConfig
+        update_params = {"httpConfig": {"endpoint": "https://newdomain.com/api"}}
+        result = _update_data_source(store, api_id, "http-ds", update_params, REGION, ACCOUNT)
+
+        # Bug: httpConfig was silently ignored in _update_data_source
+        # After fix, the httpConfig should be updated
+        assert (
+            result["dataSource"]["httpConfig"]["endpoint"] == "https://newdomain.com/api"
+        ), f"Expected updated endpoint, got: {result['dataSource'].get('httpConfig')}"
+
+    def test_update_data_source_preserves_other_fields(self):
+        """Updating httpConfig should not affect other fields."""
+        store = AppSyncStore()
+
+        # Create an API first
+        api_result = _create_graphql_api(
+            store, {"name": "test-api", "authenticationType": "API_KEY"}, REGION, ACCOUNT
+        )
+        api_id = api_result["graphqlApi"]["apiId"]
+
+        # Create a data source with multiple config fields
+        create_params = {
+            "name": "http-ds",
+            "type": "HTTP",
+            "description": "Original description",
+            "httpConfig": {"endpoint": "https://example.com/api"},
+        }
+        _create_data_source(store, api_id, create_params, REGION, ACCOUNT)
+
+        # Update only httpConfig
+        update_params = {"httpConfig": {"endpoint": "https://newdomain.com/api"}}
+        result = _update_data_source(store, api_id, "http-ds", update_params, REGION, ACCOUNT)
+
+        # Other fields should be preserved
+        assert result["dataSource"]["description"] == "Original description"
+        assert result["dataSource"]["type"] == "HTTP"
+        # httpConfig should be updated
+        assert result["dataSource"]["httpConfig"]["endpoint"] == "https://newdomain.com/api"


### PR DESCRIPTION
## What

Two more instances of the same "field stored on create, silently dropped on update" bug class already fixed in Scheduler/CloudWatch (see #291-293):

1. **AppSync `UpdateDataSource` ignored `httpConfig`.** Stored on `CreateDataSource`, never written back on update — an HTTP data source's endpoint config could never be changed after creation, with no error.
2. **API Gateway v2 `UpdateStage` ignored `AccessLogSettings` and `Tags`.** Same shape — stored on `CreateStage`, dropped on `UpdateStage`.

## Verification

- Regression tests for both (`tests/unit/services/test_appsync_bugs.py`, `tests/unit/services/test_apigatewayv2_bugs.py`).
- Full local suite: 8742 unit passed, `ruff`/`mypy`/`lint_project --fail` all clean.

Found and fixed by a Bedrock (Kimi K2.5) agent sweep, reviewed and independently re-verified (diff read, tests re-run, lint re-run, unrelated `pyproject.toml`/`uv.lock` environment-setup noise discarded) before opening this PR.