### PR TITLE
fix: Kinesis AT_TIMESTAMP shard iterator ignores Timestamp param

### DIFF
--- a/prompts/20260711-224200-kinesis-at-timestamp-bug.md
+++ b/prompts/20260711-224200-kinesis-at-timestamp-bug.md
@@ -1,0 +1,38 @@
+---
+session: "20260711-001"
+slug: "kinesis-at-timestamp-bug"
+type: "bugfix"
+---
+
+## Context
+
+While reviewing the native Kinesis provider for correctness bugs, I discovered that the `AT_TIMESTAMP` shard iterator type was not properly implemented. The `Timestamp` parameter was being silently ignored, causing `GetRecords` to return all records from the beginning of the shard instead of filtering by timestamp.
+
+## Root Cause
+
+In `src/robotocore/services/kinesis/provider.py`:
+
+1. The `_encode_iterator` function did not accept or store a `timestamp` parameter
+2. The `_get_shard_iterator` function ignored the `Timestamp` parameter when creating an `AT_TIMESTAMP` iterator
+3. The `_get_records` function did not filter records by timestamp when the iterator type was `AT_TIMESTAMP`
+
+## Fix
+
+1. Added `timestamp: float | None = None` parameter to `_encode_iterator`
+2. Store the timestamp in the iterator JSON payload
+3. In `_get_shard_iterator`, pass the `Timestamp` parameter when creating an `AT_TIMESTAMP` iterator
+4. In `_get_records`, filter records by timestamp when the iterator type is `AT_TIMESTAMP`
+
+## Verification
+
+Added regression test in `tests/unit/services/test_kinesis_bugs.py`:
+- Creates a stream with two records at different timestamps
+- Creates an `AT_TIMESTAMP` iterator for 30 minutes ago
+- Verifies that only records at or after that timestamp are returned
+
+Test passes after the fix, confirming the bug is resolved.
+
+## Files Changed
+
+- `src/robotocore/services/kinesis/provider.py` - Fixed AT_TIMESTAMP handling
+- `tests/unit/services/test_kinesis_bugs.py` - Added regression test

--- a/src/robotocore/services/kinesis/provider.py
+++ b/src/robotocore/services/kinesis/provider.py
@@ -31,7 +31,12 @@ _iterator_lock = threading.Lock()
 
 
 def _encode_iterator(
-    stream_name: str, shard_id: str, iterator_type: str, sequence: str, region: str
+    stream_name: str,
+    shard_id: str,
+    iterator_type: str,
+    sequence: str,
+    region: str,
+    timestamp: float | None = None,
 ) -> str:
     """Encode shard iterator as a base64 JSON blob."""
     payload = json.dumps(
@@ -42,6 +47,7 @@ def _encode_iterator(
             "seq": sequence,
             "region": region,
             "ts": time.time(),
+            "timestamp": timestamp,  # Store timestamp for AT_TIMESTAMP iterators
         }
     )
     return base64.b64encode(payload.encode()).decode()
@@ -298,6 +304,10 @@ def _get_shard_iterator(store: KinesisStore, params: dict, region: str, account_
     elif iterator_type == "AT_TIMESTAMP":
         # AT_TIMESTAMP starts from the beginning and filters by timestamp
         seq = "00000000000000000000"
+        # Store the timestamp for filtering in GetRecords
+        timestamp = params.get("Timestamp")
+        token = _encode_iterator(name, shard_id, iterator_type, seq, region, timestamp=timestamp)
+        return {"ShardIterator": token}
     else:
         raise KinesisError(
             "InvalidArgumentException", f"Invalid ShardIteratorType: {iterator_type}"
@@ -331,6 +341,12 @@ def _get_records(store: KinesisStore, params: dict, region: str, account_id: str
         raise KinesisError("ResourceNotFoundException", f"Shard {shard_id} not found.")
 
     records, next_seq = shard.get_records(seq, limit)
+
+    # Filter by timestamp for AT_TIMESTAMP iterators
+    iterator_type = iterator_info.get("type", "AT_SEQUENCE_NUMBER")
+    timestamp = iterator_info.get("timestamp")
+    if iterator_type == "AT_TIMESTAMP" and timestamp is not None:
+        records = [r for r in records if r.timestamp >= timestamp]
 
     # Build the next iterator
     new_seq = next_seq if next_seq else seq

--- a/tests/unit/services/test_kinesis_bugs.py
+++ b/tests/unit/services/test_kinesis_bugs.py
@@ -1,0 +1,109 @@
+"""Tests for Kinesis provider bug fixes.
+
+Each test targets a specific bug that has been fixed.
+"""
+
+import base64
+
+import pytest
+
+from robotocore.services.kinesis.models import KinesisRecord
+from robotocore.services.kinesis.provider import (
+    _decode_iterator,
+    _get_records,
+    _get_shard_iterator,
+    _get_store,
+)
+
+# ===================================================================
+# Bug 1: AT_TIMESTAMP iterator type ignores Timestamp parameter
+# ===================================================================
+
+
+class TestATTimestampIterator:
+    """Test that AT_TIMESTAMP shard iterator correctly handles the Timestamp parameter."""
+
+    def test_at_timestamp_iterator_ignores_timestamp(self):
+        """AT_TIMESTAMP iterator should store and use the Timestamp parameter.
+
+        Bug: When creating a shard iterator with AT_TIMESTAMP type, the code
+        ignores the Timestamp parameter and just uses sequence 0. This means
+        GetRecords returns all records from the beginning instead of filtering
+        by timestamp.
+        """
+        # Use the provider's store to ensure consistency
+        store = _get_store("us-east-1", "123456789012")
+        store.create_stream("test-stream", 1, "us-east-1", "123456789012")
+        stream = store.get_stream("test-stream")
+        shard = stream.shards[0]
+
+        # Put some records with different timestamps
+        import time
+
+        # Record from 1 hour ago
+        old_time = time.time() - 3600
+        record1 = KinesisRecord(
+            sequence_number="00000000000000000001",
+            partition_key="pk1",
+            data=b"old-data",
+            timestamp=old_time,
+            shard_id=shard.shard_id,
+        )
+        shard.records.append(record1)
+
+        # Record from now
+        new_time = time.time()
+        record2 = KinesisRecord(
+            sequence_number="00000000000000000002",
+            partition_key="pk2",
+            data=b"new-data",
+            timestamp=new_time,
+            shard_id=shard.shard_id,
+        )
+        shard.records.append(record2)
+
+        # Request iterator for 30 minutes ago (should only get record2)
+        thirty_mins_ago = time.time() - 1800
+
+        # Create iterator with AT_TIMESTAMP
+        result = _get_shard_iterator(
+            store,
+            {
+                "StreamName": "test-stream",
+                "ShardId": shard.shard_id,
+                "ShardIteratorType": "AT_TIMESTAMP",
+                "Timestamp": thirty_mins_ago,
+            },
+            "us-east-1",
+            "123456789012",
+        )
+
+        token = result["ShardIterator"]
+        iterator_info = _decode_iterator(token)
+
+        # Bug: The iterator should store the timestamp for filtering
+        # Currently it doesn't store the timestamp at all
+        assert "timestamp" in iterator_info or iterator_info.get("type") == "AT_TIMESTAMP", (
+            "BUG: AT_TIMESTAMP iterator doesn't store the timestamp parameter. "
+            "The Timestamp is silently ignored and all records are returned."
+        )
+
+        # Get records using the iterator
+        records_result = _get_records(
+            store,
+            {"ShardIterator": token, "Limit": 10},
+            "us-east-1",
+            "123456789012",
+        )
+
+        # Should only return record2 (the newer one)
+        # Bug: Currently returns both records because timestamp filtering is not implemented
+        records = records_result["Records"]
+        if len(records) == 2:
+            pytest.fail(
+                "BUG: AT_TIMESTAMP returned all records instead of filtering by timestamp. "
+                f"Expected 1 record (after {thirty_mins_ago}), got {len(records)}"
+            )
+
+        assert len(records) == 1, f"Expected 1 record, got {len(records)}"
+        assert base64.b64decode(records[0]["Data"]) == b"new-data"


### PR DESCRIPTION
## What

`GetShardIterator` with `ShardIteratorType=AT_TIMESTAMP` accepted the `Timestamp` parameter but never stored or used it — the iterator always started from the beginning of the shard and `GetRecords` returned every record, silently ignoring the requested timestamp filter.

## Fix

`_encode_iterator` now carries the timestamp through the iterator token; `_get_records` filters returned records to `timestamp >= requested_timestamp` when the iterator type is `AT_TIMESTAMP`.

## Verification

- New regression test (`tests/unit/services/test_kinesis_bugs.py`).
- Full local suite: 8738 unit passed (1 new), `ruff`/`mypy`/`lint_project --fail` clean.

Found by a Bedrock (Kimi K2.5) agent sweep — the same run also investigated a suspected SQS bug, concluded it wasn't real after deeper investigation, and correctly dropped it rather than reporting a false positive. Reviewed and independently re-verified before opening this PR.