### PR TITLE
test: account-isolation integration coverage for X-Ray and TaggingAPI

### DIFF
--- a/prompts/20260712-123744-xray-tagging-account-isolation-tests.md
+++ b/prompts/20260712-123744-xray-tagging-account-isolation-tests.md
@@ -1,0 +1,109 @@
+# Integration Tests for X-Ray and ResourceGroupsTaggingAPI Account Isolation
+
+type: test
+date: 2026-07-12
+
+## Summary
+
+Added two new test classes to `tests/integration/test_account_scoping_fidelity.py` to verify cross-account isolation for X-Ray and ResourceGroupsTaggingAPI services.
+
+## Changes Made
+
+### 1. Updated module docstring
+Added two new entries to the AWS scoping reference list:
+- X-Ray sampling rules — per-account + per-region
+- X-Ray groups — per-account + per-region
+- Resource Groups Tagging API — per-account + per-region
+
+### 2. Added `TestXRayAccountIsolation` class
+Two test methods:
+- `test_sampling_rules_isolated_by_account`: Creates same-named sampling rules in both accounts and verifies:
+  - Each account only sees its own rules
+  - ARNs are account-specific
+  - No cross-account leakage via GetSamplingRules
+  
+- `test_groups_isolated_by_account`: Creates same-named groups in both accounts and verifies:
+  - Each account only sees its own groups
+  - ARNs are account-specific
+  - GetGroup returns only the account's own group
+
+### 3. Added `TestTaggingApiAccountIsolation` class
+Two test methods:
+- `test_sqs_resources_isolated_by_account`: Creates tagged SQS queues in both accounts and verifies:
+  - Each account's tagging API only sees its own queues
+  - Tag values are correct per account
+  - No cross-account leakage
+  
+- `test_sns_resources_isolated_by_account`: Creates tagged SNS topics in both accounts and verifies:
+  - Each account's tagging API only sees its own topics
+  - Tag values are correct per account
+  - No cross-account leakage
+
+## Verification
+
+All 11 tests in the file pass:
+```
+tests/integration/test_account_scoping_fidelity.py::TestApiGatewayV2AccountIsolation::test_apis_isolated_by_account PASSED
+tests/integration/test_account_scoping_fidelity.py::TestCloudWatchCompositeAlarmIsolation::test_composite_alarms_isolated_by_account PASSED
+tests/integration/test_account_scoping_fidelity.py::TestCloudWatchDashboardIsolation::test_dashboards_isolated_by_account PASSED
+tests/integration/test_account_scoping_fidelity.py::TestCloudWatchMetricStreamIsolation::test_metric_streams_isolated_by_account PASSED
+tests/integration/test_account_scoping_fidelity.py::TestEventBridgeConnectionIsolation::test_connections_isolated_by_account PASSED
+tests/integration/test_account_scoping_fidelity.py::TestEventBridgeApiDestinationIsolation::test_api_destinations_isolated_by_account PASSED
+tests/integration/test_account_scoping_fidelity.py::TestEventBridgeEndpointIsolation::test_endpoints_isolated_by_account PASSED
+tests/integration/test_account_scoping_fidelity.py::TestXRayAccountIsolation::test_sampling_rules_isolated_by_account PASSED
+tests/integration/test_account_scoping_fidelity.py::TestXRayAccountIsolation::test_groups_isolated_by_account PASSED
+tests/integration/test_account_scoping_fidelity.py::TestTaggingApiAccountIsolation::test_sqs_resources_isolated_by_account PASSED
+tests/integration/test_account_scoping_fidelity.py::TestTaggingApiAccountIsolation::test_sns_resources_isolated_by_account PASSED
+```
+
+All linting checks pass:
+- ruff check: passed
+- ruff format: passed
+- mypy: passed
+
+Full integration test suite: 77 passed, 4 skipped
+
+## Bug Class Hunt Findings
+
+During the grep sweep for similar patterns, found the following potential issues (NOT fixed - test-only task):
+
+### Confirmed Bugs (no account scoping):
+
+1. **X-Ray `_resource_policies`** (`src/robotocore/services/xray/provider.py:328`)
+   - Global dict keyed only by `policy_name`
+   - `_list_resource_policies` returns all policies from all accounts
+   - Cross-account leak: Any account can see/delete another account's resource policies
+
+### Low Risk / Design Decisions:
+
+2. **X-Ray `_encryption_config`** (`src/robotocore/services/xray/provider.py:27`)
+   - Region-keyed only: `dict[str, dict[str, Any]]`  # region -> config
+   - All accounts share the same encryption config per region
+   - May be intentional (X-Ray encryption is regional)
+
+3. **Lambda `_esm_store`** (`src/robotocore/services/lambda_/provider.py:40`)
+   - UUID-keyed: `dict[str, dict]`  # uuid -> mapping config
+   - Stores `_account_id` inside config but list operations don't filter
+   - Low risk: UUIDs are hard to guess
+
+4. **Rekognition `_video_jobs`** (`src/robotocore/services/rekognition/provider.py:25`)
+   - UUID-keyed: `dict[str, dict]`  # job_id -> job
+   - No account filtering on lookups
+   - Low risk: UUIDs are hard to guess
+
+5. **Rekognition `_liveness_sessions`** (`src/robotocore/services/rekognition/provider.py:31`)
+   - UUID-keyed: `dict[str, dict]`  # session_id -> session
+   - No account filtering on lookups
+   - Low risk: UUIDs are hard to guess
+
+### Not Bugs (properly scoped):
+- API Gateway v2: Uses `_acct_region(account_id, region)` as key
+- CloudWatch: Uses `(account_id, region)` tuple as key
+- Step Functions: Uses full ARN as key (includes account)
+- S3: Bucket names are globally unique by design
+- Batch: Uses `f"{account_id}:{region}"` as key
+- SSM: Uses `f"{account_id}:{region}"` as key
+- EC2 placement groups: Uses `account_id` then `region` as nested keys
+- Pipes: Uses `f"{account_id}:{region}:{name}"` as key
+- DynamoDBStreams: Stores account_id in iterator state
+- Support: Case IDs are unique; Moto backend filters by account

--- a/prompts/20260712-123744-xray-tagging-account-isolation-tests.md
+++ b/prompts/20260712-123744-xray-tagging-account-isolation-tests.md
@@ -1,7 +1,8 @@
-# Integration Tests for X-Ray and ResourceGroupsTaggingAPI Account Isolation
-
+---
+session: 20260712
+slug: xray-tagging-account-isolation-tests
 type: test
-date: 2026-07-12
+---
 
 ## Summary
 

--- a/tests/integration/test_account_scoping_fidelity.py
+++ b/tests/integration/test_account_scoping_fidelity.py
@@ -12,6 +12,9 @@ AWS scoping reference:
 - EventBridge connections — per-account + per-region
 - EventBridge API destinations — per-account + per-region
 - EventBridge endpoints — per-account + per-region
+- Resource Groups Tagging API — per-account + per-region
+- X-Ray sampling rules — per-account + per-region
+- X-Ray groups — per-account + per-region
 """
 
 import json
@@ -466,5 +469,268 @@ class TestEventBridgeEndpointIsolation:
             for eb in [eb_a, eb_b]:
                 try:
                     eb.delete_endpoint(Name=ep_name)
+                except Exception:
+                    pass  # best-effort cleanup
+
+
+# ---------------------------------------------------------------------------
+# X-Ray — sampling rules and groups
+# ---------------------------------------------------------------------------
+
+
+class TestXRayAccountIsolation:
+    """X-Ray sampling rules and groups are per-account + per-region in AWS."""
+
+    def test_sampling_rules_isolated_by_account(self, make_boto_client):
+        """Create same-named sampling rule in both accounts; verify isolation."""
+        suffix = uuid.uuid4().hex[:8]
+        rule_name = f"rule-{suffix}"
+
+        xray_a = _client(make_boto_client, "xray", ACCT_A)
+        xray_b = _client(make_boto_client, "xray", ACCT_B)
+
+        xray_a.create_sampling_rule(
+            SamplingRule={
+                "RuleName": rule_name,
+                "ResourceARN": "*",
+                "Priority": 1000,
+                "FixedRate": 0.05,
+                "ReservoirSize": 1,
+                "ServiceName": "*",
+                "ServiceType": "*",
+                "Host": "*",
+                "HTTPMethod": "*",
+                "URLPath": "*",
+                "Version": 1,
+            }
+        )
+        xray_b.create_sampling_rule(
+            SamplingRule={
+                "RuleName": rule_name,
+                "ResourceARN": "*",
+                "Priority": 1000,
+                "FixedRate": 0.05,
+                "ReservoirSize": 1,
+                "ServiceName": "*",
+                "ServiceType": "*",
+                "Host": "*",
+                "HTTPMethod": "*",
+                "URLPath": "*",
+                "Version": 1,
+            }
+        )
+
+        try:
+            # Account A should see only its own rule
+            rules_a = xray_a.get_sampling_rules()["SamplingRuleRecords"]
+            names_a = [r["SamplingRule"]["RuleName"] for r in rules_a]
+            assert rule_name in names_a, "Account A should see its sampling rule"
+            assert names_a.count(rule_name) == 1, (
+                f"Account A sees {names_a.count(rule_name)} rules named {rule_name!r}"
+            )
+
+            # Account B should see only its own rule
+            rules_b = xray_b.get_sampling_rules()["SamplingRuleRecords"]
+            names_b = [r["SamplingRule"]["RuleName"] for r in rules_b]
+            assert rule_name in names_b, "Account B should see its sampling rule"
+            assert names_b.count(rule_name) == 1, (
+                f"Account B sees {names_b.count(rule_name)} rules named {rule_name!r}"
+            )
+
+            # ARNs must differ (account-specific)
+            arn_a = next(
+                r["SamplingRule"]["RuleARN"]
+                for r in rules_a
+                if r["SamplingRule"]["RuleName"] == rule_name
+            )
+            arn_b = next(
+                r["SamplingRule"]["RuleARN"]
+                for r in rules_b
+                if r["SamplingRule"]["RuleName"] == rule_name
+            )
+            assert arn_a != arn_b, (
+                "Same-name sampling rules in different accounts must have different ARNs"
+            )
+
+        finally:
+            for xray in [xray_a, xray_b]:
+                try:
+                    xray.delete_sampling_rule(RuleName=rule_name)
+                except Exception:
+                    pass  # best-effort cleanup
+
+    def test_groups_isolated_by_account(self, make_boto_client):
+        """Create same-named group in both accounts; verify isolation."""
+        suffix = uuid.uuid4().hex[:8]
+        group_name = f"group-{suffix}"
+
+        xray_a = _client(make_boto_client, "xray", ACCT_A)
+        xray_b = _client(make_boto_client, "xray", ACCT_B)
+
+        xray_a.create_group(GroupName=group_name, FilterExpression="service(a)")
+        xray_b.create_group(GroupName=group_name, FilterExpression="service(b)")
+
+        try:
+            # Account A should see only its own group
+            groups_a = xray_a.get_groups()["Groups"]
+            names_a = [g["GroupName"] for g in groups_a]
+            assert group_name in names_a, "Account A should see its group"
+            assert names_a.count(group_name) == 1, (
+                f"Account A sees {names_a.count(group_name)} groups named {group_name!r}"
+            )
+
+            # Account B should see only its own group
+            groups_b = xray_b.get_groups()["Groups"]
+            names_b = [g["GroupName"] for g in groups_b]
+            assert group_name in names_b, "Account B should see its group"
+            assert names_b.count(group_name) == 1, (
+                f"Account B sees {names_b.count(group_name)} groups named {group_name!r}"
+            )
+
+            # ARNs must differ (account-specific)
+            arn_a = next(g["GroupARN"] for g in groups_a if g["GroupName"] == group_name)
+            arn_b = next(g["GroupARN"] for g in groups_b if g["GroupName"] == group_name)
+            assert arn_a != arn_b, "Same-name groups in different accounts must have different ARNs"
+
+            # Verify GetGroup returns only the account's own group
+            group_a = xray_a.get_group(GroupName=group_name)["Group"]
+            assert ACCT_A in group_a["GroupARN"]
+
+            group_b = xray_b.get_group(GroupName=group_name)["Group"]
+            assert ACCT_B in group_b["GroupARN"]
+
+        finally:
+            for xray in [xray_a, xray_b]:
+                try:
+                    xray.delete_group(GroupName=group_name)
+                except Exception:
+                    pass  # best-effort cleanup
+
+
+# ---------------------------------------------------------------------------
+# Resource Groups Tagging API
+# ---------------------------------------------------------------------------
+
+
+class TestTaggingApiAccountIsolation:
+    """Resource Groups Tagging API get_resources is per-account + per-region in AWS."""
+
+    def test_sqs_resources_isolated_by_account(self, make_boto_client):
+        """Create tagged SQS queues in both accounts; verify tagging API isolation."""
+        suffix = uuid.uuid4().hex[:8]
+        queue_name = f"queue-{suffix}"
+        tag_key = "TestTag"
+
+        sqs_a = _client(make_boto_client, "sqs", ACCT_A)
+        sqs_b = _client(make_boto_client, "sqs", ACCT_B)
+        tagging_a = _client(make_boto_client, "resourcegroupstaggingapi", ACCT_A)
+        tagging_b = _client(make_boto_client, "resourcegroupstaggingapi", ACCT_B)
+
+        # Create queues with distinctive tags
+        resp_a = sqs_a.create_queue(QueueName=queue_name, tags={tag_key: "account-a"})
+        resp_b = sqs_b.create_queue(QueueName=queue_name, tags={tag_key: "account-b"})
+        url_a = resp_a["QueueUrl"]
+        url_b = resp_b["QueueUrl"]
+
+        try:
+            # Account A's tagging API should only see its own queue
+            resources_a = tagging_a.get_resources(
+                ResourceTypeFilters=["sqs"],
+                TagFilters=[{"Key": tag_key}],
+            )["ResourceTagMappingList"]
+            arns_a = [r["ResourceARN"] for r in resources_a]
+            assert any(ACCT_A in arn for arn in arns_a), "Account A should see its SQS queue"
+            assert not any(ACCT_B in arn for arn in arns_a), (
+                "Account A must not see account B's SQS queue (cross-account leak)"
+            )
+
+            # Account B's tagging API should only see its own queue
+            resources_b = tagging_b.get_resources(
+                ResourceTypeFilters=["sqs"],
+                TagFilters=[{"Key": tag_key}],
+            )["ResourceTagMappingList"]
+            arns_b = [r["ResourceARN"] for r in resources_b]
+            assert any(ACCT_B in arn for arn in arns_b), "Account B should see its SQS queue"
+            assert not any(ACCT_A in arn for arn in arns_b), (
+                "Account B must not see account A's SQS queue (cross-account leak)"
+            )
+
+            # Verify tag values are correct per account
+            for r in resources_a:
+                tags = {t["Key"]: t["Value"] for t in r.get("Tags", [])}
+                assert tags.get(tag_key) == "account-a", (
+                    "Account A's queue should have account-a tag"
+                )
+
+            for r in resources_b:
+                tags = {t["Key"]: t["Value"] for t in r.get("Tags", [])}
+                assert tags.get(tag_key) == "account-b", (
+                    "Account B's queue should have account-b tag"
+                )
+
+        finally:
+            for sqs, url in [(sqs_a, url_a), (sqs_b, url_b)]:
+                try:
+                    sqs.delete_queue(QueueUrl=url)
+                except Exception:
+                    pass  # best-effort cleanup
+
+    def test_sns_resources_isolated_by_account(self, make_boto_client):
+        """Create tagged SNS topics in both accounts; verify tagging API isolation."""
+        suffix = uuid.uuid4().hex[:8]
+        topic_name = f"topic-{suffix}"
+        tag_key = "TestTag"
+
+        sns_a = _client(make_boto_client, "sns", ACCT_A)
+        sns_b = _client(make_boto_client, "sns", ACCT_B)
+        tagging_a = _client(make_boto_client, "resourcegroupstaggingapi", ACCT_A)
+        tagging_b = _client(make_boto_client, "resourcegroupstaggingapi", ACCT_B)
+
+        # Create topics with distinctive tags
+        resp_a = sns_a.create_topic(Name=topic_name, Tags=[{"Key": tag_key, "Value": "account-a"}])
+        resp_b = sns_b.create_topic(Name=topic_name, Tags=[{"Key": tag_key, "Value": "account-b"}])
+        arn_a = resp_a["TopicArn"]
+        arn_b = resp_b["TopicArn"]
+
+        try:
+            # Account A's tagging API should only see its own topic
+            resources_a = tagging_a.get_resources(
+                ResourceTypeFilters=["sns"],
+                TagFilters=[{"Key": tag_key}],
+            )["ResourceTagMappingList"]
+            arns_a = [r["ResourceARN"] for r in resources_a]
+            assert any(ACCT_A in arn for arn in arns_a), "Account A should see its SNS topic"
+            assert not any(ACCT_B in arn for arn in arns_a), (
+                "Account A must not see account B's SNS topic (cross-account leak)"
+            )
+
+            # Account B's tagging API should only see its own topic
+            resources_b = tagging_b.get_resources(
+                ResourceTypeFilters=["sns"],
+                TagFilters=[{"Key": tag_key}],
+            )["ResourceTagMappingList"]
+            arns_b = [r["ResourceARN"] for r in resources_b]
+            assert any(ACCT_B in arn for arn in arns_b), "Account B should see its SNS topic"
+            assert not any(ACCT_A in arn for arn in arns_b), (
+                "Account B must not see account A's SNS topic (cross-account leak)"
+            )
+
+            # Verify tag values are correct per account
+            for r in resources_a:
+                tags = {t["Key"]: t["Value"] for t in r.get("Tags", [])}
+                assert tags.get(tag_key) == "account-a", (
+                    "Account A's topic should have account-a tag"
+                )
+
+            for r in resources_b:
+                tags = {t["Key"]: t["Value"] for t in r.get("Tags", [])}
+                assert tags.get(tag_key) == "account-b", (
+                    "Account B's topic should have account-b tag"
+                )
+
+        finally:
+            for sns, arn in [(sns_a, arn_a), (sns_b, arn_b)]:
+                try:
+                    sns.delete_topic(TopicArn=arn)
                 except Exception:
                     pass  # best-effort cleanup


### PR DESCRIPTION
## What

Extends `tests/integration/test_account_scoping_fidelity.py` (the canonical home for this bug class) with two new test classes for the cross-account leaks fixed in #297:

- `TestXRayAccountIsolation` — sampling rules and groups, same-name-in-both-accounts, isolation + distinct ARNs.
- `TestTaggingApiAccountIsolation` — `resourcegroupstaggingapi.get_resources()` for SQS/SNS, same isolation check.

## New finding from the bug-class hunt (not fixed here — test-only task)

While grepping other native providers for the same "global dict, no account key" shape: **X-Ray's `_resource_policies` is a global dict with no account scoping at all** — same bug class as the sampling-rules/groups fix, just not yet caught. Flagging for a follow-up fix; did not touch it in this PR.

Lower-confidence candidates also noted in the prompt log (UUID-keyed stores in Lambda ESM and Rekognition — low risk since UUIDs aren't guessable, but not hardened either).

## Verification

- All 11 tests in the file pass (9 existing + 2 new classes).
- Full integration suite: 77 passed, 4 skipped. Full unit suite: 8777 passed.
- `ruff`/`ruff format`/`mypy` clean.

Written by a Bedrock (Kimi K2.5) agent; reviewed and independently re-verified (re-ran all tests + full suites, fixed the prompt log's YAML frontmatter) before opening this PR.