### PR TITLE
fix(ec2): include partitionCount in placement group responses

### DIFF
--- a/prompts/20260711-224019-ec2-placement-group-partition-count.md
+++ b/prompts/20260711-224019-ec2-placement-group-partition-count.md
@@ -1,0 +1,34 @@
+---
+session: 20260711
+slug: ec2-placement-group-partition-count
+type: fix
+---
+
+## Context
+
+Part of a broad Bedrock-agent sweep for silent-correctness bugs across robotocore's native providers.
+
+## Root cause
+
+`_create_placement_group` and `_describe_placement_groups` in `src/robotocore/services/ec2/provider.py` stored `partitionCount` on the placement group record but never rendered it into either XML response. A `partition`-strategy placement group's partition count was silently invisible to callers.
+
+## Fix
+
+Both handlers now emit `<partitionCount>` when the group's strategy has a partition count set.
+
+## Verification
+
+- 4 new unit tests (`TestPlacementGroupPartitionCountInResponse` in `tests/unit/services/test_ec2_bugs.py`).
+- Full local suite: 8741 unit passed (4 new). `ruff`/`ruff format`/`mypy` clean.
+
+## Note
+
+The same Bedrock (Kimi K2.5) agent run also proposed ECS and EKS changes that were
+reviewed and discarded: the ECS `ListTasks` serviceName fix replaced dead logic with a
+check against a `task["group"]` field that no code path in the provider ever actually
+sets, so the filter would still always return an empty list — not a real fix, just a
+different way to be broken. The EKS change (`_CLUSTER_RE` from `[^/]+` to `.+`) broke
+nodegroup routing entirely, since `_CLUSTER_RE` is matched before
+`_NODEGROUPS_COLLECTION_RE`/`_NODEGROUP_RE` and the greedy pattern swallows
+`/clusters/{name}/node-groups...` paths too — this was the actual cause of the agent
+run's own "proof did not reproduce" full-suite failure.

--- a/src/robotocore/services/ec2/provider.py
+++ b/src/robotocore/services/ec2/provider.py
@@ -107,6 +107,12 @@ def _create_placement_group(params: dict, region: str, account_id: str) -> Respo
         }
         store[name] = group
 
+    partition_count_xml = ""
+    if group["partitionCount"]:
+        partition_count_xml = (
+            f"        <partitionCount>{group['partitionCount']}</partitionCount>\n"
+        )
+
     xml = f"""<?xml version="1.0" encoding="UTF-8"?>
 <CreatePlacementGroupResponse xmlns="http://ec2.amazonaws.com/doc/2016-11-15/">
     <requestId>{uuid.uuid4()}</requestId>
@@ -116,7 +122,7 @@ def _create_placement_group(params: dict, region: str, account_id: str) -> Respo
         <state>available</state>
         <strategy>{strategy}</strategy>
         <groupId>{group_id}</groupId>
-    </placementGroup>
+{partition_count_xml}    </placementGroup>
 </CreatePlacementGroupResponse>"""
     return Response(content=xml, status_code=200, media_type="text/xml")
 
@@ -149,12 +155,17 @@ def _describe_placement_groups(params: dict, region: str, account_id: str) -> Re
 
     items = ""
     for g in groups:
+        partition_count_xml = ""
+        if g.get("partitionCount"):
+            partition_count_xml = (
+                f"            <partitionCount>{g['partitionCount']}</partitionCount>\n"
+            )
         items += f"""        <item>
             <groupName>{g["groupName"]}</groupName>
             <strategy>{g["strategy"]}</strategy>
             <state>{g["state"]}</state>
             <groupId>{g["groupId"]}</groupId>
-        </item>
+{partition_count_xml}        </item>
 """
 
     xml = f"""<?xml version="1.0" encoding="UTF-8"?>

--- a/tests/unit/services/test_ec2_bugs.py
+++ b/tests/unit/services/test_ec2_bugs.py
@@ -1,0 +1,52 @@
+"""Tests for correctness bugs in the EC2 native provider."""
+
+from robotocore.services.ec2.provider import (
+    _create_placement_group,
+    _describe_placement_groups,
+)
+
+REGION = "us-east-1"
+ACCOUNT = "123456789012"
+
+
+def _params(**kwargs) -> dict:
+    return {k: [v] for k, v in kwargs.items()}
+
+
+class TestPlacementGroupPartitionCountInResponse:
+    """CreatePlacementGroup and DescribePlacementGroups stored partitionCount
+    but never rendered it into the XML response.
+    """
+
+    def test_create_placement_group_includes_partition_count(self):
+        resp = _create_placement_group(
+            _params(GroupName="pg-1", Strategy="partition", PartitionCount="3"),
+            REGION,
+            ACCOUNT,
+        )
+        body = resp.body.decode()
+        assert "<partitionCount>3</partitionCount>" in body
+
+    def test_describe_placement_groups_includes_partition_count(self):
+        _create_placement_group(
+            _params(GroupName="pg-2", Strategy="partition", PartitionCount="5"),
+            REGION,
+            ACCOUNT,
+        )
+        resp = _describe_placement_groups(_params(**{"GroupName.1": "pg-2"}), REGION, ACCOUNT)
+        body = resp.body.decode()
+        assert "<partitionCount>5</partitionCount>" in body
+
+    def test_partition_count_defaults_to_7_for_partition_strategy(self):
+        resp = _create_placement_group(
+            _params(GroupName="pg-3", Strategy="partition"), REGION, ACCOUNT
+        )
+        body = resp.body.decode()
+        assert "<partitionCount>7</partitionCount>" in body
+
+    def test_partition_count_absent_for_non_partition_strategy(self):
+        resp = _create_placement_group(
+            _params(GroupName="pg-4", Strategy="cluster"), REGION, ACCOUNT
+        )
+        body = resp.body.decode()
+        assert "<partitionCount>" not in body


### PR DESCRIPTION
## What

`CreatePlacementGroup`/`DescribePlacementGroups` stored `partitionCount` on the placement group record but never rendered it into either XML response — a `partition`-strategy placement group's partition count was silently invisible to callers, with no error.

## Verification

- 4 new unit tests (`TestPlacementGroupPartitionCountInResponse`).
- Full local suite: 8741 unit passed (4 new), `ruff`/`ruff format`/`mypy`/`lint_project --fail` all clean.

## Note on what's *not* in this PR

The same agent run also proposed ECS and EKS changes I reviewed and discarded:

- **ECS `ListTasks` serviceName filter**: replaced genuinely dead logic (`elif not service_name:`, unreachable for non-empty strings) with a check against `task["group"] == f"service:{service_name}"` — but no code path in the ECS provider ever actually sets `group` on a task, so the filter would still always return an empty list. Cosmetically different, still broken.
- **EKS cluster URL pattern** (`_CLUSTER_RE` from `[^/]+` to `.+`, meant to let ARNs match): this broke nodegroup routing entirely, since `_CLUSTER_RE` is matched before `_NODEGROUPS_COLLECTION_RE`/`_NODEGROUP_RE` and the greedy pattern now also swallows `/clusters/{name}/node-groups` and `/clusters/{name}/node-groups/{ng}` paths. This was the actual cause of the agent run's own "proof did not reproduce" full-suite failure (it re-ran the full suite, got a different result than its own claimed proof, and reported high confidence anyway).

Neither is in this diff.