### PR TITLE
Fix nightly: pulumi/cdk SQS queue-name collision + broken failure notifier

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -69,6 +69,7 @@ jobs:
         with:
           name: nightly-server-log-iac
           path: .robotocore.log
+          include-hidden-files: true
 
   full-parity:
     name: "nightly: parity + compatibility"
@@ -119,6 +120,7 @@ jobs:
         with:
           name: nightly-server-log-parity
           path: .robotocore.log
+          include-hidden-files: true
 
   full-coverage:
     name: "nightly: full coverage report"
@@ -230,6 +232,7 @@ jobs:
         with:
           name: nightly-server-log-shapes
           path: .robotocore.log
+          include-hidden-files: true
 
   test-timing:
     name: "nightly: test timing analysis"
@@ -282,6 +285,8 @@ jobs:
     runs-on: ubuntu-latest
     if: failure()
     needs: [full-iac, full-parity, full-coverage, full-shape-validation, test-timing]
+    permissions:
+      issues: write
     steps:
       - name: Create failure issue
         uses: actions/github-script@v9

--- a/tests/iac/pulumi/event_pipeline/__main__.py
+++ b/tests/iac/pulumi/event_pipeline/__main__.py
@@ -8,13 +8,13 @@ import pulumi_aws as aws
 # SQS queue (target for EventBridge rule)
 queue = aws.sqs.Queue(
     "event-queue",
-    name="event-pipeline-queue",
+    name="pulumi-event-pipeline-queue",
 )
 
 # SNS topic
 topic = aws.sns.Topic(
     "event-topic",
-    name="event-pipeline-topic",
+    name="pulumi-event-pipeline-topic",
 )
 
 # SNS subscription: SQS queue subscribes to topic
@@ -28,7 +28,7 @@ subscription = aws.sns.TopicSubscription(
 # EventBridge rule: match a custom event pattern
 rule = aws.cloudwatch.EventRule(
     "pipeline-rule",
-    name="event-pipeline-rule",
+    name="pulumi-event-pipeline-rule",
     description="Captures custom app events",
     event_pattern=json.dumps(
         {

--- a/tests/iac/pulumi/event_pipeline/test_event_pipeline.py
+++ b/tests/iac/pulumi/event_pipeline/test_event_pipeline.py
@@ -20,12 +20,12 @@ pytestmark = pytest.mark.iac
 def pipeline_resources(sqs_client, sns_client, events_client):
     """Create SQS queue, SNS topic, EventBridge rule via boto3."""
     # SQS queue
-    q = sqs_client.create_queue(QueueName="event-pipeline-queue")
+    q = sqs_client.create_queue(QueueName="pulumi-event-pipeline-queue")
     queue_url = q["QueueUrl"]
-    queue_arn = f"arn:aws:sqs:{REGION}:{ACCOUNT_ID}:event-pipeline-queue"
+    queue_arn = f"arn:aws:sqs:{REGION}:{ACCOUNT_ID}:pulumi-event-pipeline-queue"
 
     # SNS topic
-    topic = sns_client.create_topic(Name="event-pipeline-topic")
+    topic = sns_client.create_topic(Name="pulumi-event-pipeline-topic")
     topic_arn = topic["TopicArn"]
 
     # SNS -> SQS subscription
@@ -37,7 +37,7 @@ def pipeline_resources(sqs_client, sns_client, events_client):
     subscription_arn = sub["SubscriptionArn"]
 
     # EventBridge rule
-    rule_name = "event-pipeline-rule"
+    rule_name = "pulumi-event-pipeline-rule"
     events_client.put_rule(
         Name=rule_name,
         Description="Captures custom app events",


### PR DESCRIPTION
## What's been happening

**Every nightly run since at least July 24 has failed** — and no issue was ever filed about it, because the `notify on failure` job is itself broken. The failure emails have been landing in the inbox nightly.

## Root causes (two independent bugs)

**1. `nightly: all IaC frameworks` — deterministic SQS cooldown collision.**
`tests/iac/cdk/event_pipeline` and `tests/iac/pulumi/event_pipeline` both create a queue named `event-pipeline-queue`. The cdk suite's module teardown deletes it seconds before the pulumi fixture recreates it, and robotocore's *intentional* `QueueDeletedRecently` 60-second cooldown (documented in `src/robotocore/services/README.md` as "features, not bugs") correctly rejects the create. Since the whole IaC suite runs in ~7s, this fails every single night. Fix: prefix the pulumi suite's queue/topic/rule with `pulumi-`, mirroring the `tf-` prefix the terraform suite already uses.

**2. `nightly: notify on failure` — token can't create issues.**
`github.rest.issues.create` fails with `Resource not accessible by integration` because the workflow grants no `issues: write` permission. This is why a month of failures produced zero issues. Fix: add `permissions: issues: write` to the notify job.

Also fixed while in there: the `Upload server logs` artifact steps always uploaded nothing ("No files were found with the provided path: .robotocore.log") because `upload-artifact` v4+ excludes hidden files by default and the log is a dotfile — added `include-hidden-files: true` to the three server-log uploads.

## Verification

- Fresh local robotocore server, full `ENDPOINT_URL=http://localhost:4566 uv run pytest tests/iac/` (same as the nightly job): **220 passed, 0 errors**.
- With the rename stashed, the cdk→pulumi order reproduces the exact `QueueDeletedRecently` errors from the CI logs.
- Failure verified identical across runs 32551589190 (Aug 22) and 32215894341 (Aug 19).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FSbGGzhTYKgqDA7PKv7pLW