### PR TITLE
fix: Cognito CreateUserPoolClient drops fields; SecretsManager rotation drops binary

### DIFF
--- a/prompts/20260711-230000-cognito-secretsmanager-dropped-fields.md
+++ b/prompts/20260711-230000-cognito-secretsmanager-dropped-fields.md
@@ -1,0 +1,26 @@
+---
+session: 20260711
+slug: cognito-secretsmanager-dropped-fields
+type: fix
+---
+
+## Context
+
+Part of a broad Bedrock-agent sweep for silent-correctness bugs across robotocore's native providers. This run also produced an IAM `conditions.py` "fix" for `StringLike`/`ArnLike` wildcard matching that was factually wrong (it claimed AWS IAM doesn't support `?` as a single-character wildcard, which it does per AWS's own docs, and rewrote pre-existing correct tests to assert the wrong behavior) — that change and its test were discarded entirely during review and are not part of this commit.
+
+## Root cause
+
+Two more instances of the "field accepted, silently dropped" bug class:
+
+1. **Cognito `CreateUserPoolClient` never initialized several updatable fields** (`LogoutURLs`, `DefaultRedirectURI`, `ReadAttributes`, `WriteAttributes`, `SupportedIdentityProviders`, `AllowedOAuthFlowsUserPoolClient`, `TokenValidityUnits`, `AccessTokenValidity`, `IdTokenValidity`, `RefreshTokenValidity`) even though `_update_user_pool_client` explicitly updates all of them — a client created with these fields set would have them silently discarded at creation time.
+2. **SecretsManager `RotateSecret` only copied `secret_string` into the new `AWSPENDING` version**, never `secret_binary` — rotating a binary secret would silently lose its value.
+
+## Fix
+
+- `_create_user_pool_client` now initializes all fields from `params` that `_update_user_pool_client` is able to update, matching the schema `_update_user_pool_client` already expects.
+- `_rotate_secret` copies `secret_binary` alongside `secret_string` when present.
+
+## Verification
+
+- New tests: `TestCreateUserPoolClientInitializesAllFields` (cognito), `TestRotateSecretPreservesBinary` (secretsmanager).
+- Full local suite: 8741 unit passed. `ruff`/`ruff format`/`mypy` clean on changed files.

--- a/src/robotocore/services/cognito/provider.py
+++ b/src/robotocore/services/cognito/provider.py
@@ -333,6 +333,17 @@ def _create_user_pool_client(
         "AllowedOAuthFlows": params.get("AllowedOAuthFlows", []),
         "AllowedOAuthScopes": params.get("AllowedOAuthScopes", []),
         "CallbackURLs": params.get("CallbackURLs", []),
+        # Initialize all updatable fields to empty values
+        "LogoutURLs": params.get("LogoutURLs", []),
+        "DefaultRedirectURI": params.get("DefaultRedirectURI", ""),
+        "ReadAttributes": params.get("ReadAttributes", []),
+        "WriteAttributes": params.get("WriteAttributes", []),
+        "SupportedIdentityProviders": params.get("SupportedIdentityProviders", []),
+        "AllowedOAuthFlowsUserPoolClient": params.get("AllowedOAuthFlowsUserPoolClient", False),
+        "TokenValidityUnits": params.get("TokenValidityUnits", {}),
+        "AccessTokenValidity": params.get("AccessTokenValidity", 0),
+        "IdTokenValidity": params.get("IdTokenValidity", 0),
+        "RefreshTokenValidity": params.get("RefreshTokenValidity", 0),
     }
     if generate_secret:
         client["ClientSecret"] = _new_id()

--- a/src/robotocore/services/secretsmanager/provider.py
+++ b/src/robotocore/services/secretsmanager/provider.py
@@ -111,6 +111,8 @@ def _rotate_secret(params: dict, region: str, account_id: str) -> dict:
     }
     if hasattr(secret, "secret_string") and secret.secret_string is not None:
         secret_version["secret_string"] = secret.secret_string
+    if hasattr(secret, "secret_binary") and secret.secret_binary is not None:
+        secret_version["secret_binary"] = secret.secret_binary
 
     # Remove AWSPENDING from old versions
     if hasattr(secret, "remove_version_stages_from_old_versions"):

--- a/tests/unit/services/test_cognito_provider_bugs.py
+++ b/tests/unit/services/test_cognito_provider_bugs.py
@@ -4,12 +4,20 @@ import base64
 import hashlib
 import hmac
 
-from robotocore.services.cognito.provider import _secret_hash
+from robotocore.services.cognito.provider import (
+    CognitoStore,
+    _create_user_pool,
+    _create_user_pool_client,
+    _describe_user_pool_client,
+    _update_user_pool_client,
+)
 
 
 class TestSecretHashBug:
     def test_secret_hash_uses_hmac_sha256(self):
         """_secret_hash should use HMAC-SHA256 as AWS requires, not plain SHA-256."""
+        from robotocore.services.cognito.provider import _secret_hash
+
         username = "testuser"
         client_id = "abc123"
         client_secret = "supersecret"
@@ -24,4 +32,102 @@ class TestSecretHashBug:
         assert actual == expected, (
             f"_secret_hash should use HMAC-SHA256 but got wrong result. "
             f"Expected {expected}, got {actual}"
+        )
+
+
+# ===========================================================================
+# Bug 2: _create_user_pool_client doesn't initialize all updatable fields
+# ===========================================================================
+
+
+class TestCreateUserPoolClientInitializesAllFields:
+    """When creating a user pool client, all fields that can be updated
+    via _update_user_pool_client should be initialized. Otherwise, describe
+    operations won't return those fields even after they've been updated.
+    """
+
+    def test_create_client_initializes_all_updatable_fields(self):
+        """After creating a client, all updatable fields should exist
+        (even if empty), so that describe operations return consistent results."""
+        store = CognitoStore()
+        region = "us-east-1"
+        account_id = "123456789012"
+
+        # First create a pool
+        pool_result = _create_user_pool(store, {"PoolName": "test-pool"}, region, account_id)
+        pool_id = pool_result["UserPool"]["Id"]
+
+        # Create a client
+        result = _create_user_pool_client(
+            store,
+            {"UserPoolId": pool_id, "ClientName": "test-client"},
+            region,
+            account_id,
+        )
+        client = result["UserPoolClient"]
+
+        # These fields are in the updatable list but not initialized
+        # They should be initialized to empty values
+        assert "LogoutURLs" in client, "LogoutURLs should be initialized"
+        assert "DefaultRedirectURI" in client, "DefaultRedirectURI should be initialized"
+        assert "ReadAttributes" in client, "ReadAttributes should be initialized"
+        assert "WriteAttributes" in client, "WriteAttributes should be initialized"
+        assert "SupportedIdentityProviders" in client, (
+            "SupportedIdentityProviders should be initialized"
+        )
+        assert "AllowedOAuthFlowsUserPoolClient" in client, (
+            "AllowedOAuthFlowsUserPoolClient should be initialized"
+        )
+        assert "TokenValidityUnits" in client, "TokenValidityUnits should be initialized"
+        assert "AccessTokenValidity" in client, "AccessTokenValidity should be initialized"
+        assert "IdTokenValidity" in client, "IdTokenValidity should be initialized"
+        assert "RefreshTokenValidity" in client, "RefreshTokenValidity should be initialized"
+
+    def test_describe_returns_updated_fields(self):
+        """After updating a client, describe should return the updated fields."""
+        store = CognitoStore()
+        region = "us-east-1"
+        account_id = "123456789012"
+
+        # First create a pool
+        pool_result = _create_user_pool(store, {"PoolName": "test-pool"}, region, account_id)
+        pool_id = pool_result["UserPool"]["Id"]
+
+        # Create a client
+        create_result = _create_user_pool_client(
+            store,
+            {"UserPoolId": pool_id, "ClientName": "test-client"},
+            region,
+            account_id,
+        )
+        client_id = create_result["UserPoolClient"]["ClientId"]
+
+        # Update the client with new fields
+        _update_user_pool_client(
+            store,
+            {
+                "UserPoolId": pool_id,
+                "ClientId": client_id,
+                "LogoutURLs": ["https://example.com/logout"],
+                "ReadAttributes": ["email", "name"],
+                "AccessTokenValidity": 60,
+            },
+            region,
+            account_id,
+        )
+
+        # Describe should return the updated fields
+        describe_result = _describe_user_pool_client(
+            store, {"UserPoolId": pool_id, "ClientId": client_id}, region, account_id
+        )
+        client = describe_result["UserPoolClient"]
+
+        assert client.get("LogoutURLs") == ["https://example.com/logout"], (
+            "LogoutURLs should be returned after update"
+        )
+        assert client.get("ReadAttributes") == ["email", "name"], (
+            "ReadAttributes should be returned after update"
+        )
+        assert client.get("AccessTokenValidity") == 60, (
+            "AccessTokenValidity should be returned after update"
         )

--- a/tests/unit/services/test_secretsmanager_bugs.py
+++ b/tests/unit/services/test_secretsmanager_bugs.py
@@ -1,0 +1,134 @@
+"""Tests for correctness bugs in the SecretsManager native provider."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from robotocore.services.secretsmanager.provider import handle_secretsmanager_request
+
+
+def _make_request(action: str, body: dict | None = None) -> MagicMock:
+    req = MagicMock()
+    req.headers = {"x-amz-target": f"secretsmanager.{action}"}
+    req.method = "POST"
+    req.url = MagicMock()
+    req.url.path = "/"
+    req.query_params = {}
+    payload = json.dumps(body or {}).encode()
+    req.body = AsyncMock(return_value=payload)
+    return req
+
+
+def _get_backend():
+    from moto.backends import get_backend  # noqa: I001
+
+    return get_backend("secretsmanager")["123456789012"]["us-east-1"]
+
+
+def _create_test_secret(
+    backend, name: str, secret_string: str | None = None, secret_binary: str | None = None
+):
+    """Helper to create a secret in Moto backend."""
+    backend.create_secret(
+        name=name,
+        secret_string=secret_string,
+        secret_binary=secret_binary,
+        description=None,
+        tags=None,
+        kms_key_id=None,
+        client_request_token=None,
+        replica_regions=[],
+        force_overwrite=False,
+    )
+
+
+def _delete_test_secret(backend, name: str):
+    """Helper to force-delete a test secret."""
+    backend.delete_secret(
+        secret_id=name,
+        recovery_window_in_days=None,
+        force_delete_without_recovery=True,
+    )
+
+
+# ===========================================================================
+# Bug 1: RotateSecret doesn't preserve secret_binary
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+class TestRotateSecretPreservesBinary:
+    """RotateSecret must preserve both secret_string AND secret_binary when creating
+    the new AWSPENDING version. Currently only secret_string is copied.
+    """
+
+    async def test_rotate_preserves_secret_binary(self):
+        """When rotating a secret with secret_binary, the new version should
+        preserve the binary data, not lose it."""
+        backend = _get_backend()
+        _create_test_secret(backend, "binary-test-secret", secret_binary="aGVsbG8=")
+
+        req = _make_request(
+            "RotateSecret",
+            {
+                "SecretId": "binary-test-secret",
+                "RotationLambdaARN": "arn:aws:lambda:us-east-1:123456789012:function:myRotator",
+                "RotationRules": {"AutomaticallyAfterDays": 30},
+            },
+        )
+        resp = await handle_secretsmanager_request(req, "us-east-1", "123456789012")
+        assert resp.status_code == 200
+
+        # Check that the secret still has its binary data in the new version
+        secret = backend.secrets.get("binary-test-secret")
+        # Find the AWSPENDING version
+        pending_version = None
+        for vid, vdata in secret.versions.items():
+            if "AWSPENDING" in vdata.get("version_stages", []):
+                pending_version = vdata
+                break
+
+        assert pending_version is not None, "AWSPENDING version should exist after rotation"
+        # The binary data should be preserved
+        assert pending_version.get("secret_binary") == "aGVsbG8=", (
+            "secret_binary should be preserved in the new AWSPENDING version"
+        )
+
+        # Cleanup
+        _delete_test_secret(backend, "binary-test-secret")
+
+    async def test_rotate_preserves_secret_string(self):
+        """When rotating a secret with secret_string, the new version should
+        preserve the string data (this already works, testing for regression)."""
+        backend = _get_backend()
+        _create_test_secret(backend, "string-test-secret", secret_string="my-secret-value")
+
+        req = _make_request(
+            "RotateSecret",
+            {
+                "SecretId": "string-test-secret",
+                "RotationLambdaARN": "arn:aws:lambda:us-east-1:123456789012:function:myRotator",
+                "RotationRules": {"AutomaticallyAfterDays": 30},
+            },
+        )
+        resp = await handle_secretsmanager_request(req, "us-east-1", "123456789012")
+        assert resp.status_code == 200
+
+        # Check that the secret still has its string data in the new version
+        secret = backend.secrets.get("string-test-secret")
+        # Find the AWSPENDING version
+        pending_version = None
+        for vid, vdata in secret.versions.items():
+            if "AWSPENDING" in vdata.get("version_stages", []):
+                pending_version = vdata
+                break
+
+        assert pending_version is not None, "AWSPENDING version should exist after rotation"
+        # The string data should be preserved
+        assert pending_version.get("secret_string") == "my-secret-value", (
+            "secret_string should be preserved in the new AWSPENDING version"
+        )
+
+        # Cleanup
+        _delete_test_secret(backend, "string-test-secret")


### PR DESCRIPTION
## What

Two more instances of the "field accepted, silently dropped" bug class fixed elsewhere in this sweep (#291-#297):

1. **Cognito `CreateUserPoolClient` never initialized several fields that `UpdateUserPoolClient` can update** (`LogoutURLs`, `DefaultRedirectURI`, `ReadAttributes`, `WriteAttributes`, `SupportedIdentityProviders`, `AllowedOAuthFlowsUserPoolClient`, `TokenValidityUnits`, `AccessTokenValidity`, `IdTokenValidity`, `RefreshTokenValidity`) — specifying them at creation time was silently discarded.
2. **SecretsManager `RotateSecret` only copied `secret_string` into the new `AWSPENDING` version, never `secret_binary`** — rotating a binary secret silently lost its value.

## Verification

- New tests: `TestCreateUserPoolClientInitializesAllFields`, `TestRotateSecretPreservesBinary`.
- Full local suite: 8741 unit passed, `ruff`/`ruff format`/`mypy`/`lint_project --fail` all clean.

## Note on what's *not* in this PR

The same agent run also produced a change to IAM's `StringLike`/`ArnLike` wildcard matching (`conditions.py`), claiming AWS IAM only supports `*` and not `?`. That's factually wrong — AWS IAM's condition operators explicitly document `?` as a single-character wildcard, and the codebase's pre-existing tests correctly asserted that. The agent rewrote those correct tests to assert the opposite. I caught this on review, verified against AWS's own docs, and discarded that change and its test entirely rather than including it here. Flagging in case anyone independently rediscovers it and assumes it's real without checking.