### PR TITLE
docs: IaC recipes for Packer and Terraform, and per-operation coverage discovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,11 +179,22 @@ Non-numeric access keys (e.g. `"test"`) route to the default account `1234567890
 
 ---
 
-## Supported services (147)
+## Supported services
 
-**38 native providers** (full behavioral fidelity): ACM, API Gateway v1, API Gateway v2, AppSync, Batch, CloudFormation, CloudWatch, CloudWatch Logs, Cognito User Pools, Config, DynamoDB, DynamoDB Streams, EC2, ECR, ECS, Elasticsearch, EventBridge, Firehose, IAM, Kinesis, Lambda, OpenSearch, Rekognition, Resource Groups, Resource Groups Tagging, Route 53, S3, Scheduler, Secrets Manager, SES, SES v2, SNS, SQS, SSM, Step Functions, STS, Support, X-Ray.
+Ask the running twin rather than trusting the list below — it is authoritative and cannot drift:
 
-**109 Moto-backed services**: Account, ACM-PCA, AMP, AppConfig, Application Auto Scaling, App Mesh, Athena, Auto Scaling, Backup, Bedrock, Bedrock Agent, Budgets, CE, Cloud Directory, CloudFront, CloudHSM v2, CloudTrail, CodeBuild, CodeCommit, CodeDeploy, CodePipeline, Cognito Identity, Comprehend, Connect, DataBrew, Data Pipeline, DataSync, DAX, DMS, Directory Service, DSQL, EC2 Instance Connect, EFS, EKS, ElastiCache, Elastic Beanstalk, ELB, ELBv2, EMR, EMR Containers, EMR Serverless, FSx, Glacier, Glue, Greengrass, GuardDuty, Identity Store, Inspector2, IoT, IoT Data, IVS, Kafka, Kinesis Analytics v2, Kinesis Video, KMS, Lake Formation, Lex v2, Macie2, Managed Blockchain, MediaConnect, MediaLive, MediaPackage, MediaPackage v2, MediaStore, MemoryDB, MQ, Network Firewall, Network Manager, OpenSearch Serverless, Organizations, OSIS, Panorama, Pinpoint, Pipes, Polly, QuickSight, RAM, RDS, RDS Data, Redshift, Redshift Data, Resilience Hub, Route 53 Domains, Route 53 Resolver, S3 Control, S3 Tables, S3 Vectors, SageMaker, Security Hub, Service Catalog, Service Catalog App Registry, Service Discovery, Shield, Signer, SSO Admin, SWF, Synthetics, Textract, Timestream InfluxDB, Timestream Query, Timestream Write, Transfer, VPC Lattice, WAFv2, WorkSpaces, WorkSpaces Web.
+```bash
+curl -s http://localhost:4566/_robotocore/services | python3 -c "
+import json, sys, collections
+s = json.load(sys.stdin)['services']
+print(len(s), dict(collections.Counter(x['status'] for x in s)))
+for x in s: print(f\"{x['name']:32} {x['status']}\")
+"
+```
+
+**Native providers** (full behavioral fidelity): ACM, API Gateway v1, API Gateway v2, AppSync, Batch, CloudFormation, CloudWatch, CloudWatch Logs, Cognito User Pools, Config, DynamoDB, DynamoDB Streams, EC2, ECR, ECS, Elasticsearch, EventBridge, Firehose, IAM, Kinesis, Lambda, OpenSearch, Rekognition, Resource Groups, Resource Groups Tagging, Route 53, S3, Scheduler, Secrets Manager, SES, SES v2, SNS, SQS, SSM, Step Functions, STS, Support, X-Ray.
+
+**Moto-backed services**: Account, ACM-PCA, AMP, AppConfig, Application Auto Scaling, App Mesh, Athena, Auto Scaling, Backup, Bedrock, Bedrock Agent, Budgets, CE, Cloud Directory, CloudFront, CloudHSM v2, CloudTrail, CodeBuild, CodeCommit, CodeDeploy, CodePipeline, Cognito Identity, Comprehend, Connect, DataBrew, Data Pipeline, DataSync, DAX, DMS, Directory Service, DSQL, EC2 Instance Connect, EFS, EKS, ElastiCache, Elastic Beanstalk, ELB, ELBv2, EMR, EMR Containers, EMR Serverless, FSx, Glacier, Glue, Greengrass, GuardDuty, Identity Store, Inspector2, IoT, IoT Data, IVS, Kafka, Kinesis Analytics v2, Kinesis Video, KMS, Lake Formation, Lex v2, Macie2, Managed Blockchain, MediaConnect, MediaLive, MediaPackage, MediaPackage v2, MediaStore, MemoryDB, MQ, Network Firewall, Network Manager, OpenSearch Serverless, Organizations, OSIS, Panorama, Pinpoint, Pipes, Polly, QuickSight, RAM, RDS, RDS Data, Redshift, Redshift Data, Resilience Hub, Route 53 Domains, Route 53 Resolver, S3 Control, S3 Tables, S3 Vectors, SageMaker, Security Hub, Service Catalog, Service Catalog App Registry, Service Discovery, Shield, Signer, SSO Admin, SWF, Synthetics, Textract, Timestream InfluxDB, Timestream Query, Timestream Write, Transfer, VPC Lattice, WAFv2, WorkSpaces, WorkSpaces Web.
 
 ---
 
@@ -348,6 +359,86 @@ for svc, status in sorted(h.get('services', {}).items()):
 "
 ```
 
+| Endpoint | Returns |
+|---|---|
+| `GET /_robotocore/health` | Per-service status, native or moto, request counts, uptime, version |
+| `GET /_robotocore/services` | Per-service protocol (json, rest-json, query) and description |
+| `GET /_robotocore/audit?limit=N` | Recent calls with operation, status code, account, region |
+| `GET /_robotocore/usage/errors` | Error totals grouped by status code, plus recent errors |
+| `GET /_robotocore/resources[/<service>]` | What currently exists in the twin |
+| `GET /_robotocore/config` | Version and runtime config |
+| `GET /_robotocore/diagnose` | Full diagnostic bundle; returns 403 unless `DEBUG=1` or `ROBOTOCORE_DIAG=1` |
+
+`native` in the health output means a robotocore provider with added behavioral fidelity; `moto` means the operation is served by Moto's backend.
+
+---
+
+## Does robotocore implement operation X?
+
+No endpoint reports per-operation coverage; three routes answer the question.
+
+### 1. Read the checked-in probe results (no server needed)
+
+`probes/<service>.json` holds one entry per operation with a status.
+
+```bash
+python3 -c "
+import json
+d = json.load(open('probes/ec2.json'))
+print(d['counts'])
+m = {o['operation']: o['status'] for o in d['operations']}
+print(m['RunInstances'], m['CreateImage'])
+"
+# {'working': 449, 'needs_params': 6, 'not_implemented': 278, '500_error': 19}
+# working working
+```
+
+| Status | Meaning |
+|---|---|
+| `working` | Returned 200, or an error that proves the handler ran |
+| `needs_params` | Parameters could not be auto-filled; unknown, not absent |
+| `not_implemented` | Server returned 501 |
+| `500_error` | Server crashed — a bug worth filing |
+
+Destructive operations are excluded from probe runs, so absence from the file is not a gap. `TerminateInstances`, `DeleteBucket`, `DeleteVpc` and others are in the script's skip list and work fine. See `docs/coverage.html` for the browsable per-service view.
+
+### 2. Re-probe live
+
+```bash
+uv run python -m scripts.probe_service --service ec2 --all --json
+```
+
+Calls every operation with auto-filled parameters and classifies the result. Use when the checked-in file is older than the server you are running.
+
+### 3. Read the audit log after running an opaque tool
+
+Run the tool, then ask the twin what it received:
+
+```bash
+curl -s 'http://localhost:4566/_robotocore/audit?limit=100' | python3 -c "
+import json, sys
+for e in json.load(sys.stdin)['entries']:
+    if e['status_code'] == 501:
+        print('GAP', e['service'] + '.' + e['operation'])
+"
+```
+
+Every request is logged with service, operation, status code, account and region. `501` is the only status that means "not implemented". A full `packer build` produced 21 EC2 calls, all 200, zero 501.
+
+### Reading errors correctly
+
+The most common misread: treating a `ClientError` as a gap.
+
+| Response | Meaning |
+|---|---|
+| HTTP 501, `NotImplemented` — "The accept_address_transfer action has not been implemented" | Genuinely absent |
+| `InvalidAMIID.NotFound`, `InvalidInstanceID.NotFound` | Implemented; the ID does not exist |
+| `InvalidAMIID.Malformed` | Implemented; the ID is the wrong shape |
+| `MissingParameter`, `ValidationException` | Implemented; the request is incomplete |
+| HTTP 500 | Implemented and broken — file an issue |
+
+Only `501` is a gap.
+
 ---
 
 ## State is in-memory by default
@@ -378,7 +469,7 @@ Reset a single account's state without restarting: use a new account ID (new 12-
 | `InvalidClientTokenId` | Non-numeric access key | Use a 12-digit number: `"123456789012"` |
 | S3 `CreateBucket` fails in non-`us-east-1` region | Missing location constraint | Add `CreateBucketConfiguration={"LocationConstraint": region}` |
 | `ResourceNotFoundException` right after `create_table` | Table not ready | Call `table.wait_until_exists()` before use |
-| HTTP 501 `NotImplemented` | Operation not in Moto | Check [Moto coverage](https://github.com/getmoto/moto/blob/master/IMPLEMENTATION_COVERAGE.md) |
+| HTTP 501 `NotImplemented` | Operation genuinely absent | [Does robotocore implement operation X?](#does-robotocore-implement-operation-x) |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
   <a href="#what-is-robotocore">What is robotocore?</a> ·
   <a href="#supported-services">158 Services</a> ·
   <a href="#accounts--regions">Accounts & Regions</a> ·
+  <a href="#infrastructure-as-code">Infrastructure as Code</a> ·
   <a href="#for-ai-agents">For AI Agents</a> ·
   <a href="#architecture">Architecture</a> ·
   <a href="AGENTS.md">AGENTS.md</a>
@@ -118,6 +119,128 @@ jobs:
           AWS_SECRET_ACCESS_KEY: test
           AWS_DEFAULT_REGION: us-east-1
 ```
+
+---
+
+## Infrastructure as Code
+
+IaC tools do not read `AWS_ENDPOINT_URL`. Each tool needs an explicit per-service endpoint override in its own config. Fake credentials alone change nothing about routing — the tool still talks to real AWS.
+
+### The one error to recognize
+
+```text
+Build 'amazon-ebs.twin' errored after 365ms: error validating regions: operation error EC2: DescribeRegions, https response error StatusCode: 401, RequestID: 037d389c-..., api error AuthFailure: AWS was not able to validate the provided access credentials
+```
+
+- Reads as a credentials problem; it is a routing problem.
+- robotocore accepts any credentials, so `AuthFailure` cannot come from the twin.
+- **Rule:** `AuthFailure` against a twin-pointed build means the endpoint override is missing or misspelled.
+- The fake credentials were the only thing that stopped a real API call from succeeding.
+
+### Terraform
+
+The AWS provider needs an `endpoints {}` block, one entry per service used, plus three skip flags.
+
+```hcl
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}
+
+provider "aws" {
+  region                      = "us-east-1"
+  access_key                  = "123456789012" # the 12-digit access key IS the account ID
+  secret_key                  = "test"
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+
+  endpoints {
+    ec2 = "http://localhost:4566"
+    s3  = "http://localhost:4566"
+    sqs = "http://localhost:4566"
+  }
+}
+
+resource "aws_s3_bucket" "demo" {
+  bucket = "robotocore-tf-demo"
+}
+
+resource "aws_sqs_queue" "demo" {
+  name = "robotocore-tf-demo"
+}
+
+data "aws_vpc" "default" {
+  default = true
+}
+
+resource "aws_security_group" "demo" {
+  name        = "robotocore-tf-demo"
+  description = "created by terraform against robotocore"
+  vpc_id      = data.aws_vpc.default.id
+}
+```
+
+```bash
+terraform init
+terraform apply -auto-approve
+# Apply complete! Resources: 3 added, 0 changed, 0 destroyed.
+```
+
+A second `terraform plan` reports "No changes", so the twin reads back what it wrote.
+A service with no `endpoints` entry goes to real AWS — add one entry per service the config touches.
+Verified with Terraform v1.14.8 and `hashicorp/aws` v6.
+
+### Packer
+
+The amazon plugin's key is `custom_endpoint_ec2`; the skip flag is `skip_credential_validation` (singular "credential") — different from Terraform's `skip_credentials_validation`.
+
+```hcl
+packer {
+  required_plugins {
+    amazon = { source = "github.com/hashicorp/amazon", version = "~> 1" }
+  }
+}
+
+source "amazon-ebs" "twin" {
+  custom_endpoint_ec2        = "http://localhost:4566"
+  region                     = "us-east-1"
+  access_key                 = "123456789012"
+  secret_key                 = "test"
+  skip_credential_validation = true
+  skip_metadata_api_check    = true
+  instance_type              = "t3.micro"
+  ami_name                   = "robotocore-demo"
+  communicator               = "none"
+  source_ami_filter {
+    filters     = { name = "ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-*" }
+    owners      = ["099720109477"]
+    most_recent = true
+  }
+}
+
+build { sources = ["source.amazon-ebs.twin"] }
+```
+
+```bash
+packer init . && packer build twin.pkr.hcl
+# ==> amazon-ebs.twin: Found Image ID: ami-1e749f67
+# ==> amazon-ebs.twin: Instance ID: i-63309d3e2d75b8ce0
+# ==> amazon-ebs.twin: Creating AMI robotocore-demo from instance i-63309d3e2d75b8ce0
+# Build 'amazon-ebs.twin' finished after 114 milliseconds.
+# --> amazon-ebs.twin: AMIs were created:
+# us-east-1: ami-6bf113f8491f59456
+```
+
+The AMI persists and is queryable — `aws ec2 describe-images --image-ids ami-...` returns state `available`.
+
+**Limits:** `communicator = "none"` is required. Provisioners need a real SSH session to a booted instance; the twin returns instance metadata but runs no guest OS. Use the twin to exercise the build's AWS API path — keypair, security group, run, stop, snapshot, tag, share, terminate — not to test shell provisioning.
+
+The twin ships a catalog of 1174 stock AMIs, so `source_ami_filter` resolves against real-looking AMI names and owner IDs. The catalog includes owner `099720109477` (Canonical) Ubuntu images.
 
 ---
 
@@ -310,6 +433,8 @@ If you omit credentials or use a non-numeric access key (e.g. `"test"`), robotoc
 ## For AI Agents
 
 > **If you are an AI agent**, read [AGENTS.md](AGENTS.md) — it's a standalone reference with everything you need: Docker image, endpoint, credentials, multi-account setup, common patterns, health checks, and troubleshooting. No prior context required.
+>
+> Before writing code against the twin, answer "does robotocore implement operation X?" — [three ways to check](AGENTS.md#does-robotocore-implement-operation-x), from a checked-in file to the twin's own audit log.
 
 If you are an AI agent or LLM being asked to work with AWS infrastructure locally, here is everything you need to know:
 
@@ -477,7 +602,7 @@ uv run pytest tests/integration/    # 44 integration tests (requires Docker)
 ### Useful scripts
 
 ```bash
-uv run python scripts/probe_service.py --service s3    # which ops work
+uv run python -m scripts.probe_service --service s3    # which ops work
 uv run python scripts/generate_parity_report.py        # parity vs botocore
 uv run python scripts/analyze_localstack.py            # gaps vs LocalStack
 uv run python scripts/smoke_test.py                    # 20-service smoke test

--- a/README.md
+++ b/README.md
@@ -124,7 +124,16 @@ jobs:
 
 ## Infrastructure as Code
 
-IaC tools do not read `AWS_ENDPOINT_URL`. Each tool needs an explicit per-service endpoint override in its own config. Fake credentials alone change nothing about routing — the tool still talks to real AWS.
+Export `AWS_ENDPOINT_URL` and both Terraform and Packer route to the twin with no endpoint settings in their config at all. Credentials change nothing about routing — the twin accepts any credentials, so fake ones only stop a real API call from succeeding.
+
+```bash
+export AWS_ENDPOINT_URL=http://localhost:4566
+export AWS_ACCESS_KEY_ID=123456789012
+export AWS_SECRET_ACCESS_KEY=test
+export AWS_DEFAULT_REGION=us-east-1
+```
+
+In-config overrides — Terraform's `endpoints {}`, Packer's `custom_endpoint_ec2` — are the alternative when only some services should reach the twin. Reach for them second: `custom_endpoint_ec2` does not cover every call path (below).
 
 ### The one error to recognize
 
@@ -132,14 +141,15 @@ IaC tools do not read `AWS_ENDPOINT_URL`. Each tool needs an explicit per-servic
 Build 'amazon-ebs.twin' errored after 365ms: error validating regions: operation error EC2: DescribeRegions, https response error StatusCode: 401, RequestID: 037d389c-..., api error AuthFailure: AWS was not able to validate the provided access credentials
 ```
 
+That build set the twin's credentials and skip flags but named no endpoint anywhere.
+
 - Reads as a credentials problem; it is a routing problem.
-- robotocore accepts any credentials, so `AuthFailure` cannot come from the twin.
-- **Rule:** `AuthFailure` against a twin-pointed build means the endpoint override is missing or misspelled.
-- The fake credentials were the only thing that stopped a real API call from succeeding.
+- robotocore accepts any credentials, so `AuthFailure` can never come from the twin — it proves the request reached real AWS.
+- **Rule:** `AuthFailure` from a build you believe is twin-pointed means nothing is routing it there. Check `AWS_ENDPOINT_URL` is exported in the shell that runs the tool.
 
 ### Terraform
 
-The AWS provider needs an `endpoints {}` block, one entry per service used, plus three skip flags.
+With `AWS_ENDPOINT_URL` exported, the provider needs only the three skip flags — they stop it reaching for real STS and IMDS metadata.
 
 ```hcl
 terraform {
@@ -158,12 +168,6 @@ provider "aws" {
   skip_credentials_validation = true
   skip_metadata_api_check     = true
   skip_requesting_account_id  = true
-
-  endpoints {
-    ec2 = "http://localhost:4566"
-    s3  = "http://localhost:4566"
-    sqs = "http://localhost:4566"
-  }
 }
 
 resource "aws_s3_bucket" "demo" {
@@ -192,12 +196,44 @@ terraform apply -auto-approve
 ```
 
 A second `terraform plan` reports "No changes", so the twin reads back what it wrote.
-A service with no `endpoints` entry goes to real AWS — add one entry per service the config touches.
-Verified with Terraform v1.14.8 and `hashicorp/aws` v6.
+
+To send only some services to the twin, drop the env var and add an `endpoints {}` block instead — one entry per service. A service with no entry goes to real AWS.
+
+```hcl
+  endpoints {
+    ec2 = "http://localhost:4566"
+    s3  = "http://localhost:4566"
+    sqs = "http://localhost:4566"
+  }
+```
+
+Verified with Terraform v1.14.8 and `hashicorp/aws` v6, both ways.
 
 ### Packer
 
-The amazon plugin's key is `custom_endpoint_ec2`; the skip flag is `skip_credential_validation` (singular "credential") — different from Terraform's `skip_credentials_validation`.
+The exported `AWS_ENDPOINT_URL` is enough — the template below names no endpoint. `AWS_ENDPOINT_URL_EC2` works too if you want to scope the override to EC2. Either env var covers every call the build makes; the plugin's own `custom_endpoint_ec2` field does not.
+
+#### `custom_endpoint_ec2` alone leaks to real AWS
+
+With only that field set, a build proceeds through **DescribeImages**, **RunInstances**, **StopInstances** and **CreateImage**, then fails at **ModifyImageAttribute** because that call uses a client that does not inherit the field. `ami_description` in the template triggers **ModifyImageAttribute**.
+
+```
+Error modify AMI attributes: operation error EC2: ModifyImageAttribute, https response error StatusCode: 401, api error AuthFailure: AWS was not able to validate the provided access credentials
+```
+
+An AuthFailure this late in a build means one call path escaped — use the env var rather than adding more plugin fields.
+
+#### Pin the source AMI to EBS-backed
+
+`source_ami_filter` with `most_recent = true` can match an AMI that an earlier test created with **CreateImage**. Packer then hard-fails:
+
+```
+The provided source AMI has an invalid root device type.
+```
+
+Add `root-device-type` and `virtualization-type` to the filter. Verified — unfiltered, `most_recent` selected a created AMI and the build failed; with the filters it selected the stock image `ami-1e749f67` and the build succeeded. This filter is correct against real AWS too, so it is good practice regardless.
+
+Created images reporting `standard` is a bug in the twin, fixed separately; the filter is the defense that does not depend on the fix.
 
 ```hcl
 packer {
@@ -207,7 +243,6 @@ packer {
 }
 
 source "amazon-ebs" "twin" {
-  custom_endpoint_ec2        = "http://localhost:4566"
   region                     = "us-east-1"
   access_key                 = "123456789012"
   secret_key                 = "test"
@@ -215,9 +250,14 @@ source "amazon-ebs" "twin" {
   skip_metadata_api_check    = true
   instance_type              = "t3.micro"
   ami_name                   = "robotocore-demo"
+  ami_description            = "built against the twin"
   communicator               = "none"
   source_ami_filter {
-    filters     = { name = "ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-*" }
+    filters = {
+      name                = "ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-*"
+      root-device-type    = "ebs"
+      virtualization-type = "hvm"
+    }
     owners      = ["099720109477"]
     most_recent = true
   }
@@ -226,21 +266,22 @@ source "amazon-ebs" "twin" {
 build { sources = ["source.amazon-ebs.twin"] }
 ```
 
+`skip_credential_validation` is singular "credential" here, unlike Terraform's `skip_credentials_validation`.
+
 ```bash
-packer init . && packer build twin.pkr.hcl
+packer init .
+packer build twin.pkr.hcl
 # ==> amazon-ebs.twin: Found Image ID: ami-1e749f67
-# ==> amazon-ebs.twin: Instance ID: i-63309d3e2d75b8ce0
-# ==> amazon-ebs.twin: Creating AMI robotocore-demo from instance i-63309d3e2d75b8ce0
-# Build 'amazon-ebs.twin' finished after 114 milliseconds.
+# Build 'amazon-ebs.twin' finished after 277 milliseconds.
 # --> amazon-ebs.twin: AMIs were created:
-# us-east-1: ami-6bf113f8491f59456
+# us-east-1: ami-7ba05032dac5585f7
 ```
 
-The AMI persists and is queryable — `aws ec2 describe-images --image-ids ami-...` returns state `available`.
+The AMI persists — `aws ec2 describe-images --image-ids ami-...` returns state `available`.
 
 **Limits:** `communicator = "none"` is required. Provisioners need a real SSH session to a booted instance; the twin returns instance metadata but runs no guest OS. Use the twin to exercise the build's AWS API path — keypair, security group, run, stop, snapshot, tag, share, terminate — not to test shell provisioning.
 
-The twin ships a catalog of 1174 stock AMIs, so `source_ami_filter` resolves against real-looking AMI names and owner IDs. The catalog includes owner `099720109477` (Canonical) Ubuntu images.
+The twin ships 1174 stock AMIs, including Canonical's (owner `099720109477`), so `source_ami_filter` resolves against real-looking names and owner IDs.
 
 ---
 

--- a/scripts/probe_service.py
+++ b/scripts/probe_service.py
@@ -2,10 +2,10 @@
 """Probe a service to discover which operations actually work.
 
 Usage:
-    uv run python scripts/probe_service.py --service sqs
-    uv run python scripts/probe_service.py --service ec2 --all
-    uv run python scripts/probe_service.py --service s3 --json
-    uv run python scripts/probe_service.py --service sns --all --json
+    uv run python -m scripts.probe_service --service sqs
+    uv run python -m scripts.probe_service --service ec2 --all
+    uv run python -m scripts.probe_service --service s3 --json
+    uv run python -m scripts.probe_service --service sns --all --json
 
 Calls each operation with auto-filled parameters from botocore shapes.
 Classifies operations as:


### PR DESCRIPTION
## Why

Two gaps found by actually driving robotocore with IaC tools and by working it as an agent.

**1. Endpoint routing is easy to get half-right.** Point Packer at the twin with fake credentials and skip flags but no endpoint anywhere and you get:

```
api error AuthFailure: AWS was not able to validate the provided access credentials
```

That reads as a credentials problem. It is a routing problem — robotocore accepts any credentials, so `AuthFailure` can never come *from* the twin. The fake credentials were the only thing stopping a real API call from succeeding. This tell now has a home in the README.

**2. An agent had no way to answer "does robotocore implement operation X?"** before writing code against the twin. `_robotocore/health` reports per-service status, not per-operation. The repo already ships the answer — `probes/<service>.json` and `scripts/probe_service.py` — and neither was documented.

## What

**README — new `## Infrastructure as Code` section** (registered in the TOC), matching the existing boto3 / AWS CLI / docker-compose / GitHub Actions recipes:

- **`AWS_ENDPOINT_URL` is the recipe.** Both Terraform and Packer honor it, so neither needs an endpoint in its config. `endpoints {}` and `custom_endpoint_ec2` are the per-service alternative, documented second.
- **`custom_endpoint_ec2` does not cover every call path.** A build sails through `CreateImage` and then fails at `ModifyImageAttribute` — which `ami_description` triggers — with `AuthFailure` from real AWS. An AuthFailure that late means one call escaped.
- **Pin `source_ami_filter` to `root-device-type = "ebs"`.** With `most_recent = true` it can otherwise select an AMI a previous test created, which Packer rejects. Correct against real AWS too.
- Terraform: three skip flags, a config that applies clean, and an idempotent re-plan
- Packer: `skip_credential_validation` — singular, unlike Terraform's `skip_credentials_validation`
- The `AuthFailure` tell, placed first
- Packer's real limit: `communicator = "none"` is required, because provisioners need a booted guest OS the twin does not run

**AGENTS.md — new `## Does robotocore implement operation X?` section**, three routes cheapest-first:

| Route | Use when |
|---|---|
| `probes/<service>.json` | no server needed |
| `python -m scripts.probe_service --service X --all` | checked-in file older than your server |
| `_robotocore/audit?limit=N`, filtered to 501 | the caller is opaque — Terraform, Packer, someone else's SDK |

Plus a table separating real AWS error codes (`InvalidAMIID.NotFound`, `MissingParameter` — implemented, bad input) from genuine gaps. Only `501` is a gap. Misreading a `ClientError` as missing coverage is the easy mistake.

Also in AGENTS.md: the introspection endpoint table now lists all seven `_robotocore/*` endpoints; the service list points at `_robotocore/services` as authoritative instead of a hardcoded count that had drifted to 147; the troubleshooting 501 row points at the new section instead of Moto's coverage file.

**Bug fixed:** `uv run python scripts/probe_service.py` — the form documented in README and in the script's own docstring — dies with `ModuleNotFoundError: No module named 'scripts'`. The working form is `python -m scripts.probe_service`.

## Verified against a running twin

Everything shown was run, not assumed.

- All 13 operations in Packer's `amazon-ebs` sequence return 200. `ModifyImageAttribute` round-trips: `DescribeImageAttribute` reads back `{"Group": "all"}`.
- `terraform apply` — `3 added`. A second `terraform plan` reports `No changes`, so the twin reads back what it wrote. Verified both with `AWS_ENDPOINT_URL` and with an `endpoints {}` block.
- Packer builds with `AWS_ENDPOINT_URL` alone, with `AWS_ENDPOINT_URL_EC2` alone, and with the env var plus `custom_endpoint_ec2`. With `custom_endpoint_ec2` alone it fails at `ModifyImageAttribute`.
- `source_ami_filter` reproduced both ways: unpinned it selected a `CreateImage` AMI and the build failed; pinned to `root-device-type = "ebs"` it selected stock `ami-1e749f67` and succeeded.
- Every code block in the section was extracted from the committed README and run verbatim against a clean twin.
- `packer build` produced `ami-6bf113f8491f59456` in 115ms. The AMI persists; `describe-images` returns state `available`.
- The audit log recorded 21 EC2 calls for that build, all 200, zero 501 — a larger set than the 13 probed, including `AuthorizeSecurityGroupIngress`, `DescribeVolumes`, `DeleteKeyPair`, `DeleteSecurityGroup`.
- The no-endpoint `AuthFailure` reproduced exactly, failing at `DescribeRegions` during region validation.

Terraform v1.14.8 / `hashicorp/aws` v6, Packer v1.15.4 / amazon plugin v1.8.2.

The root-device-type trap is a real twin bug, fixed in #311. The filter is the defense that does not depend on that fix, so both belong in the docs.

Docs only — no source behavior changes.

via LD Research 🤖
