### PR TITLE
fix(ec2): AMIs from CreateImage report RootDeviceType 'standard', breaking Packer

### DIFF
--- a/tests/compatibility/test_ec2_compat.py
+++ b/tests/compatibility/test_ec2_compat.py
@@ -5150,6 +5150,59 @@ class TestEC2InstanceImageOperations:
         finally:
             ec2.terminate_instances(InstanceIds=[instance_id])
 
+    def test_created_image_is_ebs_backed(self, ec2):
+        """An image made from an EBS-backed instance reports RootDeviceType 'ebs'.
+
+        Packer's amazon-ebs builder rejects a source AMI reporting 'standard'
+        with "The provided source AMI has an invalid root device type", so a
+        created image cannot feed a subsequent build.
+        """
+        instances = ec2.run_instances(
+            ImageId="ami-12345678",
+            InstanceType="t2.micro",
+            MinCount=1,
+            MaxCount=1,
+        )
+        instance_id = instances["Instances"][0]["InstanceId"]
+        try:
+            ami_id = ec2.create_image(InstanceId=instance_id, Name=_unique("ebs-backed"))["ImageId"]
+            try:
+                image = ec2.describe_images(ImageIds=[ami_id])["Images"][0]
+                assert image["RootDeviceType"] == "ebs"
+                assert image["RootDeviceName"]
+                assert any("Ebs" in m for m in image["BlockDeviceMappings"])
+            finally:
+                ec2.deregister_image(ImageId=ami_id)
+        finally:
+            ec2.terminate_instances(InstanceIds=[instance_id])
+
+    def test_registered_and_copied_images_are_ebs_backed(self, ec2):
+        """RegisterImage and CopyImage report 'ebs' too, matching their mappings."""
+        registered = ec2.register_image(
+            Name=_unique("registered"),
+            RootDeviceName="/dev/sda1",
+            BlockDeviceMappings=[
+                {"DeviceName": "/dev/sda1", "Ebs": {"VolumeSize": 8}},
+            ],
+        )["ImageId"]
+        try:
+            image = ec2.describe_images(ImageIds=[registered])["Images"][0]
+            assert image["RootDeviceType"] == "ebs"
+        finally:
+            ec2.deregister_image(ImageId=registered)
+
+        source = ec2.describe_images(Owners=["amazon"])["Images"][0]
+        copied = ec2.copy_image(
+            SourceImageId=source["ImageId"],
+            SourceRegion="us-east-1",
+            Name=_unique("copied"),
+        )["ImageId"]
+        try:
+            image = ec2.describe_images(ImageIds=[copied])["Images"][0]
+            assert image["RootDeviceType"] == "ebs"
+        finally:
+            ec2.deregister_image(ImageId=copied)
+
     def test_get_launch_template_data(self, ec2):
         instances = ec2.run_instances(
             ImageId="ami-12345678",


### PR DESCRIPTION
## The bug

`CreateImage`, `RegisterImage` and `CopyImage` all report `RootDeviceType: "standard"` — the legacy instance-store value — while returning a block device mapping that contains an `Ebs` entry. Seeded AMIs are correct because `resources/amis.json` sets the value explicitly; the three dynamic paths pass nothing and inherit moto's `"standard"` default.

```
seeded AMI (describe_images Owners=[amazon])   RootDeviceType=ebs        BDM has Ebs
AMI from CreateImage                           RootDeviceType=standard   BDM has Ebs   <- inconsistent
AMI from RegisterImage                         RootDeviceType=standard   BDM has Ebs   <- inconsistent
AMI from CopyImage                             RootDeviceType=standard   BDM has Ebs   <- inconsistent
```

`CopyImage` is affected too, which the original report didn't cover.

## Why it matters

Packer's `amazon-ebs` builder validates the source AMI and refuses to start:

```
Build errored: The provided source AMI has an invalid root device type.
```

So a twin-built AMI cannot feed a later build — exactly what an image pipeline does. Verified A/B against the same Packer template, changing only the endpoint:

| Twin | Result |
|---|---|
| Published image, unfixed | `The provided source AMI has an invalid root device type.` |
| Local build, fixed | Build succeeded, produced `ami-bf9417a6d80671fac` |

## The fix lives in moto, not here

EC2 `CreateImage` is moto-backed. The native EC2 provider (`src/robotocore/services/ec2/provider.py`) only handles placement groups, `DetachVolume` and `DeleteVpcEndpoints`, and there is no robotocore-side mechanism for correcting moto model defaults — `providers/moto_bridge.py` is request forwarding only.

The one-line cause is `Ami.__init__`'s `root_device_type: str = "standard"`. `block_device_mappings` is a property that unconditionally returns an `Ebs` entry, and `__init__` always creates a volume and snapshot, so every moto AMI is EBS-backed and `"standard"` is never right for these paths. The fix defaults the parameter to `None` and derives it after the snapshot exists; callers passing an explicit value are unaffected.

Pushed to the fork as [`fix/ami-root-device-type`](https://github.com/JackDanger/moto/tree/fix/ami-root-device-type) (`738bf2cb0`), branched from `b5ea0bec` — the exact commit `uv.lock` pins — so the delta against what robotocore builds today is precisely this one fix.

Verified on that branch: all 46 tests in moto's own `tests/test_ec2/test_amis.py` pass, `mypy` clean, and all four paths (seeded, create, register, copy) report `ebs`.

A second commit narrows the derivation to the mapping whose `DeviceName` matches `root_device_name`, so a secondary EBS volume can never relabel an instance-store image. An explicitly passed `standard` is still honored.

## This PR is the test only — and it fails until the pin moves

Deliberately no `uv.lock` or submodule bump, for two reasons found while trying:

1. `uv.lock` pins `b5ea0bec`; the tracked branch `robotocore/all-fixes` is **123 commits ahead**. A bump would drag all 123 into a one-line bug fix.
2. That branch's current tip (`c4dff4cba`) **does not import**. `moto/ec2/models/ipam.py` declares `description` twice in `IpamScope.__init__`, a `SyntaxError` that breaks all of moto EC2. The lockfile cannot be advanced to the tracked branch until that is fixed. (Note for whoever looks: `ast.parse` does not flag duplicate arguments — use `compile()`.)

That branch was also force-pushed while this work was in progress (`a14fa32f1` → `c4dff4cba`), so pinning its tip isn't safe right now either.

Choosing how to land the moto side is a maintainer call — cherry-pick the two commits onto `robotocore/all-fixes` after fixing `ipam.py`, or repoint `[tool.uv.sources]`. Until then the two new tests fail against the current pin, which is the accurate signal.

## Tests

`tests/compatibility/test_ec2_compat.py`, in `TestEC2InstanceImageOperations`:

- `test_created_image_is_ebs_backed` — `CreateImage` reports `ebs`, has a `RootDeviceName`, and its mappings contain `Ebs`
- `test_registered_and_copied_images_are_ebs_backed` — same for `RegisterImage` and `CopyImage`

They discriminate correctly: both fail against the current pin with `assert 'standard' == 'ebs'` and pass against the fixed moto branch.

No regressions from the fix. The rest of `test_ec2_compat.py` (719 tests) passes. Three `TestEC2VPCEndpointServiceConfig` tests fail on a local source build at `d4ebe9df` with `InvalidSubnetID.NotFound` from `CreateLoadBalancer`, but they fail identically **without** the moto change and pass against the published container — a pre-existing source-vs-image difference, unrelated to AMIs and untouched here.

via LD Research 🤖
