### PR TITLE
fix: DynamoDB global-table replica never inherits source stream config

### DIFF
--- a/prompts/20260711-224500-dynamodb-replica-stream-config.md
+++ b/prompts/20260711-224500-dynamodb-replica-stream-config.md
@@ -1,0 +1,22 @@
+---
+session: 20260711
+slug: dynamodb-replica-stream-config
+type: fix
+---
+
+## Context
+
+Part of a broad Bedrock-agent sweep for silent-correctness bugs across robotocore's native providers (same bug class as the CloudWatch/Scheduler/AppSync/API Gateway v2 fixes in the same session).
+
+## Root cause
+
+`create_replica_table` (DynamoDB Global Tables replication) hardcoded `streams=None` when creating the replica table's backing table, regardless of whether the source table had a stream enabled. A global table replica would silently never get a DynamoDB Stream, even when the source table's `StreamSpecification` had `StreamEnabled: true` — no error, just a replica that can't be used with anything depending on streams (Lambda triggers, cross-region replication tooling, etc).
+
+## Fix
+
+Read the source table's `stream_specification` when `latest_stream_label` indicates a stream is active, and pass it through to `target_backend.create_table(..., streams=...)` instead of the hardcoded `None`.
+
+## Verification
+
+- 2 new unit tests (`TestGlobalTableReplicaStreamConfig`): replica inherits stream config when source has one; replica gets `streams=None` when source has none (regression guard for the correct no-stream case).
+- Full local suite: 8739 unit passed (2 new). `ruff`/`mypy` clean on changed files.

--- a/src/robotocore/services/dynamodb/replication.py
+++ b/src/robotocore/services/dynamodb/replication.py
@@ -260,6 +260,11 @@ def create_replica_table(
                 }
             )
 
+        # Inherit stream configuration from source table
+        streams = None
+        if source_table.latest_stream_label:
+            streams = source_table.stream_specification
+
         target_backend.create_table(
             table_name,
             schema=key_schema,
@@ -267,7 +272,7 @@ def create_replica_table(
             attr=attr_defs,
             global_indexes=None,
             indexes=None,
-            streams=None,
+            streams=streams,
             billing_mode="PAY_PER_REQUEST",
             sse_specification=None,
             tags=[],

--- a/tests/unit/services/test_dynamodb_bugs.py
+++ b/tests/unit/services/test_dynamodb_bugs.py
@@ -1,0 +1,128 @@
+"""Tests for correctness bugs in the DynamoDB native provider.
+
+Each test targets a specific bug that has been fixed.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from robotocore.services.dynamodb.replication import create_replica_table
+
+REGION = "us-east-1"
+ACCOUNT = "123456789012"
+
+
+# ===================================================================
+# Bug 1: Global table replica doesn't inherit stream configuration
+# ===================================================================
+
+
+class TestGlobalTableReplicaStreamConfig:
+    """When creating a global table replica, the replica table should inherit
+    the stream configuration from the source table.
+
+    Previously, create_replica_table passed streams=None, which meant
+    replica tables never had streams enabled even when the source
+    table had streaming enabled.
+    """
+
+    def test_replica_inherits_stream_config(self):
+        """Replica tables should inherit stream configuration from source."""
+        # Mock the source table with streams enabled
+        mock_source_table = MagicMock()
+        mock_source_table.hash_key_attr = "id"
+        mock_source_table.hash_key_type = "S"
+        mock_source_table.range_key_attr = None
+        mock_source_table.range_key_type = None
+        mock_source_table.latest_stream_label = "2024-01-01T00:00:00"
+        mock_source_table.stream_specification = {
+            "StreamEnabled": True,
+            "StreamViewType": "NEW_AND_OLD_IMAGES",
+        }
+
+        # Track what parameters are passed to create_table
+        create_table_calls = []
+
+        def mock_create_table(*args, **kwargs):
+            create_table_calls.append((args, kwargs))
+            return MagicMock()
+
+        # Mock the backends
+        with patch("moto.backends.get_backend") as mock_get_backend:
+            mock_source_backend = MagicMock()
+            mock_source_backend.get_table.return_value = mock_source_table
+
+            mock_target_backend = MagicMock()
+            mock_target_backend.get_table.return_value = None
+            mock_target_backend.create_table = mock_create_table
+
+            # Set up the backend dictionary
+            backend_dict = {
+                ACCOUNT: {
+                    "us-east-1": mock_source_backend,
+                    "us-west-2": mock_target_backend,
+                }
+            }
+            mock_get_backend.return_value = backend_dict
+
+            # Call create_replica_table
+            result = create_replica_table(
+                table_name="test-table",
+                source_region="us-east-1",
+                target_region="us-west-2",
+                account_id=ACCOUNT,
+            )
+
+            assert result is True
+            assert len(create_table_calls) == 1
+            args, kwargs = create_table_calls[0]
+            # The streams parameter should be inherited from source
+            assert kwargs.get("streams") == {
+                "StreamEnabled": True,
+                "StreamViewType": "NEW_AND_OLD_IMAGES",
+            }
+
+    def test_replica_with_no_source_stream(self):
+        """Replica tables should have streams=None when source has no streams."""
+        # Mock the source table WITHOUT streams
+        mock_source_table = MagicMock()
+        mock_source_table.hash_key_attr = "id"
+        mock_source_table.hash_key_type = "S"
+        mock_source_table.range_key_attr = None
+        mock_source_table.range_key_type = None
+        mock_source_table.latest_stream_label = None  # No stream
+        mock_source_table.stream_specification = {}
+
+        create_table_calls = []
+
+        def mock_create_table(*args, **kwargs):
+            create_table_calls.append((args, kwargs))
+            return MagicMock()
+
+        with patch("moto.backends.get_backend") as mock_get_backend:
+            mock_source_backend = MagicMock()
+            mock_source_backend.get_table.return_value = mock_source_table
+
+            mock_target_backend = MagicMock()
+            mock_target_backend.get_table.return_value = None
+            mock_target_backend.create_table = mock_create_table
+
+            backend_dict = {
+                ACCOUNT: {
+                    "us-east-1": mock_source_backend,
+                    "us-west-2": mock_target_backend,
+                }
+            }
+            mock_get_backend.return_value = backend_dict
+
+            result = create_replica_table(
+                table_name="test-table",
+                source_region="us-east-1",
+                target_region="us-west-2",
+                account_id=ACCOUNT,
+            )
+
+            assert result is True
+            assert len(create_table_calls) == 1
+            args, kwargs = create_table_calls[0]
+            # The streams parameter should be None when source has no stream
+            assert kwargs.get("streams") is None


### PR DESCRIPTION
## What

`create_replica_table` (DynamoDB Global Tables replication) hardcoded `streams=None` regardless of the source table's actual `StreamSpecification` — a replica silently never got a DynamoDB Stream even when the source had one enabled, with no error anywhere.

## Verification

- 2 new unit tests (`TestGlobalTableReplicaStreamConfig`): replica inherits config when source has a stream; stays `None` when source doesn't.
- Full local suite: 8739 unit passed (2 new), `ruff`/`mypy`/`lint_project --fail` clean.

Found by a Bedrock (Kimi K2.5) agent sweep. Note: this particular agent run hit its auto-resume cap without emitting a final report (a known failure mode — the model made the right edit and wrote a correct test, but never produced the closing summary block), so I reviewed the diff cold, cleaned up its leftover scratch repro scripts, discarded unrelated `pyproject.toml`/`uv.lock` environment noise, added the missing prompt log, and independently re-verified everything before opening this PR.