### PR TITLE
Fix: Lambda-configured env vars not visible at module import time

### DIFF
--- a/prompts/20260817-230324-lambda-env-vars-at-module-import-time.md
+++ b/prompts/20260817-230324-lambda-env-vars-at-module-import-time.md
@@ -1,0 +1,94 @@
+---
+session: "53e94e"
+timestamp: "2026-08-17T21:15:00Z"
+model: claude-sonnet-5
+pr: 312
+tools: [subagent-review]
+---
+
+## Human
+
+(Context: found while building an unrelated Terraform module that deploys a
+Python Lambda against robotocore as a local twin for testing.) The deployed
+Lambda's handler read a configured environment variable at module scope —
+`FORWARDER_ADDRESS = os.environ["FORWARDER_ADDRESS"]` above the handler
+function — and every invocation failed with `KeyError: 'FORWARDER_ADDRESS'`,
+even though `get_function` reported `Environment.Variables` correctly.
+
+Open a PR with fixes to RobotoCore.
+
+Later, once the PR was open:
+
+Have Fable review that PR and then attack it from every different angle
+until it's completely polished. Once you can't make it any better, merge it.
+
+## Assistant
+
+## Key decisions
+
+**Root cause**: `execute_python_handler` imported/executed the handler
+module (`spec.loader.exec_module`) in the dispatcher thread, but only
+installed the invocation's thread-local `os.environ` override
+(`_thread_local.env`) inside the separate worker thread that later calls the
+handler function. Module-level `os.environ[...]` reads therefore ran before
+the thread-local environment existed, falling through to the real process
+environment instead. `get_function`/`get_function_configuration` reported
+the configured variables correctly the whole time — only what the module's
+own code could see at import time was wrong, which is what made this
+confusing to isolate.
+
+**Fix**: moved module lookup/import/exec inside `_run_handler` (the worker
+thread), after `_thread_local.env` is set, so import-time reads resolve
+identically to invocation-time ones — matching real Lambda, where env vars
+are present on the execution environment before any code runs.
+
+**Review process**: ran three adversarial review passes (Claude Fable model,
+via subagent, each with instructions to attack the diff from a different
+angle rather than confirm the obvious story) before merging, rather than
+merging on the first green test run.
+
+- Round 1 found: two stale comments describing code that no longer ran
+  where the comment claimed; `except Exception` (not `BaseException`) in the
+  worker thread meant a handler module calling `sys.exit()` at import time
+  fell through every check to a silent `(None, None, logs)` success instead
+  of being reported as a failed invocation; post-timeout branch ordering;
+  and — the most consequential finding — that this fix's own design exposed
+  a *new* staleness bug: module-scope config resolved once at import time
+  had no way to notice `UpdateFunctionConfiguration` changing
+  `Environment.Variables`. Pre-fix this crashed loudly (the KeyError); post-fix
+  it would have silently kept serving the old value forever. Fixed by having
+  the config-update handler invalidate the code cache (forcing a re-import)
+  when `Environment`/`Handler` changes. Also added test coverage for
+  concurrent module-scope reads, the warm/cached-module path, module-scope
+  `print()`, module-scope `sys.exit()`, and the fact that module import now
+  counts against the function timeout (previously imports were
+  un-timeout-able) — a real, previously-unobserved behavior change from
+  moving import into the timeout-governed thread.
+- Round 2 found the round-1 staleness fix was itself incomplete:
+  `CodeCache.invalidate()` only cleared `_lambda_{fn}.`-prefixed
+  `sys.modules` entries, so a multi-file function's plain-named helper
+  modules (`import shared`) survived invalidation with stale state —
+  reproduced empirically before fixing. Also: a `Layers`-only config update
+  wasn't covered (layer bytes aren't part of the extraction cache key but
+  are baked into the cached extraction directory), and the round-1 pinning
+  test only called `get_code_cache().invalidate()` directly rather than
+  exercising the real `UpdateFunctionConfiguration` HTTP handler. Fixed all
+  three; verified the new HTTP-level test actually catches the regression by
+  temporarily disabling the fix and confirming the test fails, against a
+  Python-3.12 server matching the test function's declared runtime (a
+  version-mismatched server silently routes through a subprocess dispatch
+  path that sidesteps the in-process caching bug entirely and would have
+  made the test a false positive).
+- Round 3 re-verified rounds 1 and 2 hadn't introduced new problems (lock
+  ordering, multi-key cache entries, whether `Layers` is actually a valid
+  `UpdateFunctionConfiguration` field per the real botocore service model,
+  xdist/CI scheduling hermeticity of the new compat test) and ran the full
+  suite three times serially plus once under the CI's parallel xdist
+  config. Found two more pre-existing gaps in the same staleness-bug class
+  (LRU eviction and the `_pending_cleanup` path don't clear plain-named
+  modules either) but confirmed both pre-date this PR and aren't made worse
+  by it — filed as issue #313 rather than expanding this PR's scope into
+  unrelated cache-eviction code.
+
+**Merge**: all CI checks green (unit ×2 Python versions, compat, integration,
+IaC parity, docker-build) before merging.

--- a/src/robotocore/services/lambda_/executor.py
+++ b/src/robotocore/services/lambda_/executor.py
@@ -411,6 +411,13 @@ class CodeCache:
                 path = self._cache.pop(key)
                 self._refcounts.pop(path, None)
                 self._pending_cleanup.discard(path)
+                # Plain-named helper modules (e.g. a shared "import shared")
+                # aren't under the _lambda_{fn}. prefix cleared below, and the
+                # next invocation's own _clear_plain_modules_for_dir only scans
+                # its *new* tmpdir — so without this, a multi-file function's
+                # helper modules (and whatever they resolved at import time)
+                # survive invalidation and keep serving stale state forever.
+                _clear_plain_modules_for_dir(path)
                 shutil.rmtree(path, ignore_errors=True)
             # Also clear function-scoped module cache in sys.modules
             # (inside lock to prevent concurrent imports from re-adding)
@@ -426,6 +433,7 @@ class CodeCache:
         """
         with self._lock:
             for path in self._cache.values():
+                _clear_plain_modules_for_dir(path)
                 shutil.rmtree(path, ignore_errors=True)
             self._cache.clear()
             self._refcounts.clear()
@@ -855,8 +863,6 @@ def execute_python_handler(
             }
             return error_result, "Handled", logs_output.getvalue()
     finally:
-        # Stop routing this thread's prints to logs_output
-        _invocation_output.buffer = None
         # Remove only the paths we added (thread-safe: doesn't affect other threads)
         with _path_lock:
             for p in added_paths:

--- a/src/robotocore/services/lambda_/executor.py
+++ b/src/robotocore/services/lambda_/executor.py
@@ -701,38 +701,49 @@ def execute_python_handler(
         # Route prints from module-level code (exec_module) to logs_output too
         _invocation_output.buffer = logs_output
         try:
-            # Reuse cached module when hot_reload is off (matches real Lambda behavior:
-            # modules persist across invocations within the same execution environment).
-            # Also verify the cached module came from the current tmpdir — a new code
-            # deployment produces a new tmpdir, and we must not reuse the stale module.
-            cached = sys.modules.get(modules_key) if not hot_reload else None
-            if cached is not None and (getattr(cached, "__file__", "") or "").startswith(tmpdir):
-                module = cached
-            else:
-                spec = importlib.util.spec_from_file_location(module_path, module_file)
-                module = importlib.util.module_from_spec(spec)
-                spec.loader.exec_module(module)
-                sys.modules[modules_key] = module
-            handler_func = getattr(module, func_name, None)
-            if handler_func is None:
-                msg = f"Handler function '{func_name}' not found in {module_path}"
-                return (
-                    {"errorMessage": msg, "errorType": "Runtime.HandlerNotFound"},
-                    "Runtime.HandlerNotFound",
-                    msg,
-                )
-
-            # Execute handler with timeout enforcement and env var isolation
+            # Execute handler with timeout enforcement and env var isolation.
+            # Module import/exec happens inside this worker thread too, after
+            # _thread_local.env is set below — matching real Lambda, where
+            # configured env vars are present in the execution environment
+            # before any code runs, including module-level top-level
+            # statements (a common pattern: reading config at import time so
+            # it's resolved once and reused across warm invocations). Doing
+            # the import in the dispatcher thread instead — the thread that
+            # never gets invocation_env installed — is what used to make
+            # module-level os.environ[...] reads raise KeyError even though
+            # the function's Environment.Variables were configured correctly.
             handler_result = [None]
             handler_error = [None]
+            load_error = [None]
 
             def _run_handler():
                 # Route print() in this thread to the invocation's log buffer
                 _invocation_output.buffer = logs_output
                 # Set thread-local environment so os.environ reads in
-                # this thread see invocation-specific values
+                # this thread — including at module-import time below —
+                # see invocation-specific values
                 _thread_local.env = dict(invocation_env)
                 try:
+                    # Reuse cached module when hot_reload is off (matches real
+                    # Lambda behavior: modules persist across invocations
+                    # within the same execution environment). Also verify the
+                    # cached module came from the current tmpdir — a new code
+                    # deployment produces a new tmpdir, and we must not reuse
+                    # the stale module.
+                    cached = sys.modules.get(modules_key) if not hot_reload else None
+                    if cached is not None and (getattr(cached, "__file__", "") or "").startswith(
+                        tmpdir
+                    ):
+                        module = cached
+                    else:
+                        spec = importlib.util.spec_from_file_location(module_path, module_file)
+                        module = importlib.util.module_from_spec(spec)
+                        spec.loader.exec_module(module)
+                        sys.modules[modules_key] = module
+                    handler_func = getattr(module, func_name, None)
+                    if handler_func is None:
+                        load_error[0] = f"Handler function '{func_name}' not found in {module_path}"
+                        return
                     handler_result[0] = handler_func(event, context)
                 except Exception as exc:  # noqa: BLE001
                     handler_error[0] = exc
@@ -743,6 +754,13 @@ def execute_python_handler(
             worker = threading.Thread(target=_run_handler, daemon=True)
             worker.start()
             worker.join(timeout=timeout)
+
+            if load_error[0] is not None:
+                return (
+                    {"errorMessage": load_error[0], "errorType": "Runtime.HandlerNotFound"},
+                    "Runtime.HandlerNotFound",
+                    load_error[0],
+                )
 
             if worker.is_alive():
                 # Timeout: try to kill the thread

--- a/src/robotocore/services/lambda_/executor.py
+++ b/src/robotocore/services/lambda_/executor.py
@@ -698,8 +698,6 @@ def execute_python_handler(
         # Use a function-scoped key so different Lambda functions don't collide
         modules_key = f"_lambda_{function_name}.{module_path}"
 
-        # Route prints from module-level code (exec_module) to logs_output too
-        _invocation_output.buffer = logs_output
         try:
             # Execute handler with timeout enforcement and env var isolation.
             # Module import/exec happens inside this worker thread too, after
@@ -745,7 +743,11 @@ def execute_python_handler(
                         load_error[0] = f"Handler function '{func_name}' not found in {module_path}"
                         return
                     handler_result[0] = handler_func(event, context)
-                except Exception as exc:  # noqa: BLE001
+                except BaseException as exc:  # noqa: BLE001
+                    # BaseException, not Exception: a module doing sys.exit()
+                    # at import time raises SystemExit, which must still be
+                    # reported as a failed invocation rather than falling
+                    # through to the success branch below with a bare None.
                     handler_error[0] = exc
                 finally:
                     _invocation_output.buffer = None
@@ -755,15 +757,10 @@ def execute_python_handler(
             worker.start()
             worker.join(timeout=timeout)
 
-            if load_error[0] is not None:
-                return (
-                    {"errorMessage": load_error[0], "errorType": "Runtime.HandlerNotFound"},
-                    "Runtime.HandlerNotFound",
-                    load_error[0],
-                )
-
             if worker.is_alive():
-                # Timeout: try to kill the thread
+                # Timeout: try to kill the thread. Checked before load_error/
+                # handler_error so a timeout is always authoritative over
+                # whatever partial state the worker left behind.
                 try:
                     tid = worker.ident
                     if tid is not None:
@@ -792,6 +789,24 @@ def execute_python_handler(
                     "errorType": "Task.TimedOut",
                 }
                 return error_result, "Task.TimedOut", logs_output.getvalue()
+
+            if load_error[0] is not None:
+                logs_output.write(load_error[0] + "\n")
+                logs_output.write(f"END RequestId: {request_id}\n")
+                elapsed_s = time.time() - context._start_time
+                elapsed_ms = elapsed_s * 1000
+                logs_output.write(
+                    f"REPORT RequestId: {request_id}"
+                    f"\tDuration: {elapsed_ms:.2f} ms"
+                    f"\tBilled Duration: {int(elapsed_ms) + 1} ms"
+                    f"\tMemory Size: {memory_size} MB"
+                    f"\tMax Memory Used: {memory_size} MB\n"
+                )
+                return (
+                    {"errorMessage": load_error[0], "errorType": "Runtime.HandlerNotFound"},
+                    "Runtime.HandlerNotFound",
+                    logs_output.getvalue(),
+                )
 
             if handler_error[0] is not None:
                 e = handler_error[0]
@@ -828,7 +843,9 @@ def execute_python_handler(
             )
             return handler_result[0], None, logs_output.getvalue()
         except Exception as e:  # noqa: BLE001
-            # Catch module-level errors (SyntaxError, ImportError, etc.)
+            # Last-resort guard for executor-internal failures (e.g. thread
+            # start). Module-level SyntaxError/ImportError surface through
+            # handler_error inside _run_handler, not here.
             tb = traceback.format_exc()
             logs_output.write(tb)
             error_result = {

--- a/src/robotocore/services/lambda_/provider.py
+++ b/src/robotocore/services/lambda_/provider.py
@@ -261,6 +261,15 @@ async def _handle_functions(
                     _store_dlq_config(account_id, region, func_name, spec["DeadLetterConfig"])
                 qualifier = request.query_params.get("Qualifier")
                 fn = backend.update_function_configuration(func_name, qualifier, spec)
+                if "Environment" in spec or "Handler" in spec:
+                    # Module-scope code (`X = os.environ["X"]` above any def)
+                    # only re-runs on the next cold import, so without this a
+                    # changed env var — or a changed handler entry point —
+                    # would silently keep using whatever a prior invocation
+                    # already imported. Real Lambda spins a fresh execution
+                    # environment and reruns init on a config update; the
+                    # cheapest equivalent here is dropping the cached module.
+                    get_code_cache().invalidate(func_name)
                 result = fn if isinstance(fn, dict) else _fn_config(fn)
                 # Merge DLQ config into response
                 dlq = _get_dlq_config(account_id, region, func_name)

--- a/src/robotocore/services/lambda_/provider.py
+++ b/src/robotocore/services/lambda_/provider.py
@@ -261,7 +261,7 @@ async def _handle_functions(
                     _store_dlq_config(account_id, region, func_name, spec["DeadLetterConfig"])
                 qualifier = request.query_params.get("Qualifier")
                 fn = backend.update_function_configuration(func_name, qualifier, spec)
-                if "Environment" in spec or "Handler" in spec:
+                if "Environment" in spec or "Handler" in spec or "Layers" in spec:
                     # Module-scope code (`X = os.environ["X"]` above any def)
                     # only re-runs on the next cold import, so without this a
                     # changed env var — or a changed handler entry point —
@@ -269,6 +269,12 @@ async def _handle_functions(
                     # already imported. Real Lambda spins a fresh execution
                     # environment and reruns init on a config update; the
                     # cheapest equivalent here is dropping the cached module.
+                    # Layers is included for the same reason but a different
+                    # mechanism: the extraction cache key is (function_name,
+                    # sha256(code_zip)) — layer bytes aren't in it — while
+                    # layer contents are physically baked into the cached
+                    # extraction dir, so a layers-only update would otherwise
+                    # keep serving the old layer code indefinitely too.
                     get_code_cache().invalidate(func_name)
                 result = fn if isinstance(fn, dict) else _fn_config(fn)
                 # Merge DLQ config into response

--- a/tests/compatibility/test_lambda_compat.py
+++ b/tests/compatibility/test_lambda_compat.py
@@ -775,6 +775,42 @@ class TestLambdaEnvironmentVariables:
         assert payload["val"] == "updated"
         lam.delete_function(FunctionName=fname)
 
+    def test_update_env_vars_read_at_module_scope(self, lam, role):
+        """Same as test_update_env_vars, but the env var is resolved once at
+        module scope (`CONFIGURED = os.environ[...]` above the handler def,
+        not a read from inside the handler body). This is the case that
+        depends on UpdateFunctionConfiguration actually invalidating the
+        cached module — the sibling test above would pass even if it didn't,
+        since a handler-body os.environ read always sees the current config.
+        """
+        code = _make_zip(
+            'import os\nCONFIGURED = os.environ["MY_KEY"]\n'
+            'def handler(e, c): return {"val": CONFIGURED}'
+        )
+        fname = f"envvar-upd-module-{uuid.uuid4().hex[:8]}"
+        lam.create_function(
+            FunctionName=fname,
+            Runtime="python3.12",
+            Role=role,
+            Handler="lambda_function.handler",
+            Code={"ZipFile": code},
+            Environment={"Variables": {"MY_KEY": "original"}},
+        )
+        # Force a cold import — and therefore a cached module — before the
+        # config update, so this actually exercises invalidation and isn't
+        # just testing a first-ever cold start.
+        first = lam.invoke(FunctionName=fname)
+        assert json.loads(first["Payload"].read())["val"] == "original"
+
+        lam.update_function_configuration(
+            FunctionName=fname,
+            Environment={"Variables": {"MY_KEY": "updated"}},
+        )
+        resp = lam.invoke(FunctionName=fname)
+        payload = json.loads(resp["Payload"].read())
+        assert payload["val"] == "updated"
+        lam.delete_function(FunctionName=fname)
+
     def test_env_vars_in_get_configuration(self, lam, role):
         code = _make_zip("def handler(e, c): pass")
         fname = f"envvar-cfg-{uuid.uuid4().hex[:8]}"

--- a/tests/unit/services/lambda_/test_lambda_e2e.py
+++ b/tests/unit/services/lambda_/test_lambda_e2e.py
@@ -798,11 +798,15 @@ class TestConcurrency:
     def test_concurrent_invocations_read_module_scope_env_vars(self):
         """10 concurrent cold-start invocations of the same function, each
         reading a configured env var at *module scope* (`X = os.environ["X"]`
-        above the handler def, not inside it). Whichever invocation's thread
-        wins the sys.modules race, the value it captured — and that every
-        other invocation then reads off the cached module — must be the
-        configured one, not a KeyError or a value read from the wrong
-        thread's environment."""
+        above the handler def, not inside it). Pins that the sys.modules
+        cold-start race (many threads simultaneously finding `cached is
+        None`) can't crash or KeyError, and that whichever thread's import
+        wins the race captured the configured value — not cross-thread
+        contamination, which this test can't detect on its own since every
+        thread configures the *same* value (see
+        test_concurrent_invocations_have_isolated_env_vars in
+        test_lambda_executor_review.py for that: two functions, different
+        values, concurrent)."""
         code = make_zip(
             {
                 "handler.py": (

--- a/tests/unit/services/lambda_/test_lambda_e2e.py
+++ b/tests/unit/services/lambda_/test_lambda_e2e.py
@@ -795,6 +795,55 @@ class TestConcurrency:
 
         get_code_cache().invalidate("concurrent-fn")
 
+    def test_concurrent_invocations_read_module_scope_env_vars(self):
+        """10 concurrent cold-start invocations of the same function, each
+        reading a configured env var at *module scope* (`X = os.environ["X"]`
+        above the handler def, not inside it). Whichever invocation's thread
+        wins the sys.modules race, the value it captured — and that every
+        other invocation then reads off the cached module — must be the
+        configured one, not a KeyError or a value read from the wrong
+        thread's environment."""
+        code = make_zip(
+            {
+                "handler.py": (
+                    "import os\n"
+                    "CONFIGURED = os.environ['CONC_ENV_VAR']\n"
+                    "def handler(e, c):\n    return CONFIGURED\n"
+                ),
+            }
+        )
+        executor = PythonExecutor()
+        results = {}
+        errors = []
+
+        def invoke(thread_id):
+            try:
+                result, err, _ = executor.execute(
+                    code_zip=code,
+                    handler="handler.handler",
+                    event={},
+                    function_name="concurrent-env-fn",
+                    env_vars={"CONC_ENV_VAR": "expected-value"},
+                )
+                if err:
+                    errors.append((thread_id, err))
+                else:
+                    results[thread_id] = result
+            except Exception as exc:
+                errors.append((thread_id, str(exc)))
+
+        threads = [threading.Thread(target=invoke, args=(i,)) for i in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors, f"Errors: {errors}"
+        assert len(results) == 10
+        assert all(v == "expected-value" for v in results.values()), results
+
+        get_code_cache().invalidate("concurrent-env-fn")
+
     def test_concurrent_cache_get_or_extract(self):
         """Concurrent cache access should not corrupt state."""
         cache = CodeCache(max_size=50)
@@ -1018,6 +1067,105 @@ class TestEnvironmentVariables:
         assert result == "eu-west-1"
         get_code_cache().invalidate("region-fn")
 
+    def test_module_scope_env_var_read_at_import_time(self):
+        """Config read once at module scope — the pattern the KeyError bug
+        was about — must see the configured value, not just a read from
+        inside the handler body (test_env_vars_available_in_handler above)."""
+        code = make_zip(
+            {
+                "handler.py": (
+                    "import os\n"
+                    "CONFIGURED = os.environ['MODULE_SCOPE_VAR']\n"
+                    "def handler(e, c):\n    return CONFIGURED\n"
+                ),
+            }
+        )
+        result, err, _ = execute_python_handler(
+            code_zip=code,
+            handler="handler.handler",
+            event={},
+            function_name="module-scope-env-fn",
+            env_vars={"MODULE_SCOPE_VAR": "resolved-at-import"},
+        )
+        assert err is None
+        assert result == "resolved-at-import"
+        get_code_cache().invalidate("module-scope-env-fn")
+
+    def test_warm_second_invocation_sees_module_scope_env_var(self):
+        """A second, cached-module invocation must still resolve the value
+        captured at cold-start import — pins the `cached` branch (module
+        reuse when hot_reload is off) against the import-time env fix."""
+        code = make_zip(
+            {
+                "handler.py": (
+                    "import os\n"
+                    "CONFIGURED = os.environ['WARM_ENV_VAR']\n"
+                    "def handler(e, c):\n    return CONFIGURED\n"
+                ),
+            }
+        )
+        first, err1, _ = execute_python_handler(
+            code_zip=code,
+            handler="handler.handler",
+            event={},
+            function_name="warm-env-fn",
+            env_vars={"WARM_ENV_VAR": "warm-value"},
+        )
+        assert err1 is None
+        assert first == "warm-value"
+
+        second, err2, _ = execute_python_handler(
+            code_zip=code,
+            handler="handler.handler",
+            event={},
+            function_name="warm-env-fn",
+            env_vars={"WARM_ENV_VAR": "warm-value"},
+        )
+        assert err2 is None
+        assert second == "warm-value"
+        get_code_cache().invalidate("warm-env-fn")
+
+    def test_env_var_change_is_picked_up_after_cache_invalidation(self):
+        """UpdateFunctionConfiguration's PUT handler calls
+        get_code_cache().invalidate() when Environment changes, specifically
+        so a value already captured at module scope by a prior invocation
+        doesn't silently keep being served after reconfiguration. This pins
+        that the underlying mechanism actually does force a fresh read."""
+        code = make_zip(
+            {
+                "handler.py": (
+                    "import os\n"
+                    "CONFIGURED = os.environ['RECONFIG_VAR']\n"
+                    "def handler(e, c):\n    return CONFIGURED\n"
+                ),
+            }
+        )
+        first, err1, _ = execute_python_handler(
+            code_zip=code,
+            handler="handler.handler",
+            event={},
+            function_name="reconfig-fn",
+            env_vars={"RECONFIG_VAR": "old-value"},
+        )
+        assert err1 is None
+        assert first == "old-value"
+
+        # Simulates what the UpdateFunctionConfiguration PUT handler now does
+        # on an Environment change (src/robotocore/services/lambda_/provider.py).
+        # Without this, the second call below would still return "old-value".
+        get_code_cache().invalidate("reconfig-fn")
+
+        second, err2, _ = execute_python_handler(
+            code_zip=code,
+            handler="handler.handler",
+            event={},
+            function_name="reconfig-fn",
+            env_vars={"RECONFIG_VAR": "new-value"},
+        )
+        assert err2 is None
+        assert second == "new-value"
+        get_code_cache().invalidate("reconfig-fn")
+
 
 # ---------------------------------------------------------------------------
 # Handler error scenarios
@@ -1134,6 +1282,71 @@ class TestHandlerErrors:
         assert err is None
         assert "hello from lambda" in logs
         get_code_cache().invalidate("print-fn")
+
+    def test_module_scope_prints_to_stdout(self):
+        """print() at module scope (during exec_module, before the handler
+        runs) must land in this invocation's logs too — module import now
+        happens inside the same per-invocation worker thread as the handler
+        call, not in the dispatcher thread, so it shares the same stdout
+        capture setup."""
+        code = make_zip(
+            {
+                "handler.py": ("print('hello from module scope')\ndef handler(e,c): return 'ok'\n"),
+            }
+        )
+        result, err, logs = execute_python_handler(
+            code_zip=code,
+            handler="handler.handler",
+            event={},
+            function_name="module-print-fn",
+        )
+        assert err is None
+        assert "hello from module scope" in logs
+        get_code_cache().invalidate("module-print-fn")
+
+    def test_module_scope_sys_exit_reports_an_error(self):
+        """sys.exit() at module scope (SystemExit, a BaseException — not an
+        Exception) must be reported as a failed invocation, not fall through
+        to a silent (None, None, logs) success just because SystemExit isn't
+        caught by an `except Exception`."""
+        code = make_zip(
+            {
+                "handler.py": "import sys\nsys.exit(1)\ndef handler(e,c): return 'unreachable'\n",
+            }
+        )
+        result, err, _ = execute_python_handler(
+            code_zip=code,
+            handler="handler.handler",
+            event={},
+            function_name="module-exit-fn",
+        )
+        assert err is not None, "module-scope SystemExit must not report as a clean success"
+        assert result is not None
+        assert "SystemExit" in result.get("errorType", "")
+        get_code_cache().invalidate("module-exit-fn")
+
+    def test_slow_module_import_counts_against_timeout(self):
+        """Module import/exec now runs inside the same worker thread the
+        timeout's worker.join(timeout=...) governs, so a handler whose
+        *import* alone exceeds the configured timeout must time out —
+        distinct from TestTimeoutEnforcement in test_lambda_executor_review.py,
+        which only covers a slow handler body, not a slow import."""
+        code = make_zip(
+            {
+                "handler.py": (
+                    "import time\ntime.sleep(5)\ndef handler(e,c): return 'unreachable'\n"
+                ),
+            }
+        )
+        result, err, _ = execute_python_handler(
+            code_zip=code,
+            handler="handler.handler",
+            event={},
+            function_name="slow-import-fn",
+            timeout=1,
+        )
+        assert err == "Task.TimedOut"
+        get_code_cache().invalidate("slow-import-fn")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/services/test_lambda_executor.py
+++ b/tests/unit/services/test_lambda_executor.py
@@ -197,6 +197,33 @@ class TestExecutePythonHandlerSuccess:
         assert result["fn"] == "env-fn"
         assert error_type is None
 
+    def test_env_vars_available_at_module_import_time(self):
+        """Config read at module scope — `X = os.environ["X"]` above any
+        function def — must see configured env vars too, not just reads from
+        inside the handler. Real Lambda sets env vars on the execution
+        environment before any code runs, and reading required config once at
+        import time (to reuse across warm invocations) is a common pattern;
+        a KeyError here previously happened because module exec ran in the
+        dispatcher thread, before the worker thread installed the
+        invocation's thread-local environment.
+        """
+        code = (
+            "import os\n"
+            "MY_VAR = os.environ['MY_VAR']\n"
+            "def handler(event, context):\n"
+            "    return {'custom': MY_VAR}\n"
+        )
+        code_zip = _make_zip({"lambda_function.py": code})
+        result, error_type, logs = execute_python_handler(
+            code_zip=code_zip,
+            handler="lambda_function.handler",
+            event={},
+            function_name="env-import-time-fn",
+            env_vars={"MY_VAR": "custom-value"},
+        )
+        assert error_type is None, logs
+        assert result["custom"] == "custom-value"
+
     def test_env_vars_cleaned_up(self):
         """Environment variables from one invocation must not leak."""
         sentinel = "LAMBDA_TEST_SENTINEL_XYZ"


### PR DESCRIPTION
## What

`execute_python_handler` imported/executed the handler module in the dispatcher thread, then only installed the invocation's thread-local `os.environ` override inside the worker thread that later calls the handler function. A handler that reads a configured env var at **module scope** — `X = os.environ["X"]` above any `def`, a common pattern for config resolved once and reused across warm invocations — got a `KeyError`, because at exec time `os.environ` still fell through to the real process environment, which never has the function's `Environment.Variables` in it.

`get_function`/`get_function_configuration` reported the configured variables correctly the whole time, which is what made this confusing to chase down: the function's config was right, only what its own code could see at import time was wrong.

## Fix

Move module lookup/import/exec inside `_run_handler`, after `_thread_local.env` is set, so import-time `os.environ` reads resolve exactly like invocation-time ones — matching real Lambda, where configured env vars are present on the execution environment before any code runs.

## Review pass (Fable, adversarial)

Had this PR reviewed from every angle it could be attacked from — thread-safety, control-flow correctness, error-shape fidelity to real AWS, test coverage. Findings and what I did with them:

- **Stale comments** describing code that no longer runs where the comment claims (a dispatcher-thread print-routing comment, an outer-except comment about catching module errors it no longer catches) — deleted/rewritten.
- **Silent-success hole**: `except Exception` in the worker thread missed `SystemExit` — a handler module calling `sys.exit()` at import time fell through every check straight to a clean `(None, None, logs)` success. Now `except BaseException`.
- **Ordering**: post-join checks now check `worker.is_alive()` (timeout) before `load_error`, so a timeout is always authoritative.
- **A staleness bug this PR's own fix newly exposed**: module-scope config resolved once at import time has no way to notice `UpdateFunctionConfiguration` changing `Environment.Variables` — pre-fix this just crashed loudly (KeyError); post-fix it would've silently kept serving the old value forever. `provider.py`'s config-update handler now invalidates the code cache (forcing a re-import) when `Environment` or `Handler` changes.
- **A real, previously-unobserved behavior change**: module import now happens inside the same worker thread the timeout governs, so a slow cold import now correctly counts against the function's timeout (previously imports were un-timeout-able). Pinned with a test rather than silently shipped.
- **Test coverage gaps**: added coverage for concurrent invocations reading module-scope env vars under real thread contention (the exact race this fix's design exists to make safe), the warm/cached-module path, module-scope `print()`, module-scope `sys.exit()`, and the import-counts-against-timeout behavior.

## Testing

- `tests/unit/services/test_lambda_executor.py` + `tests/unit/services/lambda_/test_lambda_e2e.py` + `tests/unit/services/test_lambda_executor_review.py`: **100/100 passing**.
- Regression check against `origin/main`: ran `test_lambda_provider.py` + `test_lambda_features.py` before and after — 67 pre-existing, unrelated failures in both runs, identical failing-test sets.
- `pre-commit run` (ruff, ruff-format, mypy, bandit, empty-except) clean on all changed files.
- Clean branch: `git log origin/main..HEAD --oneline` shows exactly this PR's commits, branched off current `origin/main`.

## Note on a second bug I went looking for and didn't find here

I initially also hit a Route53 `ChangeResourceRecordSets` 404 (`NoSuchHostedZone`, with `/rrset` embedded in the reported zone ID) via Terraform's Go-based AWS provider against the published `ghcr.io/robotocore/robotocore:latest` image. Reproducing the same Terraform config against a locally-run build of current `main` succeeded cleanly — no 404, no zone-ID mangling. `git log` shows moto-bridge routing fixes (trailing-slash routing, URL double-decode) landing after whatever commit that image was built from, so this looks like a stale published image rather than a live bug — flagging in case a fresh `ghcr.io` publish is overdue, not filing a code fix since I couldn't reproduce it against `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)