### PR TITLE
Drop the CI-enforced prompt log requirement

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,34 +12,6 @@ concurrency:
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
-  prompt-log:
-    name: Prompt log check
-    runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-      - name: Check for prompt log entry
-        run: |
-          CODE=$(git diff --name-only --diff-filter=ACM origin/${{ github.base_ref }}...HEAD \
-            | grep -E '^(src/|tests/|scripts/)' || true)
-          PROMPTS=$(git diff --name-only --diff-filter=A origin/${{ github.base_ref }}...HEAD \
-            | grep '^prompts/' || true)
-          if [ -z "$CODE" ]; then
-            echo "✓ No source/test changes — prompt log not required."
-            exit 0
-          fi
-          if [ -z "$PROMPTS" ]; then
-            echo "✗ This PR changes source/tests but adds no prompt log."
-            echo ""
-            echo "  Add a file to prompts/YYYYMMDD-HHMMSS-<slug>.md documenting"
-            echo "  the human prompts and key assistant decisions in this PR."
-            echo "  See prompts/PROMPTLOG.md for format."
-            exit 1
-          fi
-          echo "✓ Prompt log present: $PROMPTS"
-
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/prompts/PROMPTLOG.md
+++ b/prompts/PROMPTLOG.md
@@ -1,6 +1,6 @@
 # Prompt Log
 
-When you make a git commit, also commit a sanitized log of the prompts that led to it. Both the human's and yours.
+Optional, but encouraged: when you make a git commit, consider also committing a sanitized log of the prompts that led to it — both the human's and yours, when there was a human. This is no longer enforced in CI, and a prompt log entry doesn't require a human prompt to exist; log whatever provenance is useful for a future reader, autonomous sessions included.
 
 ## Why
 


### PR DESCRIPTION
Per Jack: no longer required that a human be involved in each prompt, and the prompt log itself is a nice-to-have, not a requirement.

- Removed the `prompt-log` CI job from `.github/workflows/ci.yml`. It wasn't in branch protection's required status checks (confirmed via the API before this change — merges were never actually blocked by it), but it did paint a red X on every PR that touched `src/`/`tests/`/`scripts/` without adding a `prompts/` entry, which is noisy for a check with no enforcement teeth.
- Softened `prompts/PROMPTLOG.md`'s opening line to match — still documents the format for anyone who wants to use it, just doesn't frame it as mandatory or human-prompt-specific.

🤖 Generated with [Claude Code](https://claude.com/claude-code)